### PR TITLE
Release the db client on migrate every time

### DIFF
--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -4,9 +4,12 @@ import { db } from './db';
 
 export const migrate = async (): Promise<void> => {
   const client = await db.getClient();
-  await pgMigrate(
-    { client },
-    path.resolve(__dirname, 'migrations'),
-  );
-  client.release();
+  try {
+    await pgMigrate(
+      { client },
+      path.resolve(__dirname, 'migrations'),
+    );
+  } finally {
+    client.release();
+  }
 };


### PR DESCRIPTION
This seems to help integration tests finish properly when there are
failures related to database setup or tear-down.

Issue #53  Cause jest integration tests to play nicely with tinypg