### PR TITLE
Implement GET /proposals endpoint

### DIFF
--- a/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
+++ b/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
@@ -11,7 +11,7 @@ erDiagram
   }
   Applicant {
     int id
-    string externalId 
+    string externalId
     bool hasGivenPermission
   }
   ExternalSource {
@@ -35,15 +35,15 @@ erDiagram
     string title
     datetime dateCreated
   }
-  ApplicationSchema {
+  ApplicationForm {
     int id
     int opportunityId
     int version
     datetime dateCreated
   }
-  ApplicationSchemaField {
+  ApplicationFormField {
     int id
-    int applicationSchemaId
+    int applicationFormId
     int canonicalFieldId
     int order
     string label
@@ -66,7 +66,7 @@ erDiagram
   ApplicationFieldValue {
     int id
     int applicationVersionId
-    int applicationSchemaFieldId
+    int applicationFormFieldId
     int index
     string value
     datetime dateCreated
@@ -77,16 +77,16 @@ erDiagram
     string log
     datetime dateCreated
   }
-  
+
   Applicant ||--o{ Application : submits
   Application }|--|| Opportunity : "responds to"
-  Opportunity ||--|{ ApplicationSchema : establishes
+  Opportunity ||--|{ ApplicationForm : establishes
   Application ||--o{ Outcome : "has"
-  ApplicationSchema ||--|{ ApplicationSchemaField : has
-  ApplicationSchemaField }o--|| CanonicalField : represents
+  ApplicationForm ||--|{ ApplicationFormField : has
+  ApplicationFormField }o--|| CanonicalField : represents
   Application ||--|{ ApplicationVersion : has
   ApplicationVersion ||--|{ ApplicationFieldValue : contains
-  ApplicationFieldValue }o--|| ApplicationSchemaField : populates
+  ApplicationFieldValue }o--|| ApplicationFormField : populates
   Applicant ||--o{ ExternalFieldValue : "is described by"
   ExternalFieldValue }o--|| CanonicalField : "contains potential defaults for"
   ExternalSource ||--o{ ExternalFieldValue : "populates"
@@ -96,15 +96,15 @@ erDiagram
 
 1. An `Applicant` submits an `Application`
 2. An `Application` is a response to an `Opportunity`.  An `Opportunity` represents a given challenge, RFP, etc.
-3. An `Opportunity` establishes an `Application Schema`. An application schema is the set of fields that make up an application.  An `Opportunity` might update its `Application Schema` over time, which is why an `Opportunity` can have many `Application Schemas`.
-4. An `Application Schema` will define many `Application Schema Fields`.
-5. An `Application Schema Field` represents a `Canonical Field`.
+3. An `Opportunity` establishes an `Application Form`. An application form is the set of fields that make up an application.  An `Opportunity` might update its `Application Form` over time, which is why an `Opportunity` can have many `Application Forms`.
+4. An `Application Form` will define many `Application Form Fields`.
+5. An `Application Form Field` represents a `Canonical Field`.
 
 Meanwhile...
 
 6. An `Application` can have more than one `Application Version`.  This occurs as an application is updated or revised.
 7. An `Application Version` contains a set of `Application Field Values`.  These are the responses that were provided by the `Applicant`.
-8. An `Application Field Value` contains a response to a given `Application Schema Field`.  Some fields might allow multiple responses, which is why we provide an `index`.
+8. An `Application Field Value` contains a response to a given `Application Form Field`.  Some fields might allow multiple responses, which is why we provide an `index`.
 
 The thinking is that when a new application is being written, a Grant Management System could ask the PDC "is there any pre-populated data we should use for this organization?"
 
@@ -116,22 +116,22 @@ PDC would then:
 It would use the ApplicationFieldValue set as the primary source, and the ExternalFieldValue set as a secondary source.
 
 ## Examples
-### Registering an Application Schema
+### Registering an Application Form
 
 ```mermaid
 sequenceDiagram
   actor Admin
   participant API
   participant Database
-  Admin ->>+ API : Here is a new application schema
+  Admin ->>+ API : Here is a new application form
   API ->>+ Database : Register any new canonical fields
   Database ->>- API : OK!
-  API ->>+ Database : Register the new application schema
+  API ->>+ Database : Register the new application form
   Database ->>- API : OK!
   API ->>- Admin :  OK!
 ```
 
-New `Application Schemas` will have to be externally defined; some day maybe we will make a user interface that generates an `Application Schema` definition, but for the short term this will be manually written JSON (or YAML, or something else highly structured).  The schema will define the full set of `Application Schema Fields` along with the name of the `Canonical Field` to which the `Application Schema Fields` map.
+New `Application Forms` will have to be externally defined; some day maybe we will make a user interface that generates an `Application Form` definition, but for the short term this will be manually written JSON (or YAML, or something else highly structured).  The form will define the full set of `Application Form Fields` along with the name of the `Canonical Field` to which the `Application Form Fields` map.
 
 This might look something like this:
 
@@ -152,9 +152,9 @@ This might look something like this:
 }
 ```
 
-The PDC API would then ingest that new schema document.  It would first register any `Canonical Fields` that did not already exist.  It would then register the `Application Schema` and `Application Schema Fields`, with field-level associations to the `Canonical Fields`.
+The PDC API would then ingest that new form document.  It would first register any `Canonical Fields` that did not already exist.  It would then register the `Application Form` and `Application Form Fields`, with field-level associations to the `Canonical Fields`.
 
-The database does not differentiate between "core" and "custom" fields.  Rather, there will be a set of `Canonical Fields` that are used by varying numbers of `Application Schemas`.  We will likely see that some `Canonical Fields` are used more often than others, and some are only used by a single `Application Schema`.  We might choose a subset of the `Canonical Fields` to highlight in our documentation and might call those "core" fields; that decision is not directly relevant to the schema.
+The database does not differentiate between "core" and "custom" fields.  Rather, there will be a set of `Canonical Fields` that are used by varying numbers of `Application Forms`.  We will likely see that some `Canonical Fields` are used more often than others, and some are only used by a single `Application Form`.  We might choose a subset of the `Canonical Fields` to highlight in our documentation and might call those "core" fields; that decision is not directly relevant to the form.
 
 ### Pre-filling an Application
 
@@ -171,12 +171,12 @@ sequenceDiagram
   API ->>- GMS :  Here they are
 ```
 
-When an applicant begins to fills out an application, the Grant Management System would request all field values known for that `Applicant`.  Which values are returned could be based on business logic; it could be the complete set; it could be restricted to just the fields associated with a given application schema -- these would be implementation details but the schema would support any of them.
+When an applicant begins to fills out an application, the Grant Management System would request all field values known for that `Applicant`.  Which values are returned could be based on business logic; it could be the complete set; it could be restricted to just the fields associated with a given application form -- these would be implementation details but the form would support any of them.
 
 The API would use the Database to collect values associated with past applications (`Application Field Values`); these have been directly entered by an applicant representative.
 The API would use the Database to also collect values associated with external / independent sources (`External Field Values`).
 
-Which values are ultimately selected for prepopulation is an implementation detail.  It could be that we decide that ALL distinct values should be returned, and the GMS should determine whether to render a "dropdown" the user could select from.  It could be we decide that only the most recently updated values should be returned.  It could be we decide that values associated with past applications should override externally sourced values.  Again, these would be implementation decisions but the schema would support any of them.
+Which values are ultimately selected for prepopulation is an implementation detail.  It could be that we decide that ALL distinct values should be returned, and the GMS should determine whether to render a "dropdown" the user could select from.  It could be we decide that only the most recently updated values should be returned.  It could be we decide that values associated with past applications should override externally sourced values.  Again, these would be implementation decisions but the form would support any of them.
 
 ### Submitting an Application
 

--- a/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
+++ b/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
@@ -18,8 +18,9 @@ erDiagram
     int id
     string name
   }
-  Application {
+  Proposal {
     int id
+    string externalId
     int applicantId
     int opportunityId
     datetime dateCreated
@@ -57,15 +58,15 @@ erDiagram
     int sequence
     datetime dateCreated
   }
-  ApplicationVersion {
+  ProposalVersion {
     int id
-    int applicationId
+    int proposalId
     int version
     datetime dateCreated
   }
-  ApplicationFieldValue {
+  ProposalFieldValue {
     int id
-    int applicationVersionId
+    int proposalVersionId
     int applicationFormFieldId
     int index
     string value
@@ -78,15 +79,15 @@ erDiagram
     datetime dateCreated
   }
 
-  Applicant ||--o{ Application : submits
-  Application }|--|| Opportunity : "responds to"
+  Applicant ||--o{ Proposal : submits
+  Proposal }|--|| Opportunity : "responds to"
   Opportunity ||--|{ ApplicationForm : establishes
-  Application ||--o{ Outcome : "has"
+  Proposal ||--o{ Outcome : "has"
   ApplicationForm ||--|{ ApplicationFormField : has
   ApplicationFormField }o--|| CanonicalField : represents
-  Application ||--|{ ApplicationVersion : has
-  ApplicationVersion ||--|{ ApplicationFieldValue : contains
-  ApplicationFieldValue }o--|| ApplicationFormField : populates
+  Proposal ||--|{ ProposalVersion : has
+  ProposalVersion ||--|{ ProposalFieldValue : contains
+  ProposalFieldValue }o--|| ApplicationFormField : populates
   Applicant ||--o{ ExternalFieldValue : "is described by"
   ExternalFieldValue }o--|| CanonicalField : "contains potential defaults for"
   ExternalSource ||--o{ ExternalFieldValue : "populates"
@@ -94,26 +95,26 @@ erDiagram
 
 ## Narrative
 
-1. An `Applicant` submits an `Application`
-2. An `Application` is a response to an `Opportunity`.  An `Opportunity` represents a given challenge, RFP, etc.
+1. An `Applicant` submits a `Proposal`
+2. A `Proposal` is a response to an `Opportunity`.  An `Opportunity` represents a given challenge, RFP, etc.
 3. An `Opportunity` establishes an `Application Form`. An application form is the set of fields that make up an application.  An `Opportunity` might update its `Application Form` over time, which is why an `Opportunity` can have many `Application Forms`.
 4. An `Application Form` will define many `Application Form Fields`.
 5. An `Application Form Field` represents a `Canonical Field`.
 
 Meanwhile...
 
-6. An `Application` can have more than one `Application Version`.  This occurs as an application is updated or revised.
-7. An `Application Version` contains a set of `Application Field Values`.  These are the responses that were provided by the `Applicant`.
-8. An `Application Field Value` contains a response to a given `Application Form Field`.  Some fields might allow multiple responses, which is why we provide an `index`.
+6. A `Proposal` can have more than one `Proposal Version`.  This occurs as a proposal is updated or revised.
+7. A `Proposal Version` contains a set of `Proposal Field Values`.  These are the responses that were provided by the `Applicant`.
+8. A `Proposal Field Value` contains a response to a given `Application Form Field`.  Some fields might allow multiple responses, which is why we provide an `index`.
 
-The thinking is that when a new application is being written, a Grant Management System could ask the PDC "is there any pre-populated data we should use for this organization?"
+The thinking is that when a new proposal is being written, a Grant Management System could ask the PDC "is there any pre-populated data we should use for this organization?"
 
 PDC would then:
 
-* Collect the most recent ApplicationFieldValues for each CanonicalField for that Applicant.
+* Collect the most recent ProposalFieldValues for each CanonicalField for that Applicant.
 * Collect the most recent ExternalFieldValues for each CanonicalField for that Applicant.
 
-It would use the ApplicationFieldValue set as the primary source, and the ExternalFieldValue set as a secondary source.
+It would use the ProposalFieldValue set as the primary source, and the ExternalFieldValue set as a secondary source.
 
 ## Examples
 ### Registering an Application Form
@@ -171,30 +172,30 @@ sequenceDiagram
   API ->>- GMS :  Here they are
 ```
 
-When an applicant begins to fills out an application, the Grant Management System would request all field values known for that `Applicant`.  Which values are returned could be based on business logic; it could be the complete set; it could be restricted to just the fields associated with a given application form -- these would be implementation details but the form would support any of them.
+When an applicant begins to fills out a proposal, the Grant Management System would request all field values known for that `Applicant`.  Which values are returned could be based on business logic; it could be the complete set; it could be restricted to just the fields associated with a given application form -- these would be implementation details but the form would support any of them.
 
 The API would use the Database to collect values associated with past applications (`Application Field Values`); these have been directly entered by an applicant representative.
 The API would use the Database to also collect values associated with external / independent sources (`External Field Values`).
 
-Which values are ultimately selected for prepopulation is an implementation detail.  It could be that we decide that ALL distinct values should be returned, and the GMS should determine whether to render a "dropdown" the user could select from.  It could be we decide that only the most recently updated values should be returned.  It could be we decide that values associated with past applications should override externally sourced values.  Again, these would be implementation decisions but the form would support any of them.
+Which values are ultimately selected for prepopulation is an implementation detail.  It could be that we decide that ALL distinct values should be returned, and the GMS should determine whether to render a "dropdown" the user could select from.  It could be we decide that only the most recently updated values should be returned.  It could be we decide that values associated with past proposals should override externally sourced values.  Again, these would be implementation decisions but the form would support any of them.
 
-### Submitting an Application
+### Submitting a Proposal
 
 ```mermaid
 sequenceDiagram
   participant GMS
   participant API
   participant Database
-  GMS ->>+ API : Save this completed Application
-  API ->>+ Database : Create a new Application
+  GMS ->>+ API : Save this completed Proposal
+  API ->>+ Database : Create a new Proposal
   Database ->>- API : OK
-  API ->>+ Database : Save the Application Field Values
+  API ->>+ Database : Save the Proposal Field Values
   Database ->>- API : OK
   API ->>- GMS : OK
 ```
 
-The above flow is based on an assumption that we know this is the first time the applicant had submitted an application / it is not an update to an existing application.
+The above flow is based on an assumption that we know this is the first time the applicant had submitted a proposal / it is not an update to an existing proposal.
 
-The API would create a new Application, a new Application Version, and then it would store one `Application Field Value` per `Canonical Field`.  Those field values would then be incorporated in future lookups according to the "Pre-filling an Application" logic.
+The API would create a new Proposal, a new Proposal Version, and then it would store one `Proposal Field Value` per `Canonical Field`.  Those field values would then be incorporated in future lookups according to the "Pre-filling an Proposal" logic.
 
 The API might then send alerts to other GMSs depending on business logic, but that is an implementation detail and outside of the scope of this particular example.

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -1,0 +1,126 @@
+import request from 'supertest';
+import { TinyPgError } from 'tinypg';
+import { app } from '../app';
+import { db } from '../database';
+import { getLogger } from '../logger';
+import { PostgresErrorCode } from '../types/PostgresErrorCode';
+import type { Result } from 'tinypg';
+
+const logger = getLogger(__filename);
+const agent = request.agent(app);
+
+describe('/proposals', () => {
+  describe('GET /', () => {
+    logger.debug('Now running an proposals test');
+    it('returns an empty array when no data is present', async () => {
+      await agent
+        .get('/proposals')
+        .expect(200, []);
+    });
+
+    it('returns all proposals present in the database', async () => {
+      await db.query(`
+        INSERT INTO opportunities (
+          title,
+          created_at
+        )
+        VALUES
+          ( '🔥', '2525-01-02T00:00:01Z' )
+      `);
+      await db.query(`
+        INSERT INTO applicants (
+          external_id,
+          opted_in,
+          created_at
+        )
+        VALUES
+          ( '12345', 'true', '2022-07-20 12:00:00+0000' ),
+          ( '67890', 'false', '2022-07-20 12:00:00+0000' );
+      `);
+      await db.query(`
+        INSERT INTO proposals (
+          applicant_id,
+          external_id,
+          opportunity_id,
+          created_at
+        )
+        VALUES
+          ( 1, 'proposal-1', 1, '2525-01-01T00:00:05Z' ),
+          ( 1, 'proposal-2', 1, '2525-01-01T00:00:06Z' );
+      `);
+      await agent
+        .get('/proposals')
+        .expect(
+          200,
+          [
+            {
+              id: 1,
+              externalId: 'proposal-1',
+              applicantId: 1,
+              opportunityId: 1,
+              createdAt: '2525-01-01T00:00:05.000Z',
+            },
+            {
+              id: 2,
+              externalId: 'proposal-2',
+              applicantId: 1,
+              opportunityId: 1,
+              createdAt: '2525-01-01T00:00:06.000Z',
+            },
+          ],
+        );
+    });
+
+    it('should error if the database returns an unexpected data structure', async () => {
+      jest.spyOn(db, 'sql')
+        .mockImplementationOnce(async () => ({
+          rows: [{ foo: 'not a valid result' }],
+        }) as Result<object>);
+      const result = await agent
+        .get('/proposals')
+        .expect(500);
+      expect(result.body).toMatchObject({
+        name: 'InternalValidationError',
+        errors: expect.any(Array) as unknown[],
+      });
+    });
+
+    it('returns 500 UnknownError if a generic Error is thrown when selecting', async () => {
+      jest.spyOn(db, 'sql')
+        .mockImplementationOnce(async () => {
+          throw new Error('This is unexpected');
+        });
+      const result = await agent
+        .get('/proposals')
+        .expect(500);
+      expect(result.body).toMatchObject({
+        name: 'UnknownError',
+        errors: expect.any(Array) as unknown[],
+      });
+    });
+
+    it('returns 503 DatabaseError if an insufficient resources database error is thrown when selecting', async () => {
+      jest.spyOn(db, 'sql')
+        .mockImplementationOnce(async () => {
+          throw new TinyPgError(
+            'Something went wrong',
+            undefined,
+            {
+              error: {
+                code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+              },
+            },
+          );
+        });
+      const result = await agent
+        .get('/proposals')
+        .expect(503);
+      expect(result.body).toMatchObject({
+        name: 'DatabaseError',
+        errors: [{
+          code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+        }],
+      });
+    });
+  });
+});

--- a/src/database/migrations/0006-create-proposals.sql
+++ b/src/database/migrations/0006-create-proposals.sql
@@ -1,0 +1,21 @@
+CREATE TABLE proposals (
+  id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  applicant_id INTEGER NOT NULL,
+  opportunity_id INTEGER NOT NULL,
+  external_id VARCHAR NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  UNIQUE(applicant_id, opportunity_id, external_id),
+  CONSTRAINT fk_applicant
+    FOREIGN KEY(applicant_id)
+      REFERENCES applicants(id),
+  CONSTRAINT fk_opportunity
+    FOREIGN KEY(opportunity_id)
+      REFERENCES opportunities(id)
+);
+
+COMMENT ON TABLE proposals IS
+  'Sets of values submitted by applicants in response to an opportunity stored in the PDC.';
+COMMENT ON COLUMN proposals.external_id IS
+  'The client identifier associated with a given proposal. There cannot be more than one proposal with the same external ID for a given applicant + opportunity pair.';
+COMMENT ON COLUMN proposals.applicant_id IS
+  'The applicant that submitted this proposal.';

--- a/src/database/queries/proposals/selectAll.sql
+++ b/src/database/queries/proposals/selectAll.sql
@@ -1,0 +1,6 @@
+SELECT p.id AS "id",
+  p.applicant_id AS "applicantId",
+  p.external_id AS "externalId",
+  p.opportunity_id AS "opportunityId",
+  p.created_at AS "createdAt"
+FROM proposals p;

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -2,7 +2,7 @@ import { ajv } from '../ajv';
 import { getLogger } from '../logger';
 import { db } from '../database';
 import {
-  isOpportunityArraySchema,
+  isOpportunityArray,
   isOpportunity,
   isTinyPgErrorWithQueryContext,
 } from '../types';
@@ -31,14 +31,14 @@ const getOpportunities = (
     .then((opportunitiesQueryResult: Result<Opportunity>) => {
       logger.debug(opportunitiesQueryResult);
       const { rows: opportunities } = opportunitiesQueryResult;
-      if (isOpportunityArraySchema(opportunities)) {
+      if (isOpportunityArray(opportunities)) {
         res.status(200)
           .contentType('application/json')
           .send(opportunities);
       } else {
         next(new InternalValidationError(
           'The database responded with an unexpected format.',
-          isOpportunityArraySchema.errors ?? [],
+          isOpportunityArray.errors ?? [],
         ));
       }
     })

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -1,0 +1,55 @@
+import { getLogger } from '../logger';
+import { db } from '../database';
+import {
+  isProposalArray,
+  isTinyPgErrorWithQueryContext,
+} from '../types';
+import {
+  DatabaseError,
+  InternalValidationError,
+} from '../errors';
+import type {
+  Request,
+  Response,
+  NextFunction,
+} from 'express';
+import type { Result } from 'tinypg';
+import type { Proposal } from '../types';
+
+const logger = getLogger(__filename);
+
+const getProposals = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  db.sql('proposals.selectAll')
+    .then((proposalsQueryResult: Result<Proposal>) => {
+      logger.debug(proposalsQueryResult);
+      const { rows: proposals } = proposalsQueryResult;
+      if (isProposalArray(proposals)) {
+        res.status(200)
+          .contentType('application/json')
+          .send(proposals);
+      } else {
+        next(new InternalValidationError(
+          'The database responded with an unexpected format.',
+          isProposalArray.errors ?? [],
+        ));
+      }
+    })
+    .catch((error: unknown) => {
+      if (isTinyPgErrorWithQueryContext(error)) {
+        next(new DatabaseError(
+          'Error retrieving proposals.',
+          error,
+        ));
+        return;
+      }
+      next(error);
+    });
+};
+
+export const proposalsHandlers = {
+  getProposals,
+};

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -35,13 +35,17 @@
           "createdAt"
         ]
       },
-      "Application": {
+      "Proposal": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
             "readOnly": true,
             "example": 1
+          },
+          "externalId": {
+            "type": "string",
+            "example": "AnIdGeneratedByAGms"
           },
           "applicantId": {
             "type": "integer",
@@ -54,7 +58,7 @@
           "versions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ApplicationVersion"
+              "$ref": "#/components/schemas/ProposalVersion"
             },
             "nullable": true
           },
@@ -71,7 +75,7 @@
           "createdAt"
         ]
       },
-      "ApplicationVersion": {
+      "ProposalVersion": {
         "type": "object",
         "properties": {
           "id": {
@@ -79,7 +83,7 @@
             "readOnly": true,
             "example": 1
           },
-          "applicationId": {
+          "proposalId": {
             "type": "integer",
             "example": 1
           },
@@ -90,7 +94,7 @@
           "fieldValues": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ApplicationFieldValue"
+              "$ref": "#/components/schemas/ProposalFieldValue"
             },
             "nullable": true
           },
@@ -102,12 +106,12 @@
         },
         "required": [
           "id",
-          "applicationId",
+          "proposalId",
           "version",
           "createdAt"
         ]
       },
-      "ApplicationFieldValue": {
+      "ProposalFieldValue": {
         "type": "object",
         "properties": {
           "id": {
@@ -115,7 +119,7 @@
             "readOnly": true,
             "example": 1
           },
-          "applicationVersionId": {
+          "proposalVersionId": {
             "type": "integer",
             "readOnly": true,
             "example": 1
@@ -140,7 +144,7 @@
         },
         "required": [
           "id",
-          "applicationVersionId",
+          "proposalVersionId",
           "applicationFormFieldId",
           "position",
           "value",
@@ -461,21 +465,21 @@
         }
       }
     },
-    "/applications": {
+    "/proposals": {
       "get": {
-        "summary": "Get a list of applications. (In Development)",
+        "summary": "Get a list of proposals.",
         "tags": [
-          "Applications"
+          "Proposals"
         ],
         "responses": {
           "200": {
-            "description": "All applications currently registered in the PDC.",
+            "description": "All proposals currently registered in the PDC.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Application"
+                    "$ref": "#/components/schemas/Proposal"
                   }
                 }
               }
@@ -484,27 +488,27 @@
         }
       },
       "post": {
-        "summary": "Add a new application. (In Development)",
+        "summary": "Add a new proposal. (In Development)",
         "tags": [
-          "Applications"
+          "Proposals"
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Application"
+                "$ref": "#/components/schemas/Proposal"
               }
             }
           }
         },
         "responses": {
           "201": {
-            "description": "The new application that was created, with populated field values",
+            "description": "The new proposal that was created, with populated field values",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Application"
+                  "$ref": "#/components/schemas/Proposal"
                 }
               }
             }

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -3,6 +3,7 @@ import { applicantsRouter } from './applicantsRouter';
 import { applicationFormsRouter } from './applicationFormsRouter';
 import { canonicalFieldsRouter } from './canonicalFieldsRouter';
 import { opportunitiesRouter } from './opportunitiesRouter';
+import { proposalsRouter } from './proposalsRouter';
 import { documentationRouter } from './documentationRouter';
 
 const rootRouter = express.Router();
@@ -11,6 +12,7 @@ rootRouter.use('/applicants', applicantsRouter);
 rootRouter.use('/applicationForms', applicationFormsRouter);
 rootRouter.use('/canonicalFields', canonicalFieldsRouter);
 rootRouter.use('/opportunities', opportunitiesRouter);
+rootRouter.use('/proposals', proposalsRouter);
 rootRouter.use('/', documentationRouter);
 
 export { rootRouter };

--- a/src/routers/proposalsRouter.ts
+++ b/src/routers/proposalsRouter.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { proposalsHandlers } from '../handlers/proposalsHandlers';
+
+const proposalsRouter = express.Router();
+
+proposalsRouter.get('/', proposalsHandlers.getProposals);
+
+export { proposalsRouter };

--- a/src/types/Opportunity.ts
+++ b/src/types/Opportunity.ts
@@ -36,4 +36,4 @@ const opportunityArraySchema: JSONSchemaType<Opportunity[]> = {
   items: opportunitySchema,
 };
 
-export const isOpportunityArraySchema = ajv.compile(opportunityArraySchema);
+export const isOpportunityArray = ajv.compile(opportunityArraySchema);

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -1,0 +1,50 @@
+import { ajv } from '../ajv';
+import type { JSONSchemaType } from 'ajv';
+
+export interface Proposal {
+  id: number;
+  externalId: string;
+  applicantId: number;
+  opportunityId: number;
+  createdAt: Date;
+}
+
+export const proposalSchema: JSONSchemaType<Proposal> = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'integer',
+    },
+    externalId: {
+      type: 'string',
+      pattern: '.+',
+    },
+    applicantId: {
+      type: 'integer',
+    },
+    opportunityId: {
+      type: 'integer',
+    },
+    createdAt: {
+      type: 'object',
+      required: [],
+      instanceof: 'Date',
+    },
+  },
+  required: [
+    'id',
+    'externalId',
+    'applicantId',
+    'opportunityId',
+    'createdAt',
+  ],
+};
+
+export const isProposal = ajv.compile(proposalSchema);
+
+const proposalArraySchema: JSONSchemaType<Proposal[]> = {
+  type: 'array',
+  items: proposalSchema,
+};
+
+export const isProposalArray = ajv.compile(proposalArraySchema);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,4 +5,5 @@ export * from './CanonicalField';
 export * from './JsonObject';
 export * from './Opportunity';
 export * from './PostgresErrorCode';
+export * from './Proposal';
 export * from './TinyPgErrorWithQueryContext';


### PR DESCRIPTION
This PR creates a new `GET /proposals` endpoint and updates the relevant documentation to reflect the proposed change in name from `Applications` to `Proposals`.

It also sneaks in two little fixes that I noticed when implementing (one is documentation related, the other is just updating a type guard name).

Resolves #34 