### PR TITLE
Invoke test setup via suite hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "migrate": "node -r dotenv/config dist/scripts/migrate.js",
     "migrate:dev": "ts-node -r dotenv/config src/scripts/migrate.ts | pino-pretty",
     "test": "npm run test:unit && npm run test:integration",
-    "test:unit": "jest --config=jest.config.unit.js | pino-pretty",
-    "test:integration": "jest --config=jest.config.int.js --runInBand | pino-pretty",
+    "test:unit": "jest --config=jest.config.unit.js",
+    "test:integration": "jest --config=jest.config.int.js --runInBand",
     "start": "node dist/index.js",
     "start:dev": "ts-node src/index.ts | pino-pretty"
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "migrate": "node -r dotenv/config dist/scripts/migrate.js",
     "migrate:dev": "ts-node -r dotenv/config src/scripts/migrate.ts | pino-pretty",
     "test": "npm run test:unit && npm run test:integration",
-    "test:unit": "jest --config=jest.config.unit.js",
-    "test:integration": "jest --config=jest.config.int.js --runInBand",
+    "test:unit": "jest --config=jest.config.unit.js | pino-pretty",
+    "test:integration": "jest --config=jest.config.int.js --runInBand | pino-pretty",
     "start": "node dist/index.js",
     "start:dev": "ts-node src/index.ts | pino-pretty"
   },

--- a/src/__tests__/canonicalFields.int.test.ts
+++ b/src/__tests__/canonicalFields.int.test.ts
@@ -1,20 +1,14 @@
 import request from 'supertest';
 import { app } from '../app';
-import {
-  prepareDatabaseForCurrentWorker,
-  cleanupDatabaseForCurrentWorker,
-} from '../test/harnessFunctions';
 
 const agent = request.agent(app);
 
 describe('/canonicalFields', () => {
   describe('/', () => {
     it('should return HTTP Status Code 200 OK', async () => {
-      await prepareDatabaseForCurrentWorker();
       await agent
         .get('/canonicalFields')
         .expect(200);
-      await cleanupDatabaseForCurrentWorker();
     });
   });
 });

--- a/src/test/integrationSuiteSetup.ts
+++ b/src/test/integrationSuiteSetup.ts
@@ -3,7 +3,19 @@
  * via `setupFilesAfterEnv`.
  */
 import { db } from '../database';
+import {
+  prepareDatabaseForCurrentWorker,
+  cleanupDatabaseForCurrentWorker,
+} from './harnessFunctions';
 
 afterAll(async () => {
   await db.close();
+});
+
+beforeEach(async () => {
+  await prepareDatabaseForCurrentWorker();
+});
+
+afterEach(async () => {
+  await cleanupDatabaseForCurrentWorker();
 });


### PR DESCRIPTION
This PR moves the burden of running database setup / teardown within a test over to a "suite" approach.

This also solves a bug where teardown would not happen if a test failed.

Once this is merged I think we "support" integration tests (which isn't to say there isn't more room for improvement)

Resolves #43 