### PR TITLE
Add OpenAPI documentation to the root page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "pino": "^8.1.0",
         "pino-http": "^8.1.1",
         "postgres-migrations": "^5.3.0",
+        "swagger-ui-express": "^4.5.0",
         "tinypg": "^7.0.0"
       },
       "devDependencies": {
@@ -25,6 +26,7 @@
         "@types/node": "^18.0.0",
         "@types/pg": "^8.6.5",
         "@types/supertest": "^2.0.12",
+        "@types/swagger-ui-express": "^4.1.3",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0",
         "copyfiles": "^2.4.1",
@@ -1455,6 +1457,16 @@
       "dev": true,
       "dependencies": {
         "@types/superagent": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -6506,6 +6518,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.13.2.tgz",
+      "integrity": "sha512-jHL6UyIYpvEI7NsuWd0R3hJaPQTg6Oo4qSBo+oVfOEkv6rrQm/475RGSMmZgV6ajp+Sgrp9CqrDjQYAgQqiv1A=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
+      "integrity": "sha512-DHk3zFvsxrkcnurGvQlAcLuTDacAVN1JHKDgcba/gr2NFRE4HGwP1YeHIXMiGznkWR4AeS7X5vEblNn4QljuNA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.11.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
+      }
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -8311,6 +8342,16 @@
       "dev": true,
       "requires": {
         "@types/superagent": "*"
+      }
+    },
+    "@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/yargs": {
@@ -12095,6 +12136,19 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "swagger-ui-dist": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.13.2.tgz",
+      "integrity": "sha512-jHL6UyIYpvEI7NsuWd0R3hJaPQTg6Oo4qSBo+oVfOEkv6rrQm/475RGSMmZgV6ajp+Sgrp9CqrDjQYAgQqiv1A=="
+    },
+    "swagger-ui-express": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
+      "integrity": "sha512-DHk3zFvsxrkcnurGvQlAcLuTDacAVN1JHKDgcba/gr2NFRE4HGwP1YeHIXMiGznkWR4AeS7X5vEblNn4QljuNA==",
+      "requires": {
+        "swagger-ui-dist": ">=4.11.0"
+      }
     },
     "terminal-link": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/node": "^18.0.0",
     "@types/pg": "^8.6.5",
     "@types/supertest": "^2.0.12",
+    "@types/swagger-ui-express": "^4.1.3",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "copyfiles": "^2.4.1",
@@ -66,6 +67,7 @@
     "pino": "^8.1.0",
     "pino-http": "^8.1.1",
     "postgres-migrations": "^5.3.0",
+    "swagger-ui-express": "^4.5.0",
     "tinypg": "^7.0.0"
   }
 }

--- a/src/routers/documentationRouter.ts
+++ b/src/routers/documentationRouter.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import swaggerUi from 'swagger-ui-express';
+import documentation from '../openapi.json';
+import { isJsonObject } from '../types';
+
+const documentationRouter = express.Router();
+
+documentationRouter.use('/', swaggerUi.serve);
+if (isJsonObject(documentation)) {
+  documentationRouter.get('/', swaggerUi.setup(documentation));
+}
+
+export { documentationRouter };

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -2,11 +2,13 @@ import express from 'express';
 import { applicantsRouter } from './applicantsRouter';
 import { canonicalFieldsRouter } from './canonicalFieldsRouter';
 import { opportunitiesRouter } from './opportunitiesRouter';
+import { documentationRouter } from './documentationRouter';
 
 const rootRouter = express.Router();
 
 rootRouter.use('/applicants', applicantsRouter);
 rootRouter.use('/canonicalFields', canonicalFieldsRouter);
 rootRouter.use('/opportunities', opportunitiesRouter);
+rootRouter.use('/', documentationRouter);
 
 export { rootRouter };

--- a/src/types/JsonObject.ts
+++ b/src/types/JsonObject.ts
@@ -1,0 +1,5 @@
+import type { JsonObject } from 'swagger-ui-express';
+
+export const isJsonObject = (obj: unknown): obj is JsonObject => (
+  typeof obj === 'object'
+);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './Applicant';
 export * from './CanonicalField';
+export * from './JsonObject';
 export * from './Opportunity';
 export * from './QueryContextWithError';

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -2,7 +2,8 @@
 {
   "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "resolveJsonModule": true
   },
   "include": [
     "src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "outDir": "dist",
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   },
   "include": [
     "src"


### PR DESCRIPTION
Now the OpenAPI spec is served as the root page of the service.

Issue #67 Add documentation to the root page