### PR TITLE
Update to node 16.16.0 and use it consistently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build with node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.15.1
+          node-version: 16.16.0
       - run: npm ci
       - run: npm run build
       - run: npm prune --omit=dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 16
+        node-version: 16.16.0
     - run: npm ci
     - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 16.16.0
 
       - name: Install dependencies
         run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/node:16.15.1-debian-11-r10
+FROM bitnami/node:16.16.0-debian-11-r1
 
 RUN adduser --home /opt/philanthropy-data-commons --uid 902 \
     --disabled-login web


### PR DESCRIPTION
This is a minor change to test that our workflows are still OK after
changes in issue #39 (no matching manifest for linux/amd64 on docker
pull ...:latest)