### PR TITLE
Fix JsonObject type guard

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -4,7 +4,10 @@ module.exports = {
       tsconfig: 'tsconfig.dev.json',
     },
   },
-  collectCoverageFrom: ["src/**/*.ts"],
+  collectCoverageFrom: [
+    "src/**/*.ts",
+    "!src/**/*.test.*",
+  ],
   preset: 'ts-jest',
   globalSetup: "<rootDir>/src/test/globalSetup.ts",
   testEnvironment: 'node',

--- a/src/types/JsonObject.ts
+++ b/src/types/JsonObject.ts
@@ -1,5 +1,10 @@
+import { ajv } from '../ajv';
 import type { JsonObject } from 'swagger-ui-express';
+import type { JSONSchemaType } from 'ajv';
 
-export const isJsonObject = (obj: unknown): obj is JsonObject => (
-  typeof obj === 'object'
-);
+const jsonObjectSchema: JSONSchemaType<JsonObject> = {
+  type: 'object',
+  properties: {},
+  required: [],
+};
+export const isJsonObject = ajv.compile(jsonObjectSchema);

--- a/src/types/__tests__/isJsonObject.unit.test.ts
+++ b/src/types/__tests__/isJsonObject.unit.test.ts
@@ -1,0 +1,21 @@
+import { isJsonObject } from '..';
+
+describe('isJsonObject', () => {
+  it('should return false in the null case', () => {
+    expect(isJsonObject(null)).toBe(false);
+  });
+
+  it('should return false in the number case', () => {
+    expect(isJsonObject(42)).toBe(false);
+  });
+
+  it('should return true for empty objects', () => {
+    expect(isJsonObject({})).toBe(true);
+  });
+
+  it('should return true for populated objects', () => {
+    expect(isJsonObject({
+      foo: 15,
+    })).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR fixes an edge case where `isJsonObject` would return true for `null` values.  It also adds unit tests for good measure.