### PR TITLE
Try dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+open-pull-requests-limit: 10
+


### PR DESCRIPTION
Updating to recent versions of software is a chore. The reason to
update is to get ahead of CVEs or take advantage of improvements. It
is best to do these changes atomically and as frequently as new
versions are available in order to tell which update might cause an
issue. Our libraries and base images can be scanned automatically for
updates using dependabot and pull requests automatically created. If
all goes well with the proposed change, we should see the tests pass
in that pull request and can simply merge. If an issue is revealed by
the updated software library, it is visible in the pull request.

Somewhat related to issue #134 (Node.js engine versioning)