### PR TITLE
Fix OpenAPI spec for ApplicationFormField

### DIFF
--- a/src/openapi.json
+++ b/src/openapi.json
@@ -206,9 +206,9 @@
             "readOnly": true,
             "example": 1
           },
-          "canonicalFieldShortCode": {
-            "type": "string",
-            "example": "firstName"
+          "canonicalFieldId": {
+            "type": "integer",
+            "example": 1
           },
           "position": {
             "type": "integer",


### PR DESCRIPTION
This PR corrects a mistake in our OpenAPI spec which referred to the incorrect field when defining the Canonical Form Field schema.

Resolves #110