### PR TITLE
Make fields in docs, code, and schema consistent

### DIFF
--- a/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
+++ b/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
@@ -6,13 +6,15 @@ erDiagram
   CanonicalField {
     int id
     string label
-    string type
-    datetime dateCreated
+    string shortCode
+    string dataType
+    datetime createdAt
   }
   Applicant {
     int id
     string externalId
-    bool hasGivenPermission
+    bool optedIn
+    datetime createdAt
   }
   ExternalSource {
     int id
@@ -20,63 +22,63 @@ erDiagram
   }
   Proposal {
     int id
-    string externalId
     int applicantId
     int opportunityId
-    datetime dateCreated
+    string externalId
+    datetime createdAt
   }
   Outcome {
     int id
     int applicationId
     string outcome
-    datetime dateCreated
+    datetime createdAt
   }
   Opportunity {
     int id
     string title
-    datetime dateCreated
+    datetime createdAt
   }
   ApplicationForm {
     int id
     int opportunityId
     int version
-    datetime dateCreated
+    datetime createdAt
   }
   ApplicationFormField {
     int id
     int applicationFormId
     int canonicalFieldId
-    int order
+    int position
     string label
-    datetime dateCreated
+    datetime createdAt
   }
   ExternalFieldValue {
     int id
     int canonicalFieldId
     string name
     string value
-    int sequence
-    datetime dateCreated
+    int position
+    datetime createdAt
   }
   ProposalVersion {
     int id
     int proposalId
     int version
-    datetime dateCreated
+    datetime createdAt
   }
   ProposalFieldValue {
     int id
     int proposalVersionId
     int applicationFormFieldId
-    int sequence
+    int position
     string value
-    datetime dateCreated
+    datetime createdAt
   }
   ActivityLog {
     int id
     string actionType
     string log
-    datetime dateCreated
+    datetime createdAt
   }
 
   Applicant ||--o{ Proposal : submits
@@ -105,7 +107,7 @@ Meanwhile...
 
 6. A `Proposal` can have more than one `Proposal Version`.  This occurs as a proposal is updated or revised.
 7. A `Proposal Version` contains a set of `Proposal Field Values`.  These are the responses that were provided by the `Applicant`.
-8. A `Proposal Field Value` contains a response to a given `Application Form Field`.  Some fields might allow multiple responses, which is why we provide an `sequence`.
+8. A `Proposal Field Value` contains a response to a given `Application Form Field`.  Some fields might allow multiple responses, which is why we provide a `position`.
 
 The thinking is that when a new proposal is being written, a Grant Management System could ask the PDC "is there any pre-populated data we should use for this organization?"
 
@@ -132,7 +134,7 @@ sequenceDiagram
   API ->>- Admin :  OK!
 ```
 
-New `Application Forms` will have to be externally defined; some day maybe we will make a user interface that generates an `Application Form` definition, but for the short term this will be manually written JSON (or YAML, or something else highly structured).  The form will define the full set of `Application Form Fields` along with the name of the `Canonical Field` to which the `Application Form Fields` map.
+New `Application Forms` will have to be externally defined; some day maybe we will make a user interface that generates an `Application Form` definition, but for the short term this will be manually written JSON (or YAML, or something else highly structured).  The form will define the full set of `Application Form Fields` along with the id of the `Canonical Field` to which the `Application Form Fields` map.
 
 This might look something like this:
 
@@ -142,12 +144,12 @@ This might look something like this:
     {
       "name": "Applicant Name",
       "type": "string",
-      "canonicalField": "applicantName",
+      "canonicalFieldId": 42,
     },
     {
       "name": "Have you ever seen the Mona Lisa?",
       "type": "boolean",
-      "canonicalField": "haveSeenMonaLisa",
+      "canonicalFieldId": 43,
     }
   ]
 }

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -145,12 +145,12 @@ describe('/proposalVersions', () => {
           fieldValues: [
             {
               applicationFormFieldId: 1,
-              sequence: 1,
+              position: 1,
               value: 'Gronald',
             },
             {
               applicationFormFieldId: 2,
-              sequence: 1,
+              position: 1,
               value: 'Plorp',
             },
           ],
@@ -166,14 +166,14 @@ describe('/proposalVersions', () => {
           {
             id: 1,
             applicationFormFieldId: 1,
-            sequence: 1,
+            position: 1,
             value: 'Gronald',
             createdAt: expect.stringMatching(isoTimestampPattern) as string,
           },
           {
             id: 2,
             applicationFormFieldId: 2,
-            sequence: 1,
+            position: 1,
             value: 'Plorp',
             createdAt: expect.stringMatching(isoTimestampPattern) as string,
           },
@@ -445,7 +445,7 @@ describe('/proposalVersions', () => {
           fieldValues: [
             {
               applicationFormFieldId: 1,
-              sequence: 1,
+              position: 1,
               value: 'Gronald',
             },
           ],
@@ -536,7 +536,7 @@ describe('/proposalVersions', () => {
           fieldValues: [
             {
               applicationFormFieldId: 1,
-              sequence: 1,
+              position: 1,
               value: 'Gronald',
             },
           ],
@@ -821,7 +821,7 @@ describe('/proposalVersions', () => {
           fieldValues: [
             {
               applicationFormFieldId: 1,
-              sequence: 1,
+              position: 1,
               value: 'Gronald',
             },
           ],
@@ -919,7 +919,7 @@ describe('/proposalVersions', () => {
           fieldValues: [
             {
               applicationFormFieldId: 1,
-              sequence: 1,
+              position: 1,
               value: 'Gronald',
             },
           ],
@@ -1077,12 +1077,12 @@ describe('/proposalVersions', () => {
           fieldValues: [
             {
               applicationFormFieldId: 1,
-              sequence: 1,
+              position: 1,
               value: 'Gronald',
             },
             {
               applicationFormFieldId: 2,
-              sequence: 1,
+              position: 1,
               value: 'Plorp',
             },
           ],
@@ -1250,12 +1250,12 @@ describe('/proposalVersions', () => {
           fieldValues: [
             {
               applicationFormFieldId: 1,
-              sequence: 1,
+              position: 1,
               value: 'Gronald',
             },
             {
               applicationFormFieldId: 2,
-              sequence: 1,
+              position: 1,
               value: 'Plorp',
             },
           ],

--- a/src/database/migrations/0009-alter-proposal_field_values-position.sql
+++ b/src/database/migrations/0009-alter-proposal_field_values-position.sql
@@ -1,0 +1,1 @@
+ALTER TABLE proposal_field_values RENAME COLUMN sequence TO position;

--- a/src/database/queries/proposalFieldValues/insertOne.sql
+++ b/src/database/queries/proposalFieldValues/insertOne.sql
@@ -2,17 +2,17 @@ INSERT INTO proposal_field_values (
   proposal_version_id,
   application_form_field_id,
   value,
-  sequence
+  position
 ) VALUES (
   :proposalVersionId,
   :applicationFormFieldId,
   :value,
-  :sequence
+  :position
 )
 RETURNING
   id as "id",
   proposal_version_id as "proposalVersionId",
   application_form_field_id as "applicationFormFieldId",
   value as "value",
-  sequence as "sequence",
+  position as "position",
   created_at AS "createdAt"

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -43,10 +43,6 @@
             "readOnly": true,
             "example": 1
           },
-          "externalId": {
-            "type": "string",
-            "example": "AnIdGeneratedByAGms"
-          },
           "applicantId": {
             "type": "integer",
             "example": 1
@@ -54,6 +50,10 @@
           "opportunityId": {
             "type": "integer",
             "example": 1
+          },
+          "externalId": {
+            "type": "string",
+            "example": "AnIdGeneratedByAGms"
           },
           "versions": {
             "type": "array",
@@ -73,6 +73,7 @@
           "id",
           "applicantId",
           "opportunityId",
+          "externalId",
           "createdAt"
         ]
       },

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -5,9 +5,9 @@ import type { ProposalVersion } from './ProposalVersion';
 
 export interface Proposal {
   id: number;
-  externalId: string;
   applicantId: number;
   opportunityId: number;
+  externalId: string;
   versions?: ProposalVersion[];
   createdAt: Date;
 }
@@ -23,15 +23,15 @@ export const proposalSchema: JSONSchemaType<Proposal> = {
     id: {
       type: 'integer',
     },
-    externalId: {
-      type: 'string',
-      pattern: '.+',
-    },
     applicantId: {
       type: 'integer',
     },
     opportunityId: {
       type: 'integer',
+    },
+    externalId: {
+      type: 'string',
+      pattern: '.+',
     },
     versions: {
       type: 'array',
@@ -46,9 +46,9 @@ export const proposalSchema: JSONSchemaType<Proposal> = {
   },
   required: [
     'id',
-    'externalId',
     'applicantId',
     'opportunityId',
+    'externalId',
     'createdAt',
   ],
 };
@@ -56,21 +56,21 @@ export const proposalSchema: JSONSchemaType<Proposal> = {
 export const proposalWriteSchema: JSONSchemaType<ProposalWrite> = {
   type: 'object',
   properties: {
-    externalId: {
-      type: 'string',
-      pattern: '.+',
-    },
     applicantId: {
       type: 'integer',
     },
     opportunityId: {
       type: 'integer',
     },
+    externalId: {
+      type: 'string',
+      pattern: '.+',
+    },
   },
   required: [
-    'externalId',
     'applicantId',
     'opportunityId',
+    'externalId',
   ],
 };
 

--- a/src/types/ProposalFieldValue.ts
+++ b/src/types/ProposalFieldValue.ts
@@ -5,7 +5,7 @@ export interface ProposalFieldValue {
   id: number;
   proposalVersionId: number;
   applicationFormFieldId: number;
-  sequence: number;
+  position: number;
   value: string;
   createdAt: Date;
 }
@@ -27,7 +27,7 @@ export const proposalFieldValueSchema: JSONSchemaType<ProposalFieldValue> = {
     applicationFormFieldId: {
       type: 'integer',
     },
-    sequence: {
+    position: {
       type: 'integer',
     },
     value: {
@@ -43,7 +43,7 @@ export const proposalFieldValueSchema: JSONSchemaType<ProposalFieldValue> = {
     'id',
     'proposalVersionId',
     'applicationFormFieldId',
-    'sequence',
+    'position',
     'value',
     'createdAt',
   ],
@@ -55,7 +55,7 @@ export const proposalFieldValueWriteSchema: JSONSchemaType<ProposalFieldValueWri
     applicationFormFieldId: {
       type: 'integer',
     },
-    sequence: {
+    position: {
       type: 'integer',
     },
     value: {
@@ -64,7 +64,7 @@ export const proposalFieldValueWriteSchema: JSONSchemaType<ProposalFieldValueWri
   },
   required: [
     'applicationFormFieldId',
-    'sequence',
+    'position',
     'value',
   ],
 };


### PR DESCRIPTION
Make fields in docs, code, and schema consistent

* Instead of "order" or "sequence", use the word "position."
* Update some of the fields in the ER diagram.
* Make the order of Proposal fields in code more consistent with schema.

Issue #114 Missing sequence in ApplicationFormField in openapi.json
