### PR TITLE
Correct the syntax for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 2
 
-open-pull-requests-limit: 10
+
 


### PR DESCRIPTION
The open-pull-requests-limit is per package ecosystem, not overall.

Somewhat related to issue #134