### PR TITLE
Use a different workflow dispatch during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,11 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
       - name: Notify the top-level 'deploy' project that an image was pushed
-        uses: aurelien-baudet/workflow-dispatch@v2.1.1
+        uses: pauldraper/workflow-dispatch@v1.5
         with:
           workflow: update-service-image.yml
           ref: main
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repo: PhilanthropyDataCommons/deploy
           inputs: "{\"image-tag\":\"${{ env.VERSION }}\"}"
-          wait-for-completion: true
-          wait-for-completion-timeout: 5m
+          wait: true


### PR DESCRIPTION
This attempts to resolve the issue of deprecated workflow code. The workflow https://github.com/marketplace/actions/workflow-dispatch-plus appears mostly compatible with the previously used workflow.

Issue #306 Update the build's workflow dispatch task