### PR TITLE
Expand API key checks to remainder of endpoints

### DIFF
--- a/src/__tests__/applicationForm.int.test.ts
+++ b/src/__tests__/applicationForm.int.test.ts
@@ -31,6 +31,7 @@ describe('/applicationForms', () => {
     it('returns an empty array when no data is present', async () => {
       await agent
         .get('/applicationForms')
+        .set(dummyApiKey)
         .expect(200, []);
     });
 
@@ -54,6 +55,7 @@ describe('/applicationForms', () => {
       `);
       await agent
         .get('/applicationForms')
+        .set(dummyApiKey)
         .expect(
           200,
           [
@@ -86,6 +88,7 @@ describe('/applicationForms', () => {
         }) as Result<object>);
       const result = await agent
         .get('/applicationForms')
+        .set(dummyApiKey)
         .expect(500);
       expect(result.body).toMatchObject({
         name: 'InternalValidationError',
@@ -100,6 +103,7 @@ describe('/applicationForms', () => {
         });
       const result = await agent
         .get('/applicationForms')
+        .set(dummyApiKey)
         .expect(500);
       expect(result.body).toMatchObject({
         name: 'UnknownError',
@@ -122,6 +126,7 @@ describe('/applicationForms', () => {
         });
       const result = await agent
         .get('/applicationForms')
+        .set(dummyApiKey)
         .expect(503);
       expect(result.body).toMatchObject({
         name: 'DatabaseError',

--- a/src/__tests__/canonicalFields.int.test.ts
+++ b/src/__tests__/canonicalFields.int.test.ts
@@ -31,6 +31,7 @@ describe('/canonicalFields', () => {
     it('returns an empty array when no data is present', async () => {
       await agent
         .get('/canonicalFields')
+        .set(dummyApiKey)
         .expect(200, []);
     });
 
@@ -48,6 +49,7 @@ describe('/canonicalFields', () => {
       `);
       await agent
         .get('/canonicalFields')
+        .set(dummyApiKey)
         .expect(
           200,
           [
@@ -76,6 +78,7 @@ describe('/canonicalFields', () => {
         }) as Result<object>);
       const result = await agent
         .get('/canonicalFields')
+        .set(dummyApiKey)
         .expect(500);
       expect(result.body).toMatchObject({
         name: 'InternalValidationError',
@@ -90,6 +93,7 @@ describe('/canonicalFields', () => {
         });
       const result = await agent
         .get('/canonicalFields')
+        .set(dummyApiKey)
         .expect(500);
       expect(result.body).toMatchObject({
         name: 'UnknownError',
@@ -112,6 +116,7 @@ describe('/canonicalFields', () => {
         });
       const result = await agent
         .get('/canonicalFields')
+        .set(dummyApiKey)
         .expect(503);
       expect(result.body).toMatchObject({
         name: 'DatabaseError',

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -32,6 +32,7 @@ describe('/opportunities', () => {
     it('returns an empty array when no data is present', async () => {
       await agent
         .get('/opportunities')
+        .set(dummyApiKey)
         .expect(200, []);
     });
 
@@ -47,6 +48,7 @@ describe('/opportunities', () => {
       `);
       await agent
         .get('/opportunities')
+        .set(dummyApiKey)
         .expect(
           200,
           [
@@ -71,6 +73,7 @@ describe('/opportunities', () => {
         }) as Result<object>);
       const result = await agent
         .get('/opportunities')
+        .set(dummyApiKey)
         .expect(500);
       expect(result.body).toMatchObject({
         name: 'InternalValidationError',
@@ -85,6 +88,7 @@ describe('/opportunities', () => {
         });
       const result = await agent
         .get('/opportunities')
+        .set(dummyApiKey)
         .expect(500);
       expect(result.body).toMatchObject({
         name: 'UnknownError',
@@ -107,6 +111,7 @@ describe('/opportunities', () => {
         });
       const result = await agent
         .get('/opportunities')
+        .set(dummyApiKey)
         .expect(503);
       expect(result.body).toMatchObject({
         name: 'DatabaseError',
@@ -139,6 +144,7 @@ describe('/opportunities', () => {
       logger.debug('sparkleOpportunityId: %d', sparkleOpportunity.id);
       await agent
         .get(`/opportunities/${sparkleOpportunity.id}`)
+        .set(dummyApiKey)
         .expect(
           200,
           {
@@ -161,6 +167,7 @@ describe('/opportunities', () => {
       `);
       const result = await agent
         .get('/opportunities/a')
+        .set(dummyApiKey)
         .expect(400);
       expect(result.body).toMatchObject({
         name: 'InputValidationError',
@@ -180,6 +187,7 @@ describe('/opportunities', () => {
       `);
       await agent
         .get('/opportunities/9001')
+        .set(dummyApiKey)
         .expect(404);
     });
 
@@ -190,6 +198,7 @@ describe('/opportunities', () => {
         }) as Result<object>);
       const result = await agent
         .get('/opportunities/1')
+        .set(dummyApiKey)
         .expect(500);
       expect(result.body).toMatchObject({
         name: 'InternalValidationError',
@@ -204,6 +213,7 @@ describe('/opportunities', () => {
         });
       const result = await agent
         .get('/opportunities/1')
+        .set(dummyApiKey)
         .expect(500);
       expect(result.body).toMatchObject({
         name: 'UnknownError',
@@ -226,6 +236,7 @@ describe('/opportunities', () => {
         });
       const result = await agent
         .get('/opportunities/1')
+        .set(dummyApiKey)
         .expect(503);
       expect(result.body).toMatchObject({
         name: 'DatabaseError',

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -71,7 +71,7 @@ const getOpportunityParamsSchema: JSONSchemaType<GetOpportunityParams> = {
 };
 const isGetOpportunityParams = ajv.compile(getOpportunityParamsSchema);
 const getOpportunity = (
-  req: Request<GetOpportunityParams>,
+  req: Request<unknown, unknown, GetOpportunityParams>,
   res: Response,
   next: NextFunction,
 ): void => {

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -455,6 +455,11 @@
         "tags": [
           "Application Forms"
         ],
+        "security": [
+          {
+            "preSharedApiKey": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "All application forms currently registered in the PDC.",
@@ -685,6 +690,11 @@
         "tags": [
           "Canonical Fields"
         ],
+        "security": [
+          {
+            "preSharedApiKey": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "All canonical fields currently registered in the PDC.",
@@ -761,6 +771,11 @@
         "tags": [
           "Opportunities"
         ],
+        "security": [
+          {
+            "preSharedApiKey": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "A list of known funding opportunities.",
@@ -826,6 +841,11 @@
         "summary": "Get a specific opportunity.",
         "tags": [
           "Opportunities"
+        ],
+        "security": [
+          {
+            "preSharedApiKey": []
+          }
         ],
         "parameters": [
           {

--- a/src/routers/applicationFormsRouter.ts
+++ b/src/routers/applicationFormsRouter.ts
@@ -4,7 +4,7 @@ import { checkApiKey } from '../middleware/apiKeyChecker';
 
 const applicationFormsRouter = express.Router();
 
-applicationFormsRouter.get('/', applicationFormsHandlers.getApplicationForms);
+applicationFormsRouter.get('/', checkApiKey, applicationFormsHandlers.getApplicationForms);
 applicationFormsRouter.post('/', checkApiKey, applicationFormsHandlers.postApplicationForms);
 
 export { applicationFormsRouter };

--- a/src/routers/canonicalFieldsRouter.ts
+++ b/src/routers/canonicalFieldsRouter.ts
@@ -4,7 +4,7 @@ import { checkApiKey } from '../middleware/apiKeyChecker';
 
 const canonicalFieldsRouter = express.Router();
 
-canonicalFieldsRouter.get('/', canonicalFieldsHandlers.getCanonicalFields);
+canonicalFieldsRouter.get('/', checkApiKey, canonicalFieldsHandlers.getCanonicalFields);
 canonicalFieldsRouter.post('/', checkApiKey, canonicalFieldsHandlers.postCanonicalField);
 
 export { canonicalFieldsRouter };

--- a/src/routers/opportunitiesRouter.ts
+++ b/src/routers/opportunitiesRouter.ts
@@ -5,7 +5,7 @@ import { checkApiKey } from '../middleware/apiKeyChecker';
 const opportunitiesRouter = express.Router();
 
 opportunitiesRouter.post('/', checkApiKey, opportunitiesHandlers.postOpportunity);
-opportunitiesRouter.get('/:id', opportunitiesHandlers.getOpportunity);
-opportunitiesRouter.get('/', opportunitiesHandlers.getOpportunities);
+opportunitiesRouter.get('/:id', checkApiKey, opportunitiesHandlers.getOpportunity);
+opportunitiesRouter.get('/', checkApiKey, opportunitiesHandlers.getOpportunities);
 
 export { opportunitiesRouter };


### PR DESCRIPTION
We want all the endpoints (except the documentation) to be protected. This commit does that.

Issue #96 Authentication and authorization