### PR TITLE
Correct the `build` commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ docker pull ghcr.io/philanthropydatacommons/service:latest
 To run migrations:
 
 ```bash
-npm build
+npm run build
 npm run migrate
 ```
 
 To start the server:
 
 ```bash
-npm build
+npm run build
 npm start
 ```
 


### PR DESCRIPTION
This is a small but needed change. It should cause automated workflows to run again.

Issue #278 Workflow failed