### PR TITLE
Update setup instructions with test keys note

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ In order to run this software you need to set up a [Postgres 14](https://www.pos
   ```bash
   cp .env.example .env.test
   edit .env.test
+  # Along with the other variables, be sure to set `API_KEYS_FILE=test_keys.txt`
   ```
 
 4. Run migrations


### PR DESCRIPTION
This PR adds a note about setting the filename for the API keys file to the test environment setup block, resolving a hiccup one runs into while setting up the app to run locally.

Closes #126