### PR TITLE
Include fields on GET /applicationForms/{id} optionally

### DIFF
--- a/src/database/queries/applicationFormFields/selectByApplicationFormId.sql
+++ b/src/database/queries/applicationFormFields/selectByApplicationFormId.sql
@@ -7,3 +7,4 @@ SELECT
   aff.created_at as "createdAt"
 FROM application_form_fields aff
 WHERE aff.application_form_id = :applicationFormId
+ORDER BY aff.position;

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -11,6 +11,7 @@ import {
   DatabaseError,
   InputValidationError,
   InternalValidationError,
+  NotFoundError,
 } from '../errors';
 import type {
   Request,
@@ -56,6 +57,110 @@ const getApplicationForms = (
       }
       next(error);
     });
+};
+
+const getShallowApplicationForm = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  db.sql('applicationForms.selectById', { id: req.params.id })
+    .then((applicationFormsQueryResult: Result<ApplicationForm>) => {
+      if (applicationFormsQueryResult.row_count === 0) {
+        throw new NotFoundError(
+          'Not found. Find existing application forms by calling with no parameters.',
+        );
+      }
+      const applicationForm = applicationFormsQueryResult.rows[0];
+      if (!isApplicationForm(applicationForm)) {
+        throw new InternalValidationError(
+          'The database responded with an unexpected format.',
+          isApplicationForm.errors ?? [],
+        );
+      }
+      res.status(200)
+        .contentType('application/json')
+        .send(applicationForm);
+    })
+    .catch((error: unknown) => {
+      if (isTinyPgErrorWithQueryContext(error)) {
+        next(new DatabaseError(
+          'Error retrieving application forms.',
+          error,
+        ));
+        return;
+      }
+      next(error);
+    });
+};
+
+const getApplicationFormWithFields = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  db.sql('applicationForms.selectById', { id: req.params.id })
+    .then((applicationFormsQueryResult: Result<ApplicationForm>) => {
+      if (applicationFormsQueryResult.row_count === 0) {
+        throw new NotFoundError(
+          'Not found. Find existing application forms by calling with no parameters.',
+        );
+      }
+      const baseApplicationForm = applicationFormsQueryResult.rows[0];
+      if (!isApplicationForm(baseApplicationForm)) {
+        throw new InternalValidationError(
+          'The database responded with an unexpected format.',
+          isApplicationForm.errors ?? [],
+        );
+      }
+      db.sql('applicationFormFields.selectByApplicationFormId', { applicationFormId: req.params.id })
+        .then((applicationFormFieldsQueryResult) => {
+          if (!isApplicationFormFieldArray(applicationFormFieldsQueryResult.rows)) {
+            throw new InternalValidationError(
+              'The database responded with an unexpected format.',
+              isApplicationFormFieldArray.errors ?? [],
+            );
+          }
+          const applicationForm = {
+            ...baseApplicationForm,
+            fields: applicationFormFieldsQueryResult.rows,
+          };
+          res.status(200)
+            .contentType('application/json')
+            .send(applicationForm);
+        }).catch((error: unknown) => {
+          if (isTinyPgErrorWithQueryContext(error)) {
+            next(new DatabaseError(
+              'Error retrieving application form.',
+              error,
+            ));
+            return;
+          }
+          next(error);
+        });
+    })
+    .catch((error: unknown) => {
+      if (isTinyPgErrorWithQueryContext(error)) {
+        next(new DatabaseError(
+          'Error retrieving application form.',
+          error,
+        ));
+        return;
+      }
+      next(error);
+    });
+};
+
+const getApplicationForm = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  if (req.query.includeFields !== undefined && req.query.includeFields === 'true') {
+    getApplicationFormWithFields(req, res, next);
+  } else {
+    getShallowApplicationForm(req, res, next);
+  }
 };
 
 const postApplicationForms = (
@@ -134,6 +239,7 @@ const postApplicationForms = (
 };
 
 export const applicationFormsHandlers = {
+  getApplicationForm,
   getApplicationForms,
   postApplicationForms,
 };

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -471,14 +471,19 @@
                     "$ref": "#/components/schemas/ApplicationForm"
                   }
                 },
-                "example": [
-                  {
-                    "id": 3529,
-                    "opportunityId": 3203,
-                    "version": 13,
-                    "createdAt": "2022-09-13T14:45:06.139Z"
+                "examples": {
+                  "default": {
+                    "summary": "The default is a shallow response. To get deep objects, request by applicationFormId.",
+                    "value": [
+                      {
+                        "id": 3529,
+                        "opportunityId": 3203,
+                        "version": 13,
+                        "createdAt": "2022-09-13T14:45:06.139Z"
+                      }
+                    ]
                   }
-                ]
+                }
               }
             }
           }
@@ -531,6 +536,84 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applicationForms/{applicationFormId}": {
+      "get": {
+        "summary": "Get a specific application form.",
+        "tags": [
+          "Application Forms"
+        ],
+        "security": [
+          {
+            "preSharedApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "applicationFormId",
+            "description": "The PDC-generated ID of an application form.",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "includeFields",
+            "in": "query",
+            "description": "Include the fields associated with the application form when 'true', otherwise not.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All application forms currently registered in the PDC.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ApplicationForm"
+                  }
+                },
+                "examples": {
+                  "default": {
+                    "summary": "The default, shallow response with no parameters or where includeFields=false",
+                    "value": {
+                      "id": 3529,
+                      "opportunityId": 3203,
+                      "version": 13,
+                      "createdAt": "2022-09-13T14:45:06.139Z"
+                    }
+                  },
+                  "includeFields": {
+                    "summary": "The response when includeFields is set to true",
+                    "value": {
+                      "id": 3529,
+                      "opportunityId": 3203,
+                      "version": 13,
+                      "createdAt": "2022-09-13T14:45:06.139Z",
+                      "fields": [
+                        {
+                          "id": 3613,
+                          "applicationFormId": 3529,
+                          "canonicalFieldId": 3011,
+                          "position": 29,
+                          "label": "Your First Name",
+                          "createdAt": "2022-12-12T17:54:24.988Z"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }

--- a/src/routers/applicationFormsRouter.ts
+++ b/src/routers/applicationFormsRouter.ts
@@ -4,6 +4,7 @@ import { checkApiKey } from '../middleware/apiKeyChecker';
 
 const applicationFormsRouter = express.Router();
 
+applicationFormsRouter.get('/:id', checkApiKey, applicationFormsHandlers.getApplicationForm);
 applicationFormsRouter.get('/', checkApiKey, applicationFormsHandlers.getApplicationForms);
 applicationFormsRouter.post('/', checkApiKey, applicationFormsHandlers.postApplicationForms);
 


### PR DESCRIPTION
Use query parameter `includeFields=true` to include application form
fields in the response from `GET /applicationForms/{id}`, otherwise a
shallow response with only direct attributes on application form will
be returned.

The implementation is more akin to the one for /proposals in PR #210.

This commit combines four commits from 2022-12-06, 2022-12-12,
2022-12-12, 2022-12-16, 2023-02-09, respectively, and cleanup on
2023-02-13. Some history of changes should be available at
#157

Issue #132 Provide visibility of application form fields