### PR TITLE
Use consistent logger configuration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,12 @@
 import express from 'express';
-import PinoHttp from 'pino-http';
+import pinoHttp from 'pino-http';
 import { rootRouter } from './routers';
+import { logger } from './logger';
 
 const app = express();
-app.use(PinoHttp());
+app.use(pinoHttp({
+  logger,
+}));
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use('/', rootRouter);


### PR DESCRIPTION
This PR passes our configured `pino` loger to `pinoHttp` so that it uses our configurations.

Resolves #51