### PR TITLE
Add POST `/applicants` endpoint

### DIFF
--- a/src/database/queries/applicants/insertOne.sql
+++ b/src/database/queries/applicants/insertOne.sql
@@ -1,0 +1,13 @@
+INSERT INTO applicants (
+  external_id,
+  opted_in
+)
+VALUES (
+  :externalId,
+  :optedIn
+)
+RETURNING
+  id as "id",
+  external_id as "externalId",
+  opted_in AS "optedIn",
+  created_at AS "createdAt"

--- a/src/handlers/applicantsHandlers.ts
+++ b/src/handlers/applicantsHandlers.ts
@@ -1,12 +1,22 @@
+import { TinyPgError } from 'tinypg';
+import { ajv } from '../ajv';
 import { getLogger } from '../logger';
-import { db } from '../database';
-import { isApplicantArray } from '../types';
+import {
+  db,
+  detectUniqueConstraintViolation,
+} from '../database';
+import {
+  isApplicant,
+  isApplicantArray,
+  isQueryContextWithError,
+} from '../types';
 import { ValidationError } from '../errors';
 import type {
   Request,
   Response,
 } from 'express';
 import type { Result } from 'tinypg';
+import type { JSONSchemaType } from 'ajv';
 import type { Applicant } from '../types';
 
 const logger = getLogger(__filename);
@@ -35,6 +45,70 @@ const getApplicants = (req: Request, res: Response): void => {
     });
 };
 
+const postApplicantsBodySchema: JSONSchemaType<Omit<Applicant, 'createdAt' | 'id' | 'optedIn'>> = {
+  type: 'object',
+  properties: {
+    externalId: {
+      type: 'string',
+    },
+  },
+  required: [
+    'externalId',
+  ],
+};
+const isPostApplicantsBody = ajv.compile(postApplicantsBodySchema);
+const postApplicants = (
+  req: Request<unknown, unknown, Omit<Applicant, 'createdAt' | 'id' | 'optedIn'>>,
+  res: Response,
+): void => {
+  if (!isPostApplicantsBody(req.body)) {
+    res.status(400)
+      .contentType('application/json')
+      .send({
+        message: 'Invalid request body.',
+        errors: isPostApplicantsBody.errors,
+      });
+    return;
+  }
+
+  db.sql('applicants.insertOne', {
+    ...req.body,
+    optedIn: false,
+  })
+    .then((applicantsQueryResult: Result<Applicant>) => {
+      logger.debug(applicantsQueryResult);
+      const canonicalField = applicantsQueryResult.rows[0];
+      if (isApplicant(canonicalField)) {
+        res.status(201)
+          .contentType('application/json')
+          .send(canonicalField);
+      } else {
+        throw new ValidationError(
+          'The database responded with an unexpected format.',
+          isApplicant.errors ?? [],
+        );
+      }
+    })
+    .catch((error: unknown) => {
+      if (error instanceof TinyPgError
+      && isQueryContextWithError(error.queryContext)
+      && detectUniqueConstraintViolation(error)) {
+        res.status(409)
+          .contentType('application/json')
+          .send({
+            message: 'Unique key constraint violation.',
+            errors: [error.queryContext.error],
+          });
+      } else {
+        logger.warn(error);
+        res.status(500)
+          .contentType('application/json')
+          .send(error);
+      }
+    });
+};
+
 export const applicantsHandlers = {
   getApplicants,
+  postApplicants,
 };

--- a/src/routers/applicantsRouter.ts
+++ b/src/routers/applicantsRouter.ts
@@ -4,5 +4,6 @@ import { applicantsHandlers } from '../handlers/applicantsHandlers';
 const applicantsRouter = express.Router();
 
 applicantsRouter.get('/', applicantsHandlers.getApplicants);
+applicantsRouter.post('/', applicantsHandlers.postApplicants);
 
 export { applicantsRouter };

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,1 +1,18 @@
+import { db } from '../database';
+
 export const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+interface TableMetrics {
+  count: number;
+  maxId: number;
+  now: Date;
+}
+export const getTableMetrics = async (tableWithId: string): Promise<TableMetrics> => {
+  const metricsQueryResult = await db.query<TableMetrics>(`
+    SELECT COUNT(id) AS "count",
+      MAX(id) AS "maxId",
+      NOW() as "now"
+    FROM ${tableWithId};
+  `);
+  return metricsQueryResult.rows[0];
+};


### PR DESCRIPTION
This PR adds the ability to create an applicant via the API.

To test:

```
curl --request POST \
  --url http://localhost:3000/applicants \
  --header 'content-type: application/json' \
  --data '{
  "externalId": "12345"
}'
```

Resolves #37 
Relies on #77 (don't review until 77 is merged and this is rebased)