### PR TITLE
Set up CI test configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,19 +36,13 @@ jobs:
       - name: Run build
         run: npm run build
 
-      - name: Run unit tests
-        run: npm run test:unit -- --coverage
-
-      - name: Upload unit test coverage
-        uses: codecov/codecov-action@v2
-
-      - name: Run integration tests
-        run: npm run test:integration -- --coverage
+      - name: Run all tests
+        run: npm run test:ci
         env:
           PGHOST: localhost
           PGPORT: 5432
           PGUSER: postgres
           PGPASSWORD: postgres
 
-      - name: Upload integration test coverage
+      - name: Upload test coverage
         uses: codecov/codecov-action@v2

--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -1,0 +1,8 @@
+var config = require('./jest.config.base.js');
+module.exports = {
+  ...config,
+  setupFilesAfterEnv: [
+    "<rootDir>/src/test/integrationSuiteSetup.ts",
+  ],
+  collectCoverage: true,
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "jest --config=jest.config.unit.js",
     "test:integration": "jest --config=jest.config.int.js --runInBand",
+    "test:ci": "jest --config=jest.config.ci.js --runInBand",
     "start": "node dist/index.js",
     "start:dev": "ts-node src/index.ts | pino-pretty"
   },


### PR DESCRIPTION
This PR creates a new test configuration for coverage generation / CI.  This allows us to have a consistent comprehensive coverage report regardless of whether the coverage is generated from a dev environment or a CI environment.

Resolves #98