### PR TITLE
Migrate the database schema on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ WORKDIR /opt/philanthropy-data-commons/server
 COPY --chown=web:web package.json .
 COPY --chown=web:web node_modules ./node_modules
 COPY --chown=web:web dist ./dist
+COPY docker-entrypoint.sh .
 
-CMD ["npm", "start"]
+CMD ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+npm run migrate
+exec npm run start


### PR DESCRIPTION
When doing two or more commands on startup, it is straightforward to use
a small script. The downside is the command is not visible directly in
the Dockerfile, there is one level of indirection. But we do want to
do `npm run migrate` then `npm run start`. The migrate task should be
idempotent and therefore harmless to run on repeated startup even with
the same version of the software (e.g. no new schema changes).

Issue #56 Do DB migration on startup