### PR TITLE
Fix and document GET /proposals/{id} endpoint

### DIFF
--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -454,118 +454,142 @@ describe('/proposals', () => {
         }],
       });
     });
-  });
 
-  it('returns 404 when given id is not present and includeFieldsAndValues=true', async () => {
-    await agent
-      .get('/proposals/9002?includeFieldsAndValues=true')
-      .set(dummyApiKey)
-      .expect(404, {
-        name: 'NotFoundError',
-        message: 'Not found. Find existing proposals by calling with no parameters.',
-        details: [
-          {
-            name: 'NotFoundError',
-          },
-        ],
-      });
-  });
-
-  it('should error if the database returns an unexpected data structure when includeFieldsAndValues=true', async () => {
-    jest.spyOn(db, 'sql')
-      .mockImplementationOnce(async () => ({
-        rows: [{ foo: 'not a valid result' }],
-      }) as Result<object>);
-    const result = await agent
-      .get('/proposals/9003?includeFieldsAndValues=true')
-      .set(dummyApiKey)
-      .expect(500);
-    expect(result.body).toMatchObject({
-      name: 'InternalValidationError',
-      details: expect.any(Array) as unknown[],
-    });
-  });
-
-  it('returns 500 UnknownError if a generic Error is thrown when selecting and includeFieldsAndValues=true', async () => {
-    jest.spyOn(db, 'sql')
-      .mockImplementationOnce(async () => {
-        throw new Error('This is unexpected');
-      });
-    const result = await agent
-      .get('/proposals/9004?includeFieldsAndValues=true')
-      .set(dummyApiKey)
-      .expect(500);
-    expect(result.body).toMatchObject({
-      name: 'UnknownError',
-      details: expect.any(Array) as unknown[],
-    });
-  });
-
-  it('returns 503 DatabaseError if db error is thrown when includeFieldsAndValues=true', async () => {
-    await db.query(`
-      INSERT INTO opportunities (
-        title,
-        created_at
-      )
-      VALUES
-        ( '🧳', '2525-01-04T00:00:14Z' )
-    `);
-    await db.query(`
-      INSERT INTO applicants (
-        external_id,
-        opted_in,
-        created_at
-      )
-      VALUES
-        ( '🐴', 'true', '2525-01-04T00:00:15Z' );
-    `);
-    await db.query(`
-      INSERT INTO proposals (
-        applicant_id,
-        external_id,
-        opportunity_id,
-        created_at
-      )
-      VALUES
-        ( 1, 'proposal-🧳-🐴', 1, '2525-01-04T00:00:16Z' );
-    `);
-    jest.spyOn(db, 'sql')
-      .mockImplementationOnce(async () => {
-        throw new TinyPgError(
-          'Something went wrong',
-          undefined,
-          {
-            error: {
-              code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+    it('returns 404 when given id is not present and includeFieldsAndValues=true', async () => {
+      await agent
+        .get('/proposals/9002?includeFieldsAndValues=true')
+        .set(dummyApiKey)
+        .expect(404, {
+          name: 'NotFoundError',
+          message: 'Not found. Find existing proposals by calling with no parameters.',
+          details: [
+            {
+              name: 'NotFoundError',
             },
-          },
-        );
-      });
-    const result = await agent
-      .get('/proposals/1?includeFieldsAndValues=true')
-      .type('application/json')
-      .set(dummyApiKey)
-      .expect(503);
-    expect(result.body).toMatchObject({
-      name: 'DatabaseError',
-      details: [{
-        code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
-      }],
+          ],
+        });
     });
-  });
 
-  it('returns 500 UnknownError if a generic Error is thrown when selecting and includeFieldsAndValues=true', async () => {
-    jest.spyOn(db, 'sql')
-      .mockImplementationOnce(async () => {
-        throw new Error('This is unexpected');
+    it('should error if the database returns an unexpected data structure when includeFieldsAndValues=true', async () => {
+      jest.spyOn(db, 'sql')
+        .mockImplementationOnce(async () => ({
+          rows: [{ foo: 'not a valid result' }],
+        }) as Result<object>);
+      const result = await agent
+        .get('/proposals/9003?includeFieldsAndValues=true')
+        .set(dummyApiKey)
+        .expect(500);
+      expect(result.body).toMatchObject({
+        name: 'InternalValidationError',
+        details: expect.any(Array) as unknown[],
       });
-    const result = await agent
-      .get('/proposals/9004?includeFieldsAndValues=true')
-      .set(dummyApiKey)
-      .expect(500);
-    expect(result.body).toMatchObject({
-      name: 'UnknownError',
-      details: expect.any(Array) as unknown[],
+    });
+
+    it('returns 500 UnknownError if a generic Error is thrown when selecting and includeFieldsAndValues=true', async () => {
+      jest.spyOn(db, 'sql')
+        .mockImplementationOnce(async () => {
+          throw new Error('This is unexpected');
+        });
+      const result = await agent
+        .get('/proposals/9004?includeFieldsAndValues=true')
+        .set(dummyApiKey)
+        .expect(500);
+      expect(result.body).toMatchObject({
+        name: 'UnknownError',
+        details: expect.any(Array) as unknown[],
+      });
+    });
+
+    it('returns 503 DatabaseError if db error is thrown when includeFieldsAndValues=true', async () => {
+      await db.query(`
+        INSERT INTO opportunities (
+          title,
+          created_at
+        )
+        VALUES
+          ( '🧳', '2525-01-04T00:00:14Z' )
+      `);
+      await db.query(`
+        INSERT INTO applicants (
+          external_id,
+          opted_in,
+          created_at
+        )
+        VALUES
+          ( '🐴', 'true', '2525-01-04T00:00:15Z' );
+      `);
+      await db.query(`
+        INSERT INTO proposals (
+          applicant_id,
+          external_id,
+          opportunity_id,
+          created_at
+        )
+        VALUES
+          ( 1, 'proposal-🧳-🐴', 1, '2525-01-04T00:00:16Z' );
+      `);
+      jest.spyOn(db, 'sql')
+        .mockImplementationOnce(async () => {
+          throw new TinyPgError(
+            'Something went wrong',
+            undefined,
+            {
+              error: {
+                code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+              },
+            },
+          );
+        });
+      const result = await agent
+        .get('/proposals/1?includeFieldsAndValues=true')
+        .type('application/json')
+        .set(dummyApiKey)
+        .expect(503);
+      expect(result.body).toMatchObject({
+        name: 'DatabaseError',
+        details: [{
+          code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+        }],
+      });
+    });
+
+    it('should return 503 when the db has insufficient resources on proposal field values select', async () => {
+      jest.spyOn(db, 'sql')
+        .mockImplementationOnce(async () => ({
+          command: '',
+          row_count: 1,
+          rows: [
+            {
+              id: 9005,
+              applicantId: 9006,
+              opportunityId: 9007,
+              externalId: 'nine thousand eight',
+              createdAt: new Date(),
+            },
+          ],
+        }))
+        .mockImplementationOnce(async () => {
+          throw new TinyPgError(
+            'Something went wrong',
+            undefined,
+            {
+              error: {
+                code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+              },
+            },
+          );
+        });
+      const result = await agent
+        .get('/proposals/9005')
+        .query({ includeFieldsAndValues: 'true' })
+        .set(dummyApiKey)
+        .expect(503);
+      expect(result.body).toMatchObject({
+        name: 'DatabaseError',
+        details: [{
+          code: PostgresErrorCode.INSUFFICIENT_RESOURCES,
+        }],
+      });
     });
   });
 

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -171,7 +171,14 @@ const getProposalWithFieldsAndValues = (
           .contentType('application/json')
           .send(proposal);
       }).catch((error: unknown) => {
-        throw error;
+        if (isTinyPgErrorWithQueryContext(error)) {
+          next(new DatabaseError(
+            'Error retrieving proposal.',
+            error,
+          ));
+          return;
+        }
+        next(error);
       });
     }).catch((error: unknown) => {
       if (isTinyPgErrorWithQueryContext(error)) {

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -567,7 +567,7 @@
           {
             "name": "includeFields",
             "in": "query",
-            "description": "Include the fields associated with the application form when 'true', otherwise not.",
+            "description": "Include the fields associated with the application form when `true`, otherwise do not include them.",
             "required": false,
             "schema": {
               "type": "boolean"
@@ -587,7 +587,7 @@
                 },
                 "examples": {
                   "default": {
-                    "summary": "The default, shallow response with no parameters or where includeFields=false",
+                    "summary": "The default, shallow response with no parameters or where `includeFields=false`.",
                     "value": {
                       "id": 3529,
                       "opportunityId": 3203,
@@ -596,7 +596,7 @@
                     }
                   },
                   "includeFields": {
-                    "summary": "The response when includeFields is set to true",
+                    "summary": "The response when `includeFields` is set to `true`.",
                     "value": {
                       "id": 3529,
                       "opportunityId": 3203,
@@ -732,6 +732,15 @@
             "schema": {
               "type": "integer"
             }
+          },
+          {
+            "name": "includeFieldsAndValues",
+            "in": "query",
+            "description": "Include the application form fields and the associated proposal values when `true`. This necessarily includes all proposal versions because form fields are related to a particular proposal version.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -742,12 +751,54 @@
                 "schema": {
                   "$ref": "#/components/schemas/Proposal"
                 },
-                "example": {
-                  "id": 3709,
-                  "applicantId": 3407,
-                  "externalId": "AnIdGeneratedByAGms",
-                  "opportunityId": 3203,
-                  "createdAt": "2022-12-30T15:50:58.839Z"
+                "examples": {
+                  "default": {
+                    "summary": "The default, shallow response with no parameters or where `includeFieldsAndValues=false`",
+                    "value": {
+                      "id": 3709,
+                      "applicantId": 3407,
+                      "externalId": "AnIdGeneratedByAGms",
+                      "opportunityId": 3203,
+                      "createdAt": "2022-12-30T15:50:58.839Z"
+                    }
+                  },
+                  "includeFieldsAndValues": {
+                    "summary": "The response when `includeFieldsAndValues` is set to `true`.",
+                    "value": {
+                      "id": 3709,
+                      "applicantId": 3407,
+                      "externalId": "AnIdGeneratedByAGms",
+                      "opportunityId": 3203,
+                      "createdAt": "2022-12-30T15:50:58.839Z",
+                      "versions": [
+                        {
+                          "id": 3821,
+                          "proposalId": 3709,
+                          "applicationFormId": 3529,
+                          "version": 17,
+                          "createdAt": "2023-02-14T09:52:00.000",
+                          "fieldValues": [
+                            {
+                              "id": 3943,
+                              "proposalVersionId": 3821,
+                              "applicationFormFieldId": 3613,
+                              "value": "John",
+                              "position": 23,
+                              "createdAt": "2023-02-14T09:57:00.000Z",
+                              "applicationFormField": {
+                                "id": 3613,
+                                "applicationFormId": 3529,
+                                "canonicalFieldId": 3011,
+                                "position": 19,
+                                "label": "Your First Name",
+                                "createdAt": "2023-02-14T09:58:00.000Z"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
Add more complete details to the OpenAPI documentation, specifically about the `includeFieldsAndValues` query parameter. Also fix a potential bug where a promise could be left hanging.

Issue #101 Implement GET /proposals/{proposalId} endpoint