### PR TITLE
Add param to deep GET /proposals/{proposalId}

### DIFF
--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -199,6 +199,199 @@ describe('/proposals', () => {
         );
     });
 
+    it('returns one proposal with deep fields when includeFieldsAndValues=true', async () => {
+      // Needs canonical fields,
+      // opportunity,
+      // an applicant,
+      // application form,
+      // application form fields,
+      // proposal,
+      // proposal versions, and
+      // proposal field values.
+      await db.query(`
+        INSERT INTO canonical_fields (
+          label,
+          short_code,
+          data_type,
+          created_at
+        )
+        VALUES
+          ( 'Summary', 'summary', '{ type: "string" }', '2023-01-06T16:22:00+0000' ),
+          ( 'Title', 'title', '{ type: "string" }', '2023-01-06T16:24:00+0000' );
+      `);
+      await db.query(`
+        INSERT INTO opportunities (
+          title,
+          created_at
+        )
+        VALUES
+          ( '🌎', '2525-01-04T00:00:01Z' )
+      `);
+      await db.query(`
+        INSERT INTO applicants (
+          external_id,
+          opted_in,
+          created_at
+        )
+        VALUES
+          ( '🐯', 'true', '2525-01-04T00:00:02Z' ),
+          ( '🐅', 'false', '2525-01-04T00:00:03Z' );
+      `);
+      await db.query(`
+        INSERT INTO application_forms (
+          opportunity_id,
+          version,
+          created_at
+        )
+        VALUES
+          ( 1, 1, '2525-01-04T00:00:04Z' )
+      `);
+      await db.query(`
+        INSERT INTO application_form_fields (
+          application_form_id,
+          canonical_field_id,
+          position,
+          label,
+          created_at
+        )
+        VALUES
+          ( 1, 2, 1, 'Short summary or title', '2525-01-04T00:00:05Z' ),
+          ( 1, 1, 2, 'Long summary or abstract', '2525-01-04T00:00:06Z' );
+      `);
+      await db.query(`
+        INSERT INTO proposals (
+          applicant_id,
+          external_id,
+          opportunity_id,
+          created_at
+        )
+        VALUES
+          ( 2, 'proposal-2525-01-04T00Z', 1, '2525-01-04T00:00:07Z' );
+      `);
+      await db.query(`
+        INSERT INTO proposal_versions (
+          proposal_id,
+          application_form_id,
+          version,
+          created_at
+        )
+        VALUES
+          ( 1, 1, 1, '2525-01-04T00:00:08Z' ),
+          ( 1, 1, 2, '2525-01-04T00:00:09Z' );
+      `);
+      await db.query(`
+        INSERT INTO proposal_field_values (
+          proposal_version_id,
+          application_form_field_id,
+          position,
+          value,
+          created_at
+        )
+        VALUES
+          ( 1, 1, 1, 'Title for version 1 from 2525-01-04', '2525-01-04T00:00:10Z' ),
+          ( 1, 2, 2, 'Abstract for version 1 from 2525-01-04', '2525-01-04T00:00:11Z' ),
+          ( 2, 1, 1, 'Title for version 2 from 2525-01-04', '2525-01-04T00:00:12Z' ),
+          ( 2, 2, 2, 'Abstract for version 2 from 2525-01-04', '2525-01-04T00:00:13Z' );
+      `);
+      await agent
+        .get('/proposals/1/?includeFieldsAndValues=true')
+        .set(dummyApiKey)
+        .expect(
+          200,
+          {
+            id: 1,
+            applicantId: 2,
+            opportunityId: 1,
+            externalId: 'proposal-2525-01-04T00Z',
+            createdAt: '2525-01-04T00:00:07.000Z',
+            versions: [
+              {
+                id: 2,
+                proposalId: 1,
+                applicationFormId: 1,
+                version: 2,
+                createdAt: '2525-01-04T00:00:09.000Z',
+                fieldValues: [
+                  {
+                    id: 3,
+                    proposalVersionId: 2,
+                    applicationFormFieldId: 1,
+                    position: 1,
+                    value: 'Title for version 2 from 2525-01-04',
+                    createdAt: '2525-01-04T00:00:12.000Z',
+                    applicationFormField: {
+                      id: 1,
+                      applicationFormId: 1,
+                      canonicalFieldId: 2,
+                      position: 1,
+                      label: 'Short summary or title',
+                      createdAt: '2525-01-04T00:00:05.000Z',
+                    },
+                  },
+                  {
+                    id: 4,
+                    proposalVersionId: 2,
+                    applicationFormFieldId: 2,
+                    position: 2,
+                    value: 'Abstract for version 2 from 2525-01-04',
+                    createdAt: '2525-01-04T00:00:13.000Z',
+                    applicationFormField: {
+                      id: 2,
+                      applicationFormId: 1,
+                      canonicalFieldId: 1,
+                      position: 2,
+                      label: 'Long summary or abstract',
+                      createdAt: '2525-01-04T00:00:06.000Z',
+                    },
+                  },
+                ],
+              },
+              {
+                id: 1,
+                proposalId: 1,
+                applicationFormId: 1,
+                version: 1,
+                createdAt: '2525-01-04T00:00:08.000Z',
+                fieldValues: [
+                  {
+                    id: 1,
+                    proposalVersionId: 1,
+                    applicationFormFieldId: 1,
+                    position: 1,
+                    value: 'Title for version 1 from 2525-01-04',
+                    createdAt: '2525-01-04T00:00:10.000Z',
+                    applicationFormField: {
+                      id: 1,
+                      applicationFormId: 1,
+                      canonicalFieldId: 2,
+                      position: 1,
+                      label: 'Short summary or title',
+                      createdAt: '2525-01-04T00:00:05.000Z',
+                    },
+                  },
+                  {
+                    id: 2,
+                    proposalVersionId: 1,
+                    applicationFormFieldId: 2,
+                    position: 2,
+                    value: 'Abstract for version 1 from 2525-01-04',
+                    createdAt: '2525-01-04T00:00:11.000Z',
+                    applicationFormField: {
+                      id: 2,
+                      applicationFormId: 1,
+                      canonicalFieldId: 1,
+                      position: 2,
+                      label: 'Long summary or abstract',
+                      createdAt: '2525-01-04T00:00:06.000Z',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        );
+    });
+
     it('should error if the database returns an unexpected data structure', async () => {
       jest.spyOn(db, 'sql')
         .mockImplementationOnce(async () => ({
@@ -252,6 +445,96 @@ describe('/proposals', () => {
           code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
         }],
       });
+    });
+  });
+
+  it('returns 404 when given id is not present and includeFieldsAndValues=true', async () => {
+    await agent
+      .get('/proposals/9002?includeFieldsAndValues=true')
+      .set(dummyApiKey)
+      .expect(404, { message: 'Not found. Find existing proposals by calling with no parameters.' });
+  });
+
+  it('should error if the database returns an unexpected data structure when includeFieldsAndValues=true', async () => {
+    jest.spyOn(db, 'sql')
+      .mockImplementationOnce(async () => ({
+        rows: [{ foo: 'not a valid result' }],
+      }) as Result<object>);
+    const result = await agent
+      .get('/proposals/9003?includeFieldsAndValues=true')
+      .set(dummyApiKey)
+      .expect(500);
+    expect(result.body).toMatchObject({
+      name: 'InternalValidationError',
+      details: expect.any(Array) as unknown[],
+    });
+  });
+
+  it('returns 500 UnknownError if a generic Error is thrown when selecting and includeFieldsAndValues=true', async () => {
+    jest.spyOn(db, 'sql')
+      .mockImplementationOnce(async () => {
+        throw new Error('This is unexpected');
+      });
+    const result = await agent
+      .get('/proposals/9004?includeFieldsAndValues=true')
+      .set(dummyApiKey)
+      .expect(500);
+    expect(result.body).toMatchObject({
+      name: 'UnknownError',
+      details: expect.any(Array) as unknown[],
+    });
+  });
+
+  it('returns 503 DatabaseError if db error is thrown when includeFieldsAndValues=true', async () => {
+    await db.query(`
+      INSERT INTO opportunities (
+        title,
+        created_at
+      )
+      VALUES
+        ( '🧳', '2525-01-04T00:00:14Z' )
+    `);
+    await db.query(`
+      INSERT INTO applicants (
+        external_id,
+        opted_in,
+        created_at
+      )
+      VALUES
+        ( '🐴', 'true', '2525-01-04T00:00:15Z' );
+    `);
+    await db.query(`
+      INSERT INTO proposals (
+        applicant_id,
+        external_id,
+        opportunity_id,
+        created_at
+      )
+      VALUES
+        ( 1, 'proposal-🧳-🐴', 1, '2525-01-04T00:00:16Z' );
+    `);
+    jest.spyOn(db, 'sql')
+      .mockImplementationOnce(async () => {
+        throw new TinyPgError(
+          'Something went wrong',
+          undefined,
+          {
+            error: {
+              code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+            },
+          },
+        );
+      });
+    const result = await agent
+      .get('/proposals/1?includeFieldsAndValues=true')
+      .type('application/json')
+      .set(dummyApiKey)
+      .expect(503);
+    expect(result.body).toMatchObject({
+      name: 'DatabaseError',
+      details: [{
+        code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+      }],
     });
   });
 

--- a/src/database/queries/proposals/selectByIdDeep.sql
+++ b/src/database/queries/proposals/selectByIdDeep.sql
@@ -1,0 +1,27 @@
+SELECT p.id AS "id",
+  p.applicant_id AS "applicantId",
+  p.opportunity_id AS "opportunityId",
+  p.external_id AS "externalId",
+  p.created_at AS "createdAt",
+  pv.id AS "proposalVersionId",
+  pv.application_form_id AS "proposalVersionApplicationFormId",
+  pv.version AS "proposalVersionVersion",
+  pv.created_at AS "proposalVersionCreatedAt",
+  pfv.id as "proposalFieldValueId",
+  pfv.application_form_field_id AS "proposalFieldValueApplicationFormFieldId",
+  pfv.value AS "proposalFieldValueValue",
+  pfv.position AS "proposalFieldValuePosition",
+  pfv.created_at AS "proposalFieldValueCreatedAt",
+  aff.canonical_field_id AS "applicationFormFieldCanonicalFieldId",
+  aff.position AS "applicationFormFieldPosition",
+  aff.label AS "applicationFormFieldLabel",
+	aff.created_at AS "applicationFormFieldCreatedAt"
+FROM proposals p
+LEFT OUTER JOIN proposal_versions pv
+  ON pv.proposal_id = p.id
+LEFT OUTER JOIN proposal_field_values pfv
+  ON pfv.proposal_version_id = pv.id
+LEFT OUTER JOIN application_form_fields aff
+  ON pfv.application_form_field_id = aff.id
+WHERE p.id = :id
+ORDER BY pv.version DESC, pfv.position, aff.position;

--- a/src/handlers/__tests__/proposalsHandlers.unit.test.ts
+++ b/src/handlers/__tests__/proposalsHandlers.unit.test.ts
@@ -1,0 +1,30 @@
+import { getValueWithFullFieldFromRow } from '../proposalsHandlers';
+import type { ProposalRowWithFieldsAndValues } from '../../types';
+
+describe('proposals handlers', () => {
+  it('getValueWithFullFieldFromRow should throw an error when an application form field value is null', () => {
+    const rowWithAlmostAllFieldsAndValues: ProposalRowWithFieldsAndValues = {
+      id: 1,
+      applicantId: 1,
+      opportunityId: 1,
+      externalId: 'external id',
+      createdAt: new Date('2022-01-06T22:05:00Z'),
+      proposalVersionId: 1,
+      proposalVersionApplicationFormId: 1,
+      proposalVersionVersion: 1,
+      proposalVersionCreatedAt: new Date('2022-01-06T22:05:01Z'),
+      proposalFieldValueId: 1,
+      proposalFieldValueApplicationFormFieldId: 1,
+      proposalFieldValueValue: 'blah',
+      proposalFieldValuePosition: 1,
+      proposalFieldValueCreatedAt: new Date('2022-01-06T22:06:00Z'),
+      applicationFormFieldCanonicalFieldId: 1,
+      applicationFormFieldPosition: 1,
+      applicationFormFieldLabel: 'label',
+      applicationFormFieldCreatedAt: null,
+    };
+
+    expect(() => { getValueWithFullFieldFromRow(rowWithAlmostAllFieldsAndValues); })
+      .toThrow('Expected ProposalVersion, ProposalFieldValue, and ApplicationFormField values to be present.');
+  });
+});

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -5,6 +5,7 @@ import {
   isProposalWrite,
   isProposal,
   isTinyPgErrorWithQueryContext,
+  isProposalRowWithFieldsAndValuesArray,
 } from '../types';
 import {
   DatabaseError,
@@ -19,7 +20,10 @@ import type {
 import type { Result } from 'tinypg';
 import type {
   Proposal,
+  ProposalFieldValue,
+  ProposalRowWithFieldsAndValues,
   ProposalWrite,
+  ProposalVersion,
 } from '../types';
 
 const logger = getLogger(__filename);
@@ -56,7 +60,160 @@ const getProposals = (
     });
 };
 
-const getProposal = (
+export const getValueWithFullFieldFromRow = (row: ProposalRowWithFieldsAndValues):
+ProposalFieldValue => {
+  if (row.proposalVersionId === undefined
+    || row.proposalVersionId === null
+    || row.proposalVersionApplicationFormId === undefined
+    || row.proposalVersionApplicationFormId === null
+    || row.proposalVersionVersion === undefined
+    || row.proposalVersionVersion === null
+    || row.proposalVersionCreatedAt === undefined
+    || row.proposalVersionCreatedAt === null
+    || row.proposalFieldValueId === undefined
+    || row.proposalFieldValueId === null
+    || row.proposalFieldValueApplicationFormFieldId === undefined
+    || row.proposalFieldValueApplicationFormFieldId === null
+    || row.proposalFieldValueValue === undefined
+    || row.proposalFieldValueValue === null
+    || row.proposalFieldValuePosition === undefined
+    || row.proposalFieldValuePosition === null
+    || row.proposalFieldValueCreatedAt === undefined
+    || row.proposalFieldValueCreatedAt === null
+    || row.applicationFormFieldCanonicalFieldId === undefined
+    || row.applicationFormFieldCanonicalFieldId === null
+    || row.applicationFormFieldPosition === undefined
+    || row.applicationFormFieldPosition === null
+    || row.applicationFormFieldLabel === undefined
+    || row.applicationFormFieldLabel === null
+    || row.applicationFormFieldCreatedAt === undefined
+    || row.applicationFormFieldCreatedAt === null) {
+    throw new Error('Expected ProposalVersion, ProposalFieldValue, and ApplicationFormField values to be present.');
+  }
+  return {
+    id: row.proposalFieldValueId,
+    proposalVersionId: row.proposalVersionId,
+    applicationFormFieldId: row.proposalFieldValueApplicationFormFieldId,
+    position: row.proposalFieldValuePosition,
+    value: row.proposalFieldValueValue,
+    createdAt: row.proposalFieldValueCreatedAt,
+    applicationFormField: {
+      id: row.proposalFieldValueApplicationFormFieldId,
+      applicationFormId: row.proposalVersionApplicationFormId,
+      canonicalFieldId: row.applicationFormFieldCanonicalFieldId,
+      position: row.applicationFormFieldPosition,
+      label: row.applicationFormFieldLabel,
+      createdAt: row.applicationFormFieldCreatedAt,
+    },
+  };
+};
+
+const getProposalWithFieldsAndValues = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  db.sql('proposals.selectByIdDeep', { id: req.params.id })
+    .then((proposalQueryResult: Result<ProposalRowWithFieldsAndValues>) => {
+      const { rows: proposalVersionsWithFields } = proposalQueryResult;
+      if (proposalVersionsWithFields.length === 0
+        || proposalVersionsWithFields[0] === undefined) {
+        res.status(404)
+          .contentType('application/json')
+          .send({ message: 'Not found. Find existing proposals by calling with no parameters.' });
+        return;
+      }
+      if (isProposalRowWithFieldsAndValuesArray(proposalVersionsWithFields)) {
+        let currentProposalVersion: ProposalVersion = {
+          id: 0,
+          proposalId: 0,
+          applicationFormId: 0,
+          version: -1,
+          fieldValues: [],
+          createdAt: new Date(),
+        };
+        const proposalVersions: ProposalVersion[] = [];
+        proposalVersionsWithFields.forEach((proposalVersionWithFieldRow) => {
+          if (currentProposalVersion.id === proposalVersionWithFieldRow.proposalVersionId) {
+            if (proposalVersionWithFieldRow.proposalFieldValueId !== undefined
+              && proposalVersionWithFieldRow.proposalFieldValueId !== null) {
+              const fieldAndValue = getValueWithFullFieldFromRow(proposalVersionWithFieldRow);
+              if (currentProposalVersion.fieldValues === undefined) {
+                currentProposalVersion.fieldValues = [fieldAndValue];
+              } else {
+                currentProposalVersion.fieldValues.push(fieldAndValue);
+              }
+            }
+          } else {
+            if (currentProposalVersion.id > 0) {
+              proposalVersions.push(currentProposalVersion);
+            }
+            // It is valid to have a proposal with no versions, likewise a version with no values.
+            if (proposalVersionWithFieldRow.proposalVersionId !== undefined
+              && proposalVersionWithFieldRow.proposalVersionId !== null
+              && proposalVersionWithFieldRow.proposalVersionApplicationFormId !== undefined
+              && proposalVersionWithFieldRow.proposalVersionApplicationFormId !== null
+              && proposalVersionWithFieldRow.proposalVersionVersion !== undefined
+              && proposalVersionWithFieldRow.proposalVersionVersion !== null
+              && proposalVersionWithFieldRow.proposalVersionCreatedAt !== undefined
+              && proposalVersionWithFieldRow.proposalVersionCreatedAt !== null) {
+              currentProposalVersion = {
+                id: proposalVersionWithFieldRow.proposalVersionId,
+                proposalId: proposalVersionWithFieldRow.id,
+                applicationFormId: proposalVersionWithFieldRow.proposalVersionApplicationFormId,
+                version: proposalVersionWithFieldRow.proposalVersionVersion,
+                createdAt: proposalVersionWithFieldRow.proposalVersionCreatedAt,
+                fieldValues: [],
+              };
+              if (proposalVersionWithFieldRow.proposalFieldValueId !== undefined
+                && proposalVersionWithFieldRow.proposalFieldValueId !== null) {
+                const fieldAndValue = getValueWithFullFieldFromRow(proposalVersionWithFieldRow);
+                // add field to previousRow
+                if (currentProposalVersion.fieldValues === undefined) {
+                  currentProposalVersion.fieldValues = [fieldAndValue];
+                } else {
+                  currentProposalVersion.fieldValues.push(fieldAndValue);
+                }
+              }
+            }
+          }
+        });
+        // Include the last row after iteration completes.
+        if (currentProposalVersion.id > 0) {
+          proposalVersions.push(currentProposalVersion);
+        }
+
+        const proposal: Proposal = {
+          id: proposalVersionsWithFields[0].id,
+          applicantId: proposalVersionsWithFields[0].applicantId,
+          opportunityId: proposalVersionsWithFields[0].opportunityId,
+          externalId: proposalVersionsWithFields[0].externalId,
+          createdAt: proposalVersionsWithFields[0].createdAt,
+          versions: proposalVersions,
+        };
+        res.status(200)
+          .contentType('application/json')
+          .send(proposal);
+      } else {
+        next(new InternalValidationError(
+          'The database responded with an unexpected format.',
+          isProposalRowWithFieldsAndValuesArray.errors ?? [],
+        ));
+      }
+    })
+    .catch((error: unknown) => {
+      if (isTinyPgErrorWithQueryContext(error)) {
+        next(new DatabaseError(
+          'Error retrieving proposal.',
+          error,
+        ));
+        return;
+      }
+      next(error);
+    });
+};
+
+const getProposalShallow = (
   req: Request,
   res: Response,
   next: NextFunction,
@@ -92,6 +249,18 @@ const getProposal = (
       }
       next(error);
     });
+};
+
+const getProposal = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  if (req.query.includeFieldsAndValues !== undefined && req.query.includeFieldsAndValues === 'true') {
+    getProposalWithFieldsAndValues(req, res, next);
+  } else {
+    getProposalShallow(req, res, next);
+  }
 };
 
 const postProposal = (
@@ -135,7 +304,7 @@ const postProposal = (
 };
 
 export const proposalsHandlers = {
-  getProposals,
   getProposal,
+  getProposals,
   postProposal,
 };

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -6,11 +6,14 @@ import {
   InputConflictError,
 } from '../errors';
 import { PostgresErrorCode } from '../types';
+import { getLogger } from '../logger';
 import type {
   NextFunction,
   Request,
   Response,
 } from 'express';
+
+const logger = getLogger(__filename);
 
 const getHttpStatusCodeForDatabaseErrorCode = (errorCode: string): number => {
   switch (errorCode) {
@@ -102,6 +105,8 @@ export const errorHandler = (
   res: Response,
   next: NextFunction, // eslint-disable-line @typescript-eslint/no-unused-vars
 ): void => {
+  logger.debug(err);
+  logger.trace(req.body);
   const statusCode = getHttpStatusCodeForError(err);
   res.status(statusCode)
     .contentType('application/json')

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -12,6 +12,27 @@ export interface Proposal {
   createdAt: Date;
 }
 
+export interface ProposalRowWithFieldsAndValues {
+  readonly id: number;
+  readonly applicantId: number;
+  readonly opportunityId: number;
+  readonly externalId: string;
+  readonly createdAt: Date;
+  readonly proposalVersionId?: number | null;
+  readonly proposalVersionApplicationFormId?: number | null;
+  readonly proposalVersionVersion?: number | null;
+  readonly proposalVersionCreatedAt?: Date | null;
+  readonly proposalFieldValueId?: number | null;
+  readonly proposalFieldValueApplicationFormFieldId?: number | null;
+  readonly proposalFieldValueValue?: string | null;
+  readonly proposalFieldValuePosition?: number | null;
+  readonly proposalFieldValueCreatedAt?: Date | null;
+  readonly applicationFormFieldCanonicalFieldId?: number | null;
+  readonly applicationFormFieldPosition?: number | null;
+  readonly applicationFormFieldLabel?: string | null;
+  readonly applicationFormFieldCreatedAt?: Date | null;
+}
+
 // See https://github.com/typescript-eslint/typescript-eslint/issues/1824
 /* eslint-disable @typescript-eslint/indent */
 export type ProposalWrite = Omit<Proposal, 'createdAt' | 'id' | 'versions'>;
@@ -74,9 +95,105 @@ export const proposalWriteSchema: JSONSchemaType<ProposalWrite> = {
   ],
 };
 
+export const proposalRowWithFieldsAndValuesSchema:
+JSONSchemaType<ProposalRowWithFieldsAndValues> = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'integer',
+    },
+    applicantId: {
+      type: 'integer',
+    },
+    opportunityId: {
+      type: 'integer',
+    },
+    externalId: {
+      type: 'string',
+      pattern: '.+',
+    },
+    createdAt: {
+      type: 'object',
+      required: [],
+      instanceof: 'Date',
+    },
+    proposalVersionId: {
+      type: 'integer',
+      nullable: true,
+    },
+    proposalVersionApplicationFormId: {
+      type: 'integer',
+      nullable: true,
+    },
+    proposalVersionVersion: {
+      type: 'integer',
+      nullable: true,
+    },
+    proposalVersionCreatedAt: {
+      type: 'object',
+      required: [],
+      nullable: true,
+      instanceof: 'Date',
+    },
+    proposalFieldValueId: {
+      type: 'integer',
+      nullable: true,
+    },
+    proposalFieldValueApplicationFormFieldId: {
+      type: 'integer',
+      nullable: true,
+    },
+    proposalFieldValueValue: {
+      type: 'string',
+      nullable: true,
+    },
+    proposalFieldValuePosition: {
+      type: 'integer',
+      nullable: true,
+    },
+    proposalFieldValueCreatedAt: {
+      type: 'object',
+      required: [],
+      nullable: true,
+      instanceof: 'Date',
+    },
+    applicationFormFieldCanonicalFieldId: {
+      type: 'integer',
+      nullable: true,
+    },
+    applicationFormFieldPosition: {
+      type: 'integer',
+      nullable: true,
+    },
+    applicationFormFieldLabel: {
+      type: 'string',
+      nullable: true,
+    },
+    applicationFormFieldCreatedAt: {
+      type: 'object',
+      required: [],
+      nullable: true,
+      instanceof: 'Date',
+    },
+  },
+  required: [
+    'id',
+    'applicantId',
+    'opportunityId',
+    'externalId',
+    'createdAt',
+  ],
+};
+
 const proposalArraySchema: JSONSchemaType<Proposal[]> = {
   type: 'array',
   items: proposalSchema,
+};
+
+const proposalRowWithFieldsAndValuesArraySchema:
+JSONSchemaType<ProposalRowWithFieldsAndValues[]> = {
+  type: 'array',
+  items: proposalRowWithFieldsAndValuesSchema,
 };
 
 export const isProposal = ajv.compile(proposalSchema);
@@ -84,3 +201,11 @@ export const isProposal = ajv.compile(proposalSchema);
 export const isProposalWrite = ajv.compile(proposalWriteSchema);
 
 export const isProposalArray = ajv.compile(proposalArraySchema);
+
+export const isProposalRowWithFieldsAndValues = ajv.compile(
+  proposalRowWithFieldsAndValuesSchema,
+);
+
+export const isProposalRowWithFieldsAndValuesArray = ajv.compile(
+  proposalRowWithFieldsAndValuesArraySchema,
+);

--- a/src/types/ProposalFieldValue.ts
+++ b/src/types/ProposalFieldValue.ts
@@ -1,18 +1,21 @@
 import { ajv } from '../ajv';
+import { applicationFormFieldSchema } from './ApplicationFormField';
 import type { JSONSchemaType } from 'ajv';
+import type { ApplicationFormField } from './ApplicationFormField';
 
 export interface ProposalFieldValue {
-  id: number;
+  readonly id: number;
   proposalVersionId: number;
   applicationFormFieldId: number;
   position: number;
   value: string;
-  createdAt: Date;
+  readonly createdAt: Date;
+  readonly applicationFormField?: ApplicationFormField | null;
 }
 
 // See https://github.com/typescript-eslint/typescript-eslint/issues/1824
 /* eslint-disable @typescript-eslint/indent */
-export type ProposalFieldValueWrite = Omit<ProposalFieldValue, 'createdAt' | 'id' | 'proposalVersionId'>;
+export type ProposalFieldValueWrite = Omit<ProposalFieldValue, 'applicationFormField' | 'createdAt' | 'id' | 'proposalVersionId'>;
 /* eslint-enable @typescript-eslint/indent */
 
 export const proposalFieldValueSchema: JSONSchemaType<ProposalFieldValue> = {
@@ -37,6 +40,14 @@ export const proposalFieldValueSchema: JSONSchemaType<ProposalFieldValue> = {
       type: 'object',
       required: [],
       instanceof: 'Date',
+    },
+    applicationFormField: {
+      type: 'object',
+      /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+      properties: applicationFormFieldSchema.properties,
+      /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+      required: [],
+      nullable: true,
     },
   },
   required: [


### PR DESCRIPTION
Add optional param to GET /proposals/{proposalId}

When optional query parameter includeFieldsAndValues is set to true on GET /proposals/{proposalId}, include all proposal versions, associated values, and associated application form fields in the response.

By returning this almost-fully-deep object tree, it is more convenient for the caller and more efficient in terms of request, query, and response counts. The assumption is that the purpose of the PDC is to see and compare which fields are used for what purpose for proposals.

Issue #101 Implement GET /proposals/{proposalId} endpoint
