### PR TITLE
Use typescript-eslint recommended rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,9 @@
     "sort-exports"
   ],
   "extends": [
-    "plugin:@typescript-eslint/all",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:@typescript-eslint/strict",
     "airbnb-base",
     "airbnb-typescript/base"
   ],


### PR DESCRIPTION
The typescript-eslint project has [three sets of recommended rules](https://typescript-eslint.io/linting/configs#recommended-configurations). The [`all` configuration](https://typescript-eslint.io/linting/configs#all) is actually called out by the project as a bad idea!

> We do not recommend a TypeScript projects extend from `plugin:@typescript-eslint/all`. Many rules conflict with each other and/or are intended to be configured per-project.

I think some of those potential conflicts are smoothed out by our later `extends`, but let's start from a better base!

Happily, we are already following all of these rules, so we do not need to make any code changes to adopt these rule sets.