### PR TITLE
Add integration test support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,16 +36,16 @@ jobs:
       - name: Run build
         run: npm run build
 
-      - name: Run migrations
-        run: npm run migrate
+      - name: Run unit tests
+        run: npm run test:unit -- --coverage
+
+      - name: Run integration tests
+        run: npm run test:integration -- --coverage
         env:
           PGHOST: localhost
           PGPORT: 5432
           PGUSER: postgres
           PGPASSWORD: postgres
-
-      - name: Run tests
-        run: npm run test -- --coverage
 
       - name: Upload coverage
         uses: codecov/codecov-action@v2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ In order to run this software you need to set up a [Postgres 14](https://www.pos
   edit .env
   ```
 
-3. Run migrations
+3. Set up test environment variables
+
+  ```bash
+  cp .env.example .env.test
+  edit .env.test
+  ```
+
+4. Run migrations
 
   ```bash
   npm run migrate:dev

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   collectCoverageFrom: ["src/**/*.ts"],
   preset: 'ts-jest',
+  setupFiles: ['<rootDir>/src/test/setupEnv.ts'],
   testEnvironment: 'node',
   testPathIgnorePatterns: ["<rootDir>/dist/"],
   silent: true,

--- a/jest.config.int.js
+++ b/jest.config.int.js
@@ -1,0 +1,4 @@
+var config = require('./jest.config.base.js');
+config.testMatch = ['**/?(*.)+(int).(spec|test).[jt]s?(x)'];
+config.setupFilesAfterEnv = ["<rootDir>/src/test/integrationSuiteSetup.ts"];
+module.exports = config;

--- a/jest.config.unit.js
+++ b/jest.config.unit.js
@@ -1,0 +1,3 @@
+var config = require('./jest.config.base.js');
+config.testMatch = ['**/?(*.)+(unit).(spec|test).[jt]s?(x)'];
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint": "eslint ./src --ext .ts",
     "migrate": "node -r dotenv/config dist/scripts/migrate.js",
     "migrate:dev": "ts-node -r dotenv/config src/scripts/migrate.ts | pino-pretty",
-    "test": "jest",
+    "test": "npm run test:unit && npm run test:integration",
+    "test:unit": "jest --config=jest.config.unit.js",
+    "test:integration": "jest --config=jest.config.int.js --runInBand",
     "start": "node dist/index.js",
     "start:dev": "ts-node src/index.ts | pino-pretty"
   },

--- a/src/__tests__/canonicalFields.int.test.ts
+++ b/src/__tests__/canonicalFields.int.test.ts
@@ -1,14 +1,20 @@
 import request from 'supertest';
 import { app } from '../app';
+import {
+  prepareDatabaseForCurrentWorker,
+  cleanupDatabaseForCurrentWorker,
+} from '../test/harnessFunctions';
 
 const agent = request.agent(app);
 
 describe('/canonicalFields', () => {
   describe('/', () => {
     it('should return HTTP Status Code 200 OK', async () => {
+      await prepareDatabaseForCurrentWorker();
       await agent
         .get('/canonicalFields')
         .expect(200);
+      await cleanupDatabaseForCurrentWorker();
     });
   });
 });

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -1,0 +1,6 @@
+import path from 'path';
+import { TinyPg } from 'tinypg';
+
+export const db = new TinyPg({
+  root_dir: [path.resolve(__dirname, 'queries')],
+});

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,15 +1,2 @@
-import path from 'path';
-import { TinyPg } from 'tinypg';
-import { migrate as pgMigrate } from 'postgres-migrations';
-
-export const db = new TinyPg({
-  root_dir: [path.resolve(__dirname, 'queries')],
-});
-
-export const migrate = async (): Promise<void> => {
-  const client = await db.getClient();
-  await pgMigrate(
-    { client },
-    path.resolve(__dirname, 'migrations'),
-  );
-};
+export * from './db';
+export * from './migrate';

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -8,4 +8,5 @@ export const migrate = async (): Promise<void> => {
     { client },
     path.resolve(__dirname, 'migrations'),
   );
+  client.release();
 };

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+import { migrate as pgMigrate } from 'postgres-migrations';
+import { db } from './db';
+
+export const migrate = async (): Promise<void> => {
+  const client = await db.getClient();
+  await pgMigrate(
+    { client },
+    path.resolve(__dirname, 'migrations'),
+  );
+};

--- a/src/scripts/migrate.ts
+++ b/src/scripts/migrate.ts
@@ -7,7 +7,6 @@ logger.info('Starting migrations...');
 migrate()
   .then(() => {
     logger.info('Migrations complete.');
-    process.exit();
   })
   .catch((reason: unknown) => {
     logger.error('Migrations failed!');

--- a/src/test/harnessFunctions.ts
+++ b/src/test/harnessFunctions.ts
@@ -1,0 +1,40 @@
+import {
+  db,
+  migrate,
+} from '../database';
+
+const generateSchemaName = (workerId: string): string => `test_${workerId}`;
+
+const getSchemaNameForCurrentTestWorker = (): string => {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('You cannot get a test schema name outside of a test environment.');
+  }
+  if (process.env.JEST_WORKER_ID === undefined) {
+    throw new Error('You cannot get a test schema name if jest has not specified a worker ID.');
+  }
+  return generateSchemaName(process.env.JEST_WORKER_ID);
+};
+
+const createSchema = async (schemaName: string): Promise<void> => {
+  await db.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName};`);
+};
+
+const setSchema = async (schemaName: string): Promise<void> => {
+  await db.query(`SET search_path TO ${schemaName};`);
+};
+
+const dropSchema = async (schemaName: string): Promise<void> => {
+  await db.query(`DROP SCHEMA ${schemaName} CASCADE;`);
+};
+
+export const prepareDatabaseForCurrentWorker = async (): Promise<void> => {
+  const schemaName = getSchemaNameForCurrentTestWorker();
+  await createSchema(schemaName);
+  await setSchema(schemaName);
+  await migrate();
+};
+
+export const cleanupDatabaseForCurrentWorker = async (): Promise<void> => {
+  const schemaName = getSchemaNameForCurrentTestWorker();
+  await dropSchema(schemaName);
+};

--- a/src/test/integrationSuiteSetup.ts
+++ b/src/test/integrationSuiteSetup.ts
@@ -1,0 +1,9 @@
+/**
+ * This file is loaded by jest, as specified by the integration test jest configuration file
+ * via `setupFilesAfterEnv`.
+ */
+import { db } from '../database';
+
+afterAll(async () => {
+  await db.close();
+});

--- a/src/test/setupEnv.ts
+++ b/src/test/setupEnv.ts
@@ -1,0 +1,3 @@
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.test' });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "src"
   ],
   "exclude": [
-    "**/*.test.ts"
+    "**/*.test.ts",
+    "**/src/test"
   ]
 }


### PR DESCRIPTION
This PR adds support for unit and integration tests -- test files need to be named `.unit.test.ts` and `.int.test.ts` going forward.

Note: I was tempted to have the filename be `integration.test.ts` to avoid shorthand / be explicit but it seems like people prefer `int` out there.

This PR currently has integration tests run in sequence until an upstream bug is patched.  I'll open an issue to track that improvement.