### PR TITLE
Add `POST /canonicalFields` endpoint

### DIFF
--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -1,6 +1,13 @@
 import path from 'path';
 import { TinyPg } from 'tinypg';
+import { isQueryContextWithError } from '../types';
+import type { TinyPgError } from 'tinypg';
 
 export const db = new TinyPg({
   root_dir: [path.resolve(__dirname, 'queries')],
 });
+
+export const detectUniqueConstraintViolation = (error: TinyPgError): boolean => (
+  isQueryContextWithError(error.queryContext)
+  && error.queryContext.error.routine === '_bt_check_unique'
+);

--- a/src/database/queries/canonicalFields/insertOne.sql
+++ b/src/database/queries/canonicalFields/insertOne.sql
@@ -1,0 +1,16 @@
+INSERT INTO canonical_fields (
+  label,
+  short_code,
+  data_type
+)
+VALUES (
+  :label,
+  :shortCode,
+  :dataType
+)
+RETURNING
+  id as "id",
+  label as "label",
+  short_code as "shortCode",
+  data_type as "dataType",
+  created_at as "createdAt"

--- a/src/handlers/canonicalFieldsHandlers.ts
+++ b/src/handlers/canonicalFieldsHandlers.ts
@@ -1,11 +1,23 @@
+import { TinyPgError } from 'tinypg';
+import { ajv } from '../ajv';
 import { getLogger } from '../logger';
-import { db } from '../database';
-import { isCanonicalFieldArray } from '../types';
+import {
+  db,
+  detectUniqueConstraintViolation,
+} from '../database';
+import {
+  isCanonicalFieldArray,
+  isCanonicalField,
+  isQueryContextWithError,
+} from '../types';
 import { ValidationError } from '../errors';
+import type { JSONSchemaType } from 'ajv';
 import type {
   Request,
   Response,
 } from 'express';
+import type { Result } from 'tinypg';
+import type { CanonicalField } from '../types';
 
 const logger = getLogger(__filename);
 
@@ -33,6 +45,75 @@ const getCanonicalFields = (req: Request, res: Response): void => {
     });
 };
 
+const postCanonicalFieldBodySchema: JSONSchemaType<Omit<CanonicalField, 'createdAt' | 'id'>> = {
+  type: 'object',
+  properties: {
+    label: {
+      type: 'string',
+    },
+    shortCode: {
+      type: 'string',
+    },
+    dataType: {
+      type: 'string',
+    },
+  },
+  required: [
+    'label',
+    'shortCode',
+    'dataType',
+  ],
+};
+const isPostCanonicalFieldBody = ajv.compile(postCanonicalFieldBodySchema);
+const postCanonicalField = (
+  req: Request<unknown, unknown, Omit<CanonicalField, 'createdAt' | 'id'>>,
+  res: Response,
+): void => {
+  if (!isPostCanonicalFieldBody(req.body)) {
+    res.status(400)
+      .contentType('application/json')
+      .send({
+        message: 'Invalid request body.',
+        errors: isPostCanonicalFieldBody.errors,
+      });
+    return;
+  }
+
+  db.sql('canonicalFields.insertOne', req.body)
+    .then((insertOneQueryResult: Result<CanonicalField>) => {
+      logger.debug(insertOneQueryResult);
+      const canonicalField = insertOneQueryResult.rows[0];
+      if (isCanonicalField(canonicalField)) {
+        res.status(201)
+          .contentType('application/json')
+          .send(canonicalField);
+      } else {
+        throw new ValidationError(
+          'The database responded with an unexpected format.',
+          isCanonicalField.errors ?? [],
+        );
+      }
+    })
+    .catch((error: unknown) => {
+      if (error instanceof TinyPgError
+      && isQueryContextWithError(error.queryContext)
+      && detectUniqueConstraintViolation(error)) {
+        res.status(409)
+          .contentType('application/json')
+          .send({
+            message: 'Unique key constraint violation.',
+            errors: [error.queryContext.error],
+          });
+      } else {
+        logger.warn(error);
+        res.status(500)
+          .contentType('application/json')
+          .send(error);
+      }
+    });
+};
+
 export const canonicalFieldsHandlers = {
   getCanonicalFields,
+  postCanonicalField,
 };

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -11,6 +11,7 @@ import type {
   Response,
 } from 'express';
 import type { Result } from 'tinypg';
+import type { JSONSchemaType } from 'ajv';
 import type { Opportunity } from '../types';
 
 const logger = getLogger(__filename);
@@ -42,7 +43,7 @@ const getOpportunities = (req: Request, res: Response): void => {
 interface GetOpportunityParams {
   id: number;
 }
-const isGetOpportunityParams = ajv.compile<GetOpportunityParams>({
+const getOpportunityParamsSchema: JSONSchemaType<GetOpportunityParams> = {
   type: 'object',
   properties: {
     id: {
@@ -53,7 +54,8 @@ const isGetOpportunityParams = ajv.compile<GetOpportunityParams>({
   required: [
     'id',
   ],
-});
+};
+const isGetOpportunityParams = ajv.compile(getOpportunityParamsSchema);
 const getOpportunity = (req: Request<GetOpportunityParams>, res: Response): void => {
   if (!isGetOpportunityParams(req.params)) {
     res.status(400)

--- a/src/routers/canonicalFieldsRouter.ts
+++ b/src/routers/canonicalFieldsRouter.ts
@@ -3,6 +3,7 @@ import { canonicalFieldsHandlers } from '../handlers/canonicalFieldsHandlers';
 
 const canonicalFieldsRouter = express.Router();
 
-canonicalFieldsRouter.use('/', canonicalFieldsHandlers.getCanonicalFields);
+canonicalFieldsRouter.get('/', canonicalFieldsHandlers.getCanonicalFields);
+canonicalFieldsRouter.post('/', canonicalFieldsHandlers.postCanonicalField);
 
 export { canonicalFieldsRouter };

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,0 +1,1 @@
+export const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;

--- a/src/types/QueryContextWithError.ts
+++ b/src/types/QueryContextWithError.ts
@@ -1,0 +1,82 @@
+import { ajv } from '../ajv';
+import type { JSONSchemaType } from 'ajv';
+
+// This type is defined to fill a type void in the tinypg library
+// See: https://github.com/dynajoe/tinypg/issues/40
+export interface QueryContextWithError {
+  error: {
+    length: number;
+    name: string;
+    severity: string;
+    code: string;
+    detail: string;
+    schema: string;
+    table: string;
+    constraint: string;
+    file: string;
+    line: string;
+    routine: string;
+  };
+}
+
+export const queryContextWithErrorSchema: JSONSchemaType<QueryContextWithError> = {
+  type: 'object',
+  properties: {
+    error: {
+      type: 'object',
+      properties: {
+        length: {
+          type: 'number',
+        },
+        name: {
+          type: 'string',
+        },
+        severity: {
+          type: 'string',
+        },
+        code: {
+          type: 'string',
+        },
+        detail: {
+          type: 'string',
+        },
+        schema: {
+          type: 'string',
+        },
+        table: {
+          type: 'string',
+        },
+        constraint: {
+          type: 'string',
+        },
+        file: {
+          type: 'string',
+        },
+        line: {
+          type: 'string',
+        },
+        routine: {
+          type: 'string',
+        },
+      },
+      required: [
+        'length',
+        'name',
+        'severity',
+        'code',
+        'detail',
+        'schema',
+        'table',
+        'constraint',
+        'file',
+        'line',
+        'routine',
+      ],
+    },
+  },
+  required: [
+    'error',
+  ],
+};
+
+export const isQueryContextWithError = ajv.compile(queryContextWithErrorSchema);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './CanonicalField';
 export * from './Opportunity';
+export * from './QueryContextWithError';


### PR DESCRIPTION
This PR adds the ability to create canonical fields.

To test:

```
curl --request POST \
  --url http://localhost:3000/canonicalFields \
  --header 'content-type: application/json' \
  --data '{
  "label": "First name",
  "shortCode": "firstName",
  "dataType": "string"
}'
```

Resolves #75 