### PR TITLE
Add option to deep GET /proposals/{proposalId}

### DIFF
--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -151,7 +151,15 @@ describe('/proposals', () => {
       await agent
         .get('/proposals/9001')
         .set(dummyApiKey)
-        .expect(404, { message: 'Not found. Find existing proposals by calling with no parameters.' });
+        .expect(404, {
+          name: 'NotFoundError',
+          message: 'Not found. Find existing proposals by calling with no parameters.',
+          details: [
+            {
+              name: 'NotFoundError',
+            },
+          ],
+        });
     });
 
     it('returns the one proposal asked for', async () => {
@@ -195,6 +203,199 @@ describe('/proposals', () => {
             applicantId: 1,
             opportunityId: 1,
             createdAt: '2525-01-03T00:00:05.000Z',
+          },
+        );
+    });
+
+    it('returns one proposal with deep fields when includeFieldsAndValues=true', async () => {
+      // Needs canonical fields,
+      // opportunity,
+      // an applicant,
+      // application form,
+      // application form fields,
+      // proposal,
+      // proposal versions, and
+      // proposal field values.
+      await db.query(`
+        INSERT INTO canonical_fields (
+          label,
+          short_code,
+          data_type,
+          created_at
+        )
+        VALUES
+          ( 'Summary', 'summary', '{ type: "string" }', '2023-01-06T16:22:00+0000' ),
+          ( 'Title', 'title', '{ type: "string" }', '2023-01-06T16:24:00+0000' );
+      `);
+      await db.query(`
+        INSERT INTO opportunities (
+          title,
+          created_at
+        )
+        VALUES
+          ( '🌎', '2525-01-04T00:00:01Z' )
+      `);
+      await db.query(`
+        INSERT INTO applicants (
+          external_id,
+          opted_in,
+          created_at
+        )
+        VALUES
+          ( '🐯', 'true', '2525-01-04T00:00:02Z' ),
+          ( '🐅', 'false', '2525-01-04T00:00:03Z' );
+      `);
+      await db.query(`
+        INSERT INTO application_forms (
+          opportunity_id,
+          version,
+          created_at
+        )
+        VALUES
+          ( 1, 1, '2525-01-04T00:00:04Z' )
+      `);
+      await db.query(`
+        INSERT INTO application_form_fields (
+          application_form_id,
+          canonical_field_id,
+          position,
+          label,
+          created_at
+        )
+        VALUES
+          ( 1, 2, 1, 'Short summary or title', '2525-01-04T00:00:05Z' ),
+          ( 1, 1, 2, 'Long summary or abstract', '2525-01-04T00:00:06Z' );
+      `);
+      await db.query(`
+        INSERT INTO proposals (
+          applicant_id,
+          external_id,
+          opportunity_id,
+          created_at
+        )
+        VALUES
+          ( 2, 'proposal-2525-01-04T00Z', 1, '2525-01-04T00:00:07Z' );
+      `);
+      await db.query(`
+        INSERT INTO proposal_versions (
+          proposal_id,
+          application_form_id,
+          version,
+          created_at
+        )
+        VALUES
+          ( 1, 1, 1, '2525-01-04T00:00:08Z' ),
+          ( 1, 1, 2, '2525-01-04T00:00:09Z' );
+      `);
+      await db.query(`
+        INSERT INTO proposal_field_values (
+          proposal_version_id,
+          application_form_field_id,
+          position,
+          value,
+          created_at
+        )
+        VALUES
+          ( 1, 1, 1, 'Title for version 1 from 2525-01-04', '2525-01-04T00:00:10Z' ),
+          ( 1, 2, 2, 'Abstract for version 1 from 2525-01-04', '2525-01-04T00:00:11Z' ),
+          ( 2, 1, 1, 'Title for version 2 from 2525-01-04', '2525-01-04T00:00:12Z' ),
+          ( 2, 2, 2, 'Abstract for version 2 from 2525-01-04', '2525-01-04T00:00:13Z' );
+      `);
+      await agent
+        .get('/proposals/1/?includeFieldsAndValues=true')
+        .set(dummyApiKey)
+        .expect(
+          200,
+          {
+            id: 1,
+            applicantId: 2,
+            opportunityId: 1,
+            externalId: 'proposal-2525-01-04T00Z',
+            createdAt: '2525-01-04T00:00:07.000Z',
+            versions: [
+              {
+                id: 2,
+                proposalId: 1,
+                applicationFormId: 1,
+                version: 2,
+                createdAt: '2525-01-04T00:00:09.000Z',
+                fieldValues: [
+                  {
+                    id: 3,
+                    proposalVersionId: 2,
+                    applicationFormFieldId: 1,
+                    position: 1,
+                    value: 'Title for version 2 from 2525-01-04',
+                    createdAt: '2525-01-04T00:00:12.000Z',
+                    applicationFormField: {
+                      id: 1,
+                      applicationFormId: 1,
+                      canonicalFieldId: 2,
+                      position: 1,
+                      label: 'Short summary or title',
+                      createdAt: '2525-01-04T00:00:05.000Z',
+                    },
+                  },
+                  {
+                    id: 4,
+                    proposalVersionId: 2,
+                    applicationFormFieldId: 2,
+                    position: 2,
+                    value: 'Abstract for version 2 from 2525-01-04',
+                    createdAt: '2525-01-04T00:00:13.000Z',
+                    applicationFormField: {
+                      id: 2,
+                      applicationFormId: 1,
+                      canonicalFieldId: 1,
+                      position: 2,
+                      label: 'Long summary or abstract',
+                      createdAt: '2525-01-04T00:00:06.000Z',
+                    },
+                  },
+                ],
+              },
+              {
+                id: 1,
+                proposalId: 1,
+                applicationFormId: 1,
+                version: 1,
+                createdAt: '2525-01-04T00:00:08.000Z',
+                fieldValues: [
+                  {
+                    id: 1,
+                    proposalVersionId: 1,
+                    applicationFormFieldId: 1,
+                    position: 1,
+                    value: 'Title for version 1 from 2525-01-04',
+                    createdAt: '2525-01-04T00:00:10.000Z',
+                    applicationFormField: {
+                      id: 1,
+                      applicationFormId: 1,
+                      canonicalFieldId: 2,
+                      position: 1,
+                      label: 'Short summary or title',
+                      createdAt: '2525-01-04T00:00:05.000Z',
+                    },
+                  },
+                  {
+                    id: 2,
+                    proposalVersionId: 1,
+                    applicationFormFieldId: 2,
+                    position: 2,
+                    value: 'Abstract for version 1 from 2525-01-04',
+                    createdAt: '2525-01-04T00:00:11.000Z',
+                    applicationFormField: {
+                      id: 2,
+                      applicationFormId: 1,
+                      canonicalFieldId: 1,
+                      position: 2,
+                      label: 'Long summary or abstract',
+                      createdAt: '2525-01-04T00:00:06.000Z',
+                    },
+                  },
+                ],
+              },
+            ],
           },
         );
     });
@@ -252,6 +453,119 @@ describe('/proposals', () => {
           code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
         }],
       });
+    });
+  });
+
+  it('returns 404 when given id is not present and includeFieldsAndValues=true', async () => {
+    await agent
+      .get('/proposals/9002?includeFieldsAndValues=true')
+      .set(dummyApiKey)
+      .expect(404, {
+        name: 'NotFoundError',
+        message: 'Not found. Find existing proposals by calling with no parameters.',
+        details: [
+          {
+            name: 'NotFoundError',
+          },
+        ],
+      });
+  });
+
+  it('should error if the database returns an unexpected data structure when includeFieldsAndValues=true', async () => {
+    jest.spyOn(db, 'sql')
+      .mockImplementationOnce(async () => ({
+        rows: [{ foo: 'not a valid result' }],
+      }) as Result<object>);
+    const result = await agent
+      .get('/proposals/9003?includeFieldsAndValues=true')
+      .set(dummyApiKey)
+      .expect(500);
+    expect(result.body).toMatchObject({
+      name: 'InternalValidationError',
+      details: expect.any(Array) as unknown[],
+    });
+  });
+
+  it('returns 500 UnknownError if a generic Error is thrown when selecting and includeFieldsAndValues=true', async () => {
+    jest.spyOn(db, 'sql')
+      .mockImplementationOnce(async () => {
+        throw new Error('This is unexpected');
+      });
+    const result = await agent
+      .get('/proposals/9004?includeFieldsAndValues=true')
+      .set(dummyApiKey)
+      .expect(500);
+    expect(result.body).toMatchObject({
+      name: 'UnknownError',
+      details: expect.any(Array) as unknown[],
+    });
+  });
+
+  it('returns 503 DatabaseError if db error is thrown when includeFieldsAndValues=true', async () => {
+    await db.query(`
+      INSERT INTO opportunities (
+        title,
+        created_at
+      )
+      VALUES
+        ( '🧳', '2525-01-04T00:00:14Z' )
+    `);
+    await db.query(`
+      INSERT INTO applicants (
+        external_id,
+        opted_in,
+        created_at
+      )
+      VALUES
+        ( '🐴', 'true', '2525-01-04T00:00:15Z' );
+    `);
+    await db.query(`
+      INSERT INTO proposals (
+        applicant_id,
+        external_id,
+        opportunity_id,
+        created_at
+      )
+      VALUES
+        ( 1, 'proposal-🧳-🐴', 1, '2525-01-04T00:00:16Z' );
+    `);
+    jest.spyOn(db, 'sql')
+      .mockImplementationOnce(async () => {
+        throw new TinyPgError(
+          'Something went wrong',
+          undefined,
+          {
+            error: {
+              code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+            },
+          },
+        );
+      });
+    const result = await agent
+      .get('/proposals/1?includeFieldsAndValues=true')
+      .type('application/json')
+      .set(dummyApiKey)
+      .expect(503);
+    expect(result.body).toMatchObject({
+      name: 'DatabaseError',
+      details: [{
+        code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+      }],
+    });
+  });
+
+  it('returns 500 UnknownError if a generic Error is thrown when selecting and includeFieldsAndValues=true', async () => {
+    jest.spyOn(db, 'sql')
+      .mockImplementationOnce(async () => {
+        throw new Error('This is unexpected');
+      });
+    const result = await agent
+      .get('/proposals/9004?includeFieldsAndValues=true')
+      .set(dummyApiKey)
+      .expect(500);
+    expect(result.body).toMatchObject({
+      name: 'UnknownError',
+      details: expect.any(Array) as unknown[],
     });
   });
 

--- a/src/database/queries/applicationFormFields/selectByProposalId.sql
+++ b/src/database/queries/applicationFormFields/selectByProposalId.sql
@@ -1,0 +1,13 @@
+SELECT aff.id AS "id",
+  aff.application_form_id AS "applicationFormId",
+  aff.canonical_field_id AS "canonicalFieldId",
+  aff.position AS "position",
+  aff.label AS "label",
+  aff.created_at AS "createdAt"
+FROM application_form_fields aff
+INNER JOIN proposal_field_values pfv
+  ON pfv.application_form_field_id = aff.id
+INNER JOIN proposal_versions pv
+  ON pv.id = pfv.proposal_version_id
+WHERE pv.proposal_id = :proposalId
+ORDER BY pv.version DESC, pfv.position;

--- a/src/database/queries/proposalFieldValues/selectByProposalId.sql
+++ b/src/database/queries/proposalFieldValues/selectByProposalId.sql
@@ -1,0 +1,11 @@
+SELECT pfv.id AS "id",
+  pfv.proposal_version_id AS "proposalVersionId",
+  pfv.application_form_field_id AS "applicationFormFieldId",
+  pfv.value AS "value",
+  pfv.position AS "position",
+  pfv.created_at AS "createdAt"
+FROM proposal_field_values pfv
+INNER JOIN proposal_versions pv
+  ON pv.id = pfv.proposal_version_id
+WHERE pv.proposal_id = :proposalId
+ORDER BY pv.version DESC, pfv.position;

--- a/src/database/queries/proposalVersions/selectByProposalId.sql
+++ b/src/database/queries/proposalVersions/selectByProposalId.sql
@@ -1,0 +1,8 @@
+SELECT pv.id AS "id",
+  pv.proposal_id AS "proposalId",
+  pv.application_form_id AS "applicationFormId",
+  pv.version AS "version",
+  pv.created_at AS "createdAt"
+FROM proposal_versions pv
+WHERE pv.proposal_id = :proposalId
+ORDER BY pv.version DESC;

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,0 +1,8 @@
+export class NotFoundError extends Error {
+  public constructor(
+    message: string,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,3 +3,4 @@ export * from './DatabaseError';
 export * from './InputConflictError';
 export * from './InputValidationError';
 export * from './InternalValidationError';
+export * from './NotFoundError';

--- a/src/handlers/__tests__/proposals.unit.test.ts
+++ b/src/handlers/__tests__/proposals.unit.test.ts
@@ -1,0 +1,306 @@
+import {
+  joinApplicationFormFieldsToProposalFieldValues,
+  joinProposalFieldValuesToProposalVersion,
+} from '../proposalsHandlers';
+import type {
+  ApplicationFormField,
+  ProposalFieldValue,
+  ProposalVersion,
+} from '../../types';
+
+describe('mergeProposalFieldValues', () => {
+  it('should merge proposal values into proposal version', () => {
+    const proposalVersion: ProposalVersion = {
+      id: 3049,
+      proposalId: 3019,
+      applicationFormId: 3061,
+      version: 3067,
+      createdAt: new Date('2023-01-23T12:08:00-0600'),
+    };
+    const fieldValues: ProposalFieldValue[] = [
+      {
+        id: 3109,
+        proposalVersionId: 3049,
+        applicationFormFieldId: 3119,
+        position: 3121,
+        value: 'Three thousand one hundred thirty seven',
+        createdAt: new Date('2023-01-23T12:14:00-0600'),
+      },
+      {
+        id: 3163,
+        proposalVersionId: 3049,
+        applicationFormFieldId: 3167,
+        position: 3169,
+        value: 'Three thousand one hundred eighty one',
+        createdAt: new Date('2023-01-23T12:16:00-0600'),
+      },
+      {
+        id: 3187,
+        proposalVersionId: 3079,
+        applicationFormFieldId: 3191,
+        position: 3203,
+        value: 'Three thousand two hundred nine',
+        createdAt: new Date('2023-01-23T12:17:00-0600'),
+      },
+      {
+        id: 3217,
+        proposalVersionId: 3079,
+        applicationFormFieldId: 3251,
+        position: 3253,
+        value: 'Three thousand two hundred fifty seven',
+        createdAt: new Date('2023-01-23T12:18:00-0600'),
+      },
+    ];
+    const proposalVersionWithFieldValues = joinProposalFieldValuesToProposalVersion(
+      proposalVersion,
+      fieldValues,
+    );
+    const expectedProposalVersion = {
+      id: 3049,
+      proposalId: 3019,
+      applicationFormId: 3061,
+      version: 3067,
+      createdAt: new Date('2023-01-23T12:08:00-0600'),
+      fieldValues: [
+        {
+          id: 3109,
+          proposalVersionId: 3049,
+          applicationFormFieldId: 3119,
+          position: 3121,
+          value: 'Three thousand one hundred thirty seven',
+          createdAt: new Date('2023-01-23T12:14:00-0600'),
+        },
+        {
+          id: 3163,
+          proposalVersionId: 3049,
+          applicationFormFieldId: 3167,
+          position: 3169,
+          value: 'Three thousand one hundred eighty one',
+          createdAt: new Date('2023-01-23T12:16:00-0600'),
+        },
+      ],
+    };
+    expect(proposalVersionWithFieldValues).toEqual(expectedProposalVersion);
+  });
+
+  it('should return a proposal version like the one given when no field values are given', () => {
+    const proposalVersion: ProposalVersion = {
+      id: 3413,
+      proposalId: 3433,
+      applicationFormId: 3449,
+      version: 3457,
+      createdAt: new Date('2023-01-23T13:54:00-0600'),
+    };
+    expect(joinProposalFieldValuesToProposalVersion(proposalVersion, [])).toEqual({
+      id: 3413,
+      proposalId: 3433,
+      applicationFormId: 3449,
+      version: 3457,
+      createdAt: new Date('2023-01-23T13:54:00-0600'),
+    });
+  });
+});
+
+describe('mergeApplicationFormFields', () => {
+  it('should merge application form fields into proposal field values', () => {
+    const values: ProposalFieldValue[] = [
+      {
+        id: 3271,
+        proposalVersionId: 3299,
+        applicationFormFieldId: 3301,
+        position: 3307,
+        value: 'Three thousand three hundred thirteen',
+        createdAt: new Date('2023-01-23T13:39:00-0600'),
+      },
+      {
+        id: 3319,
+        proposalVersionId: 3323,
+        applicationFormFieldId: 3329,
+        position: 3331,
+        value: 'Three thousand three hundred forty three',
+        createdAt: new Date('2023-01-23T13:41:00-0600'),
+      },
+    ];
+    const fields: ApplicationFormField[] = [
+      {
+        id: 3301,
+        applicationFormId: 3347,
+        canonicalFieldId: 3359,
+        position: 3361,
+        label: 'Three thousand three hundred sixty one',
+        createdAt: new Date('2023-01-23T13:42:00-0600'),
+      },
+      {
+        id: 3329,
+        applicationFormId: 3371,
+        canonicalFieldId: 3389,
+        position: 3391,
+        label: 'Three thousand four hundred seven',
+        createdAt: new Date('2023-01-23T13:43:00-0600'),
+      },
+    ];
+    const valuesWithFields = joinApplicationFormFieldsToProposalFieldValues(values, fields);
+    expect(valuesWithFields).toEqual([
+      {
+        id: 3271,
+        proposalVersionId: 3299,
+        applicationFormFieldId: 3301,
+        position: 3307,
+        value: 'Three thousand three hundred thirteen',
+        createdAt: new Date('2023-01-23T13:39:00-0600'),
+        applicationFormField: {
+          id: 3301,
+          applicationFormId: 3347,
+          canonicalFieldId: 3359,
+          position: 3361,
+          label: 'Three thousand three hundred sixty one',
+          createdAt: new Date('2023-01-23T13:42:00-0600'),
+        },
+      },
+      {
+        id: 3319,
+        proposalVersionId: 3323,
+        applicationFormFieldId: 3329,
+        position: 3331,
+        value: 'Three thousand three hundred forty three',
+        createdAt: new Date('2023-01-23T13:41:00-0600'),
+        applicationFormField: {
+          id: 3329,
+          applicationFormId: 3371,
+          canonicalFieldId: 3389,
+          position: 3391,
+          label: 'Three thousand four hundred seven',
+          createdAt: new Date('2023-01-23T13:43:00-0600'),
+        },
+      },
+    ]);
+  });
+
+  it('should throw an Error when lengths of the two args differ', () => {
+    const values: ProposalFieldValue[] = [
+      {
+        id: 3631,
+        proposalVersionId: 3637,
+        applicationFormFieldId: 3643,
+        position: 3659,
+        value: 'Three thousand six hundred seventy one',
+        createdAt: new Date('2023-01-23T14:14:00-0600'),
+      },
+    ];
+    const fields: ApplicationFormField[] = [
+      {
+        id: 3643,
+        applicationFormId: 3673,
+        canonicalFieldId: 3677,
+        position: 3691,
+        label: 'Three thousand six hundred ninety seven',
+        createdAt: new Date('2023-01-23T14:15:00-0600'),
+      },
+      {
+        id: 3701,
+        applicationFormId: 3673,
+        canonicalFieldId: 3709,
+        position: 3719,
+        label: 'Three thousand seven hundred twenty seven',
+        createdAt: new Date('2023-01-23T14:16:00-0600'),
+      },
+    ];
+    expect(() => {
+      joinApplicationFormFieldsToProposalFieldValues(values, fields);
+    }).toThrow(Error);
+  });
+
+  it('should throw an Error when a field is missing at the same index as value', () => {
+    const values: ProposalFieldValue[] = [
+      {
+        id: 3733,
+        proposalVersionId: 3739,
+        applicationFormFieldId: 3761,
+        position: 3767,
+        value: 'Three thousand seven hundred sixty seven',
+        createdAt: new Date('2023-01-23T14:28:00-0600'),
+      },
+      {
+        id: 3769,
+        proposalVersionId: 3779,
+        applicationFormFieldId: 3793,
+        position: 3797,
+        value: 'Three thousand eight hundred three',
+        createdAt: new Date('2023-01-23T14:30:00-0600'),
+      },
+    ];
+    // Skip array index 2, go to 3, such that we have an array like [a, b, undefined, c]:
+    values[3] = {
+      id: 3821,
+      proposalVersionId: 3823,
+      applicationFormFieldId: 3833,
+      position: 3847,
+      value: 'Three thousand eight hundred fifty one',
+      createdAt: new Date('2023-01-23T14:32:00-0600'),
+    };
+
+    const fields: ApplicationFormField[] = [
+      {
+        // Matches the first value.
+        id: 3761,
+        applicationFormId: 3863,
+        canonicalFieldId: 3877,
+        position: 3881,
+        label: 'Three thousand eight hundred eighty nine',
+        createdAt: new Date('2023-01-23T14:33:00-0600'),
+      },
+    ];
+    // Skip array index 1, go to 2, such that we have an array like [a, undefined, b, c]:
+    fields[2] = {
+      // Matches the second value, but in the wrong position here.
+      id: 3793,
+      applicationFormId: 3907,
+      canonicalFieldId: 3911,
+      position: 3917,
+      label: 'Three thousand nine hundred nineteen',
+      createdAt: new Date('2023-01-23T14:36:00-0600'),
+    };
+    fields[3] = {
+      // Matches the third value, but in the wrong position here.
+      id: 3833,
+      applicationFormId: 3923,
+      canonicalFieldId: 3929,
+      position: 3931,
+      label: 'Three thousand nine forty three',
+      createdAt: new Date('2023-01-23T14:39:00-0600'),
+    };
+    // We now have values and fields of equal length, defined either by max index or by element
+    // count, but with mismatches in position within those arrays. This should throw an Error.
+    expect(() => {
+      joinApplicationFormFieldsToProposalFieldValues(values, fields);
+    }).toThrow(Error);
+  });
+
+  it('should throw an Error when the application form field IDs do not match', () => {
+    const values: ProposalFieldValue[] = [
+      {
+        id: 3947,
+        proposalVersionId: 3967,
+        /// This application form field id 3989 does not match the below 4007
+        applicationFormFieldId: 3989,
+        position: 4001,
+        value: 'Four thousand three',
+        createdAt: new Date('2023-01-24T08:49:00-0600'),
+      },
+    ];
+    const fields: ApplicationFormField[] = [
+      {
+        /// This application form field id 4007 does not match the above 3989
+        id: 4007,
+        applicationFormId: 4013,
+        canonicalFieldId: 4019,
+        position: 4021,
+        label: 'Four thousand twenty seven',
+        createdAt: new Date('2023-01-24T08:50:00-0600'),
+      },
+    ];
+    expect(() => {
+      joinApplicationFormFieldsToProposalFieldValues(values, fields);
+    }).toThrow(Error);
+  });
+});

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -4,13 +4,17 @@ import {
   InternalValidationError,
   InputValidationError,
   InputConflictError,
+  NotFoundError,
 } from '../errors';
 import { PostgresErrorCode } from '../types';
+import { getLogger } from '../logger';
 import type {
   NextFunction,
   Request,
   Response,
 } from 'express';
+
+const logger = getLogger(__filename);
 
 const getHttpStatusCodeForDatabaseErrorCode = (errorCode: string): number => {
   switch (errorCode) {
@@ -63,6 +67,9 @@ const getHttpStatusCodeForError = (error: unknown): number => {
   if (error instanceof AuthenticationError) {
     return 401;
   }
+  if (error instanceof NotFoundError) {
+    return 404;
+  }
   return 500;
 };
 
@@ -102,6 +109,8 @@ export const errorHandler = (
   res: Response,
   next: NextFunction, // eslint-disable-line @typescript-eslint/no-unused-vars
 ): void => {
+  logger.debug(err);
+  logger.trace(req.body);
   const statusCode = getHttpStatusCodeForError(err);
   res.status(statusCode)
     .contentType('application/json')

--- a/src/types/ProposalFieldValue.ts
+++ b/src/types/ProposalFieldValue.ts
@@ -1,5 +1,7 @@
 import { ajv } from '../ajv';
+import { applicationFormFieldSchema } from './ApplicationFormField';
 import type { JSONSchemaType } from 'ajv';
+import type { ApplicationFormField } from './ApplicationFormField';
 
 export interface ProposalFieldValue {
   id: number;
@@ -8,11 +10,12 @@ export interface ProposalFieldValue {
   position: number;
   value: string;
   createdAt: Date;
+  applicationFormField?: ApplicationFormField;
 }
 
 // See https://github.com/typescript-eslint/typescript-eslint/issues/1824
 /* eslint-disable @typescript-eslint/indent */
-export type ProposalFieldValueWrite = Omit<ProposalFieldValue, 'createdAt' | 'id' | 'proposalVersionId'>;
+export type ProposalFieldValueWrite = Omit<ProposalFieldValue, 'applicationFormField' | 'createdAt' | 'id' | 'proposalVersionId'>;
 /* eslint-enable @typescript-eslint/indent */
 
 export const proposalFieldValueSchema: JSONSchemaType<ProposalFieldValue> = {
@@ -37,6 +40,10 @@ export const proposalFieldValueSchema: JSONSchemaType<ProposalFieldValue> = {
       type: 'object',
       required: [],
       instanceof: 'Date',
+    },
+    applicationFormField: {
+      ...applicationFormFieldSchema,
+      nullable: true,
     },
   },
   required: [


### PR DESCRIPTION
When optional query parameter includeFieldsAndValues is set to true on GET /proposals/{proposalId}, include all proposal versions, associated values, and associated application form fields in the response.

By returning this almost-fully-deep object tree, it is more convenient for the caller and more efficient in terms of request, query, and response counts. The assumption is that the purpose of the PDC is to see and compare which fields are used for what purpose for proposals.

Issue #101 Implement GET /proposals/{proposalId} endpoint

(Alternative approach vs #198)