### PR TITLE
Create fields on form creation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,10 @@
     "import/order": ["error", {
       "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object", "type"],
       "newlines-between": "never"
+    }],
+    "@typescript-eslint/no-type-alias": ["error", {
+      "allowGenerics": "always",
+      "allowLiterals": "in-intersections"
     }]
   },
   "overrides": [

--- a/src/database/migrations/0001-create-canonical_fields.sql
+++ b/src/database/migrations/0001-create-canonical_fields.sql
@@ -6,10 +6,8 @@ CREATE TABLE canonical_fields (
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-
-
-comment on table canonical_fields is
+COMMENT ON TABLE canonical_fields is
   'Canonical fields are those fields that are unique across organizations.';
-comment on column canonical_fields.label is 'A word or phrase that communicates the meaning of the field for end users';
-comment on column canonical_fields.short_code is 'An externally meaningful alphanumeric code tht can be used to reference this field without knowing the internal id';
-comment on column canonical_fields.data_type is 'The type of data that can be associated with this field';
+COMMENT ON COLUMN canonical_fields.label is 'A word or phrase that communicates the meaning of the field for end users';
+COMMENT ON COLUMN canonical_fields.short_code is 'An externally meaningful alphanumeric code tht can be used to reference this field without knowing the internal id';
+COMMENT ON COLUMN canonical_fields.data_type is 'The type of data that can be associated with this field';

--- a/src/database/migrations/0005-create-application_form_fields.sql
+++ b/src/database/migrations/0005-create-application_form_fields.sql
@@ -1,0 +1,21 @@
+CREATE TABLE application_form_fields (
+  id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  application_form_id INTEGER NOT NULL,
+  canonical_field_id INTEGER NOT NULL,
+  position INTEGER NOT NULL,
+  label VARCHAR,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  CONSTRAINT fk_application_form
+    FOREIGN KEY(application_form_id)
+      REFERENCES application_forms(id),
+  CONSTRAINT fk_canonical_field
+    FOREIGN KEY(canonical_field_id)
+      REFERENCES canonical_fields(id),
+  UNIQUE(application_form_id, position)
+);
+
+COMMENT ON TABLE application_form_fields is
+  'Application form fields represent a specific piece of data being collected as part of a given application form.';
+COMMENT ON COLUMN application_form_fields.canonical_field_id is 'The id of the canonical field associated with the data being collected by this form field';
+COMMENT ON COLUMN application_form_fields.position is 'The order that this field should appear on the application form';
+COMMENT ON COLUMN application_form_fields.label is 'The language presented to an applicant for this field';

--- a/src/database/queries/applicationFormFields/insertOne.sql
+++ b/src/database/queries/applicationFormFields/insertOne.sql
@@ -1,0 +1,18 @@
+INSERT INTO application_form_fields (
+  application_form_id,
+  canonical_field_id,
+  position,
+  label
+) VALUES (
+  :applicationFormId,
+  :canonicalFieldId,
+  :position,
+  :label
+)
+RETURNING
+  id as "id",
+  application_form_id as "applicationFormId",
+  canonical_field_id as "canonicalFieldId",
+  position as "position",
+  label as "label",
+  created_at as "createdAt"

--- a/src/database/queries/applicationFormFields/selectByApplicationFormId.sql
+++ b/src/database/queries/applicationFormFields/selectByApplicationFormId.sql
@@ -1,0 +1,9 @@
+SELECT
+  aff.id as "id",
+  aff.application_form_id as "applicationFormId",
+  aff.canonical_field_id as "canonicalFieldId",
+  aff.position as "position",
+  aff.label as "label",
+  aff.created_at as "createdAt"
+FROM application_form_fields aff
+WHERE aff.application_form_id = :applicationFormId

--- a/src/types/ApplicationForm.ts
+++ b/src/types/ApplicationForm.ts
@@ -1,12 +1,27 @@
 import { ajv } from '../ajv';
+import {
+  applicationFormFieldSchema,
+  applicationFormFieldWriteSchema,
+} from './ApplicationFormField';
 import type { JSONSchemaType } from 'ajv';
+import type {
+  ApplicationFormField,
+  ApplicationFormFieldWrite,
+} from './ApplicationFormField';
 
 export interface ApplicationForm {
-  id: number;
+  readonly id: number;
   opportunityId: number;
   version: number;
-  createdAt: Date;
+  fields?: ApplicationFormField[];
+  readonly createdAt: Date;
 }
+
+// See https://github.com/typescript-eslint/typescript-eslint/issues/1824
+/* eslint-disable @typescript-eslint/indent */
+export type ApplicationFormWrite = Omit<ApplicationForm, 'createdAt' | 'fields' | 'id' | 'version'>
+  & { fields: ApplicationFormFieldWrite[] };
+/* eslint-enable @typescript-eslint/indent */
 
 export const applicationFormSchema: JSONSchemaType<ApplicationForm> = {
   type: 'object',
@@ -19,6 +34,11 @@ export const applicationFormSchema: JSONSchemaType<ApplicationForm> = {
     },
     version: {
       type: 'integer',
+    },
+    fields: {
+      type: 'array',
+      items: applicationFormFieldSchema,
+      nullable: true,
     },
     createdAt: {
       type: 'object',
@@ -35,6 +55,25 @@ export const applicationFormSchema: JSONSchemaType<ApplicationForm> = {
 };
 
 export const isApplicationForm = ajv.compile(applicationFormSchema);
+
+export const applicationFormWriteSchema: JSONSchemaType<ApplicationFormWrite> = {
+  type: 'object',
+  properties: {
+    opportunityId: {
+      type: 'number',
+    },
+    fields: {
+      type: 'array',
+      items: applicationFormFieldWriteSchema,
+    },
+  },
+  required: [
+    'opportunityId',
+    'fields',
+  ],
+};
+
+export const isApplicationFormWrite = ajv.compile(applicationFormWriteSchema);
 
 const applicationFormArraySchema: JSONSchemaType<ApplicationForm[]> = {
   type: 'array',

--- a/src/types/ApplicationFormField.ts
+++ b/src/types/ApplicationFormField.ts
@@ -1,0 +1,76 @@
+import { ajv } from '../ajv';
+import type { JSONSchemaType } from 'ajv';
+
+export interface ApplicationFormField {
+  readonly id: number;
+  applicationFormId: number;
+  canonicalFieldId: number;
+  position: number;
+  label: string;
+  readonly createdAt: Date;
+}
+
+export type ApplicationFormFieldWrite = Omit<ApplicationFormField, 'applicationFormId' | 'createdAt' | 'id'>;
+
+export const applicationFormFieldSchema: JSONSchemaType<ApplicationFormField> = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'integer',
+    },
+    applicationFormId: {
+      type: 'integer',
+    },
+    canonicalFieldId: {
+      type: 'integer',
+    },
+    position: {
+      type: 'integer',
+    },
+    label: {
+      type: 'string',
+    },
+    createdAt: {
+      type: 'object',
+      required: [],
+      instanceof: 'Date',
+    },
+  },
+  required: [
+    'id',
+    'applicationFormId',
+    'canonicalFieldId',
+    'position',
+    'label',
+    'createdAt',
+  ],
+};
+
+export const isApplicationFormField = ajv.compile(applicationFormFieldSchema);
+
+export const applicationFormFieldWriteSchema: JSONSchemaType<ApplicationFormFieldWrite> = {
+  type: 'object',
+  properties: {
+    canonicalFieldId: {
+      type: 'integer',
+    },
+    position: {
+      type: 'integer',
+    },
+    label: {
+      type: 'string',
+    },
+  },
+  required: [
+    'canonicalFieldId',
+    'position',
+    'label',
+  ],
+};
+
+const applicationFormFieldArraySchema: JSONSchemaType<ApplicationFormField[]> = {
+  type: 'array',
+  items: applicationFormFieldSchema,
+};
+
+export const isApplicationFormFieldArray = ajv.compile(applicationFormFieldArraySchema);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './Applicant';
 export * from './ApplicationForm';
+export * from './ApplicationFormField';
 export * from './CanonicalField';
 export * from './JsonObject';
 export * from './Opportunity';


### PR DESCRIPTION
This PR updates the POST `/applicationForm` endpoint to require a list of fields to store as part of the form's definition.

It also updates the shape of the response so that it contains those fields.

GET `/applicationForm` does NOT populate the results with fields, but eventually `GET /applicationForm/{applicationFormId}` should do so.

This PR builds on #82 and should not be reviewed until that is rebased

Resolves #83 