### PR TITLE
For audit capabilities, log subset of API keys

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,9 +11,21 @@ import type {
 // here in the logger code.
 dotenv.config();
 
+export const redactAllButFirstAndLastThreeDigits = (secret: string): string => {
+  // We want to redact much more than we log. These are usually >=80 characters.
+  if (secret.length >= 24) {
+    return `${secret.slice(0, 3)}...[redacted]...${secret.slice(-3)}`;
+  }
+
+  return '[redacted a secret that was too short]';
+};
+
 const logger = pino({
   level: process.env.LOG_LEVEL ?? 'info',
-  redact: ['req.headers["x-api-key"]'],
+  redact: {
+    paths: ['req.headers["x-api-key"]'],
+    censor: redactAllButFirstAndLastThreeDigits,
+  },
 });
 
 export const getLogger = (source: string): Logger => logger.child({ source });

--- a/src/test/__tests__/logger.unit.test.ts
+++ b/src/test/__tests__/logger.unit.test.ts
@@ -1,0 +1,15 @@
+import { redactAllButFirstAndLastThreeDigits } from '../../logger';
+
+describe('logger redaction function', () => {
+  it('should redact all but six chars when given 50 digit secret', () => {
+    const longishSecret = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWX';
+    const redacted = redactAllButFirstAndLastThreeDigits(longishSecret);
+    expect(redacted).toBe('abc...[redacted]...VWX');
+  });
+
+  it('should redact all chars when given eight digit secret', () => {
+    const shortishSecret = 'abcdefgh';
+    const redacted = redactAllButFirstAndLastThreeDigits(shortishSecret);
+    expect(redacted).toBe('[redacted a secret that was too short]');
+  });
+});


### PR DESCRIPTION
When using x-api-key for auth, there is only a set of authentication keys. To have a clearer picture of which entity made which API call, log some subset of that key, assuming that it is long enough to not compromise it by this logging.

Issue #135 Logging and creating an audit trail