### PR TITLE
Configure dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,7 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 2
 
-
-
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR gets dependabot to keep our actions up to date (in theory!)