### PR TITLE
Configure CORS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "ajv": "^8.12.0",
         "ajv-keywords": "^5.1.0",
+        "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "pino": "^8.11.0",
@@ -21,6 +22,7 @@
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.3",
+        "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/jest": "^28.1.2",
         "@types/node": "^18.11.17",
@@ -1371,6 +1373,15 @@
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
@@ -2506,6 +2517,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -5485,6 +5508,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -8656,6 +8687,15 @@
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
     },
+    "@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/express": {
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
@@ -9487,6 +9527,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-require": {
       "version": "1.1.1",
@@ -11732,6 +11781,11 @@
       "requires": {
         "path-key": "^3.0.0"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
       "version": "1.12.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/PhilanthropyDataCommons/pdc#readme",
   "devDependencies": {
     "@tsconfig/node16": "^1.0.3",
+    "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jest": "^28.1.2",
     "@types/node": "^18.11.17",
@@ -63,6 +64,7 @@
   "dependencies": {
     "ajv": "^8.12.0",
     "ajv-keywords": "^5.1.0",
+    "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "pino": "^8.11.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,13 @@
 import express from 'express';
 import pinoHttp from 'pino-http';
+import cors from 'cors';
 import { rootRouter } from './routers';
 import { errorHandler } from './middleware';
 import { getLogger } from './logger';
 
 const logger = getLogger(__filename);
 const app = express();
+app.use(cors());
 app.use(pinoHttp({
   logger,
 }));


### PR DESCRIPTION
We expect clients, including the [data-viewer](https://github.com/PhilanthropyDataCommons/data-viewer), to make requests from a different domain than the API itself. For security, browsers will not allow [cross-origin requests](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) that include credentials - as are required by every endpoint of this API - without permission from the target server, in order to protect against malicious third-party websites from exploiting a logged-in user's session.

Install and use the [CORS middleware](https://expressjs.com/en/resources/middleware/cors.html) with the default options, which allows requests from any origin. This is not the ideal security policy from a defense-in-depth standpoint, but is useful during development. The current lack of destructive endpoints is one mitigation, and the lack of cookie authentication is another: by default, browser requests do not include the authentication headers we [are planning to] use, so an attacker would need to directly compromise the credentials from the user's browser, not just fire off a request.

I advocate for this initial laxity for the sake of speed; it of course does not preclude a later move to limit CORS requests to a known good list of domains. I suspect that configuration will be somewhat complex, though - either a hardcoded list in the code (which I don't like), some complicated environment variable parsing (which can make deployment more difficult, with string quoting and related issues), or runtime configuration via the database (which is ideal, but effortful).

Issue #96 Authentication
Issue PhilanthropyDataCommons/data-viewer#6 Proof of concept authentication via Keycloak