### PR TITLE
Use env var `LOG_LEVEL` to set pino log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ To start the server in a development environment:
 npm start:dev
 ```
 
+### Logging
+
+To override the default log level in any environment, set the environment variable `LOG_LEVEL` with any of the above `npm` commands:
+
+```bash
+LOG_LEVEL=trace npm run test
+```
+
+Alternatively, one may set `LOG_LEVEL` in the `.env` file.
+
 ### Understanding the Project
 
 #### Project Structure

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   collectCoverageFrom: ["src/**/*.ts"],
   preset: 'ts-jest',
-  setupFiles: ['<rootDir>/src/test/setupEnv.ts'],
+  globalSetup: "<rootDir>/src/test/globalSetup.ts",
   testEnvironment: 'node',
   testPathIgnorePatterns: ["<rootDir>/dist/"],
   silent: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
-import dotenv from 'dotenv';
 import { app } from './app';
 import { getLogger } from './logger';
 
 const logger = getLogger(__filename);
-dotenv.config();
+
+// The .env file is loaded in 'logger' to ensure correct order of events. See
+// more discussion in the 'logger.ts' code.
 
 const port = Number(process.env.PORT ?? 3000);
 const host = process.env.HOST ?? 'localhost';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,10 +1,18 @@
+import dotenv from 'dotenv';
 import pino from 'pino';
 import type {
   Logger,
 } from 'pino';
 
+// Calling dotenv.config() prior to creating a logger ensures that environment
+// variable LOG_LEVEL can be loaded from .env files. See
+// https://github.com/PhilanthropyDataCommons/service/issues/59#issuecomment-1197227254
+// and following. There may be a better place than including and calling dotenv
+// here in the logger code.
+dotenv.config();
+
 const logger = pino({
-  level: process.env.LOG_LEVEL ?? 'silent',
+  level: process.env.LOG_LEVEL ?? 'info',
 });
 
 export const getLogger = (source: string): Logger => logger.child({ source });

--- a/src/test/globalSetup.ts
+++ b/src/test/globalSetup.ts
@@ -1,0 +1,22 @@
+// Jest expects a single default function to be exported from this file.
+/* eslint-disable import/no-default-export */
+import dotenv from 'dotenv';
+import type { Config } from 'jest';
+
+// TODO: reconsider use of '.env.test' if or when
+// https://github.com/ThomWright/postgres-migrations/pull/93 gets merged/fixed.
+dotenv.config({ path: '.env.test' });
+
+// Production code will run dotenv.config() anyway, so make clear that it
+// happens by running the same explicitly here. If '.env.test' has any variables
+// set, they will override the later/inner set variables such as those in the
+// '.env' file. There might be a better way to manage 'dotenv' and pino logger
+// setup.
+dotenv.config();
+
+export default (globalConfig: Config, projectConfig: Config): void => {
+  if ((process.env.LOG_LEVEL === undefined || process.env.LOG_LEVEL === '')
+      && (globalConfig.silent === true || projectConfig.silent === true)) {
+    process.env.LOG_LEVEL = 'silent';
+  }
+};

--- a/src/test/setupEnv.ts
+++ b/src/test/setupEnv.ts
@@ -1,3 +1,0 @@
-import dotenv from 'dotenv';
-
-dotenv.config({ path: '.env.test' });


### PR DESCRIPTION
The environment variable `LOG_LEVEL` will set the level on the root
logger when it is set. When running tests under jest, the globalSetup
examines the (jest) global and project configurations as well as the env
var `LOG_LEVEL` to decide whether to silence pino using the same env var
`LOG_LEVEL`. If you set `LOG_LEVEL`, that level takes precedence in all
environments. If you do not set `LOG_LEVEL` and the jest config sets
`silent: true`, the globalSetup for jest sets `LOG_LEVEL` to `silent` on
your behalf, essentially passing jest's `silent: true` setting through.

There are multiple ways to set `LOG_LEVEL` such as on the command line
or in a `.env` file.

Issue #59 Get pino and jest to agree on console verbosity

