### PR TITLE
Validate base field `dataType` values as JSON

### DIFF
--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -95,8 +95,8 @@ describe('/applicationForms', () => {
         created_at
       )
       VALUES
-        ( 'Organization Name', 'organizationName', '{ type: "string" }', '2510-02-02 00:00:04+0000' ),
-        ( 'Years of work', 'yearsOfWork', '{ type: "integer" }', '2510-02-02 00:00:05+0000' );
+        ( 'Organization Name', 'organizationName', '{ "type": "string" }', '2510-02-02 00:00:04+0000' ),
+        ( 'Years of work', 'yearsOfWork', '{ "type": "integer" }', '2510-02-02 00:00:05+0000' );
       `);
       await agent
         .get('/applicationForms/2')
@@ -138,8 +138,8 @@ describe('/applicationForms', () => {
         created_at
       )
       VALUES
-        ( 'Organization Name', 'organizationName', '{ type: "string" }', '2510-02-01 00:00:04+0000' ),
-        ( 'Years of work', 'yearsOfWork', '{ type: "integer" }', '2510-02-01 00:00:05+0000' );
+        ( 'Organization Name', 'organizationName', '{ "type": "string" }', '2510-02-01 00:00:04+0000' ),
+        ( 'Years of work', 'yearsOfWork', '{ "type": "integer" }', '2510-02-01 00:00:05+0000' );
       `);
       await db.query(`
         INSERT INTO application_form_fields (
@@ -439,7 +439,7 @@ describe('/applicationForms', () => {
           data_type
         )
         VALUES
-          ( 'First Name', 'firstName', 'string' );
+          ( 'First Name', 'firstName', '{ "type": "string" }' );
       `);
       const before = await loadTableMetrics('application_form_fields');
       const result = await agent
@@ -642,7 +642,7 @@ describe('/applicationForms', () => {
           data_type
         )
         VALUES
-          ( 'First Name', 'firstName', 'string' );
+          ( 'First Name', 'firstName', '{ "type": "string" }' );
       `);
       jest.spyOn(db, 'sql')
         .mockImplementationOnce(async () => ({
@@ -695,7 +695,7 @@ describe('/applicationForms', () => {
           data_type
         )
         VALUES
-          ( 'First Name', 'firstName', 'string' );
+          ( 'First Name', 'firstName', '{ "type": "string" }' );
       `);
       jest.spyOn(db, 'sql')
         .mockImplementationOnce(async () => ({

--- a/src/__tests__/canonicalFields.int.test.ts
+++ b/src/__tests__/canonicalFields.int.test.ts
@@ -32,8 +32,8 @@ describe('/canonicalFields', () => {
           created_at
         )
         VALUES
-          ( 'First Name', 'firstName', 'string', '2022-07-20 12:00:00+0000' ),
-          ( 'Last Name', 'lastName', 'string', '2022-07-20 12:00:00+0000' );
+          ( 'First Name', 'firstName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' ),
+          ( 'Last Name', 'lastName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' );
       `);
       await agent
         .get('/canonicalFields')
@@ -43,14 +43,14 @@ describe('/canonicalFields', () => {
           [
             {
               createdAt: '2022-07-20T12:00:00.000Z',
-              dataType: 'string',
+              dataType: { type: 'string' },
               id: 1,
               label: 'First Name',
               shortCode: 'firstName',
             },
             {
               createdAt: '2022-07-20T12:00:00.000Z',
-              dataType: 'string',
+              dataType: { type: 'string' },
               id: 2,
               label: 'Last Name',
               shortCode: 'lastName',
@@ -126,7 +126,7 @@ describe('/canonicalFields', () => {
         .send({
           label: '🏷️',
           shortCode: '🩳',
-          dataType: '📊',
+          dataType: { type: 'string' },
         })
         .expect(201);
       const after = await loadTableMetrics('canonical_fields');
@@ -136,7 +136,7 @@ describe('/canonicalFields', () => {
         id: expect.any(Number) as number,
         label: '🏷️',
         shortCode: '🩳',
-        dataType: '📊',
+        dataType: { type: 'string' },
         createdAt: expect.stringMatching(isoTimestampPattern) as string,
       });
       expect(after.count).toEqual(1);
@@ -148,7 +148,7 @@ describe('/canonicalFields', () => {
         .set(authHeader)
         .send({
           shortCode: '🩳',
-          dataType: '📊',
+          dataType: { type: 'string' },
         })
         .expect(400);
       expect(result.body).toMatchObject({
@@ -163,7 +163,7 @@ describe('/canonicalFields', () => {
         .set(authHeader)
         .send({
           label: '🏷️',
-          dataType: '📊',
+          dataType: { type: 'string' },
         })
         .expect(400);
       expect(result.body).toMatchObject({
@@ -186,6 +186,22 @@ describe('/canonicalFields', () => {
         details: expect.any(Array) as unknown[],
       });
     });
+    it('returns 400 bad request when non-JSON dataType is sent', async () => {
+      const result = await agent
+        .post('/canonicalFields')
+        .type('application/json')
+        .set(authHeader)
+        .send({
+          label: '🏷️',
+          shortCode: '🩳',
+          dataType: '{ this: "is", not: \'json\' }',
+        })
+        .expect(400);
+      expect(result.body).toMatchObject({
+        name: 'InputValidationError',
+        details: expect.any(Array) as unknown[],
+      });
+    });
     it('returns 409 conflict when a duplicate short name is submitted', async () => {
       await db.query(`
         INSERT INTO canonical_fields (
@@ -195,7 +211,7 @@ describe('/canonicalFields', () => {
           created_at
         )
         VALUES
-          ( 'First Name', 'firstName', 'string', '2022-07-20 12:00:00+0000' );
+          ( 'First Name', 'firstName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' );
       `);
       const result = await agent
         .post('/canonicalFields')
@@ -204,7 +220,7 @@ describe('/canonicalFields', () => {
         .send({
           label: '🏷️',
           shortCode: 'firstName',
-          dataType: '📊',
+          dataType: { type: 'string' },
         })
         .expect(409);
       expect(result.body).toMatchObject({
@@ -227,7 +243,7 @@ describe('/canonicalFields', () => {
         .send({
           label: '🏷️',
           shortCode: 'firstName',
-          dataType: '📊',
+          dataType: { type: 'string' },
         })
         .expect(500);
       expect(result.body).toMatchObject({
@@ -248,7 +264,7 @@ describe('/canonicalFields', () => {
         .send({
           label: '🏷️',
           shortCode: '🩳',
-          dataType: '📊',
+          dataType: { type: 'string' },
         })
         .expect(500);
       expect(result.body).toMatchObject({

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -121,8 +121,8 @@ describe('/proposalVersions', () => {
           created_at
         )
         VALUES
-          ( 'First Name', 'firstName', 'string', '2022-07-20 12:00:00+0000' ),
-          ( 'Last Name', 'lastName', 'string', '2022-07-20 12:00:00+0000' );
+          ( 'First Name', 'firstName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' ),
+          ( 'Last Name', 'lastName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' );
       `);
       await db.query(`
         INSERT INTO application_form_fields (
@@ -520,8 +520,8 @@ describe('/proposalVersions', () => {
           created_at
         )
         VALUES
-          ( 'First Name', 'firstName', 'string', '2022-07-20 12:00:00+0000' ),
-          ( 'Last Name', 'lastName', 'string', '2022-07-20 12:00:00+0000' );
+          ( 'First Name', 'firstName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' ),
+          ( 'Last Name', 'lastName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' );
       `);
       await db.query(`
         INSERT INTO application_form_fields (
@@ -800,8 +800,8 @@ describe('/proposalVersions', () => {
           created_at
         )
         VALUES
-          ( 'First Name', 'firstName', 'string', '2022-07-20 12:00:00+0000' ),
-          ( 'Last Name', 'lastName', 'string', '2022-07-20 12:00:00+0000' );
+          ( 'First Name', 'firstName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' ),
+          ( 'Last Name', 'lastName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' );
       `);
       await db.query(`
         INSERT INTO application_form_fields (
@@ -894,8 +894,8 @@ describe('/proposalVersions', () => {
           created_at
         )
         VALUES
-          ( 'First Name', 'firstName', 'string', '2022-07-20 12:00:00+0000' ),
-          ( 'Last Name', 'lastName', 'string', '2022-07-20 12:00:00+0000' );
+          ( 'First Name', 'firstName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' ),
+          ( 'Last Name', 'lastName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' );
       `);
       await db.query(`
         INSERT INTO application_form_fields (
@@ -1059,8 +1059,8 @@ describe('/proposalVersions', () => {
           created_at
         )
         VALUES
-          ( 'First Name', 'firstName', 'string', '2022-07-20 12:00:00+0000' ),
-          ( 'Last Name', 'lastName', 'string', '2022-07-20 12:00:00+0000' );
+          ( 'First Name', 'firstName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' ),
+          ( 'Last Name', 'lastName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' );
       `);
       await db.query(`
         INSERT INTO application_form_fields (
@@ -1229,8 +1229,8 @@ describe('/proposalVersions', () => {
           created_at
         )
         VALUES
-          ( 'First Name', 'firstName', 'string', '2022-07-20 12:00:00+0000' ),
-          ( 'Last Name', 'lastName', 'string', '2022-07-20 12:00:00+0000' );
+          ( 'First Name', 'firstName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' ),
+          ( 'Last Name', 'lastName', '{ "type": "string" }', '2022-07-20 12:00:00+0000' );
       `);
       await db.query(`
         INSERT INTO application_form_fields (

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -278,8 +278,8 @@ describe('/proposals', () => {
           created_at
         )
         VALUES
-          ( 'Summary', 'summary', '{ type: "string" }', '2023-01-06T16:22:00+0000' ),
-          ( 'Title', 'title', '{ type: "string" }', '2023-01-06T16:24:00+0000' );
+          ( 'Summary', 'summary', '{ "type": "string" }', '2023-01-06T16:22:00+0000' ),
+          ( 'Title', 'title', '{ "type": "string" }', '2023-01-06T16:24:00+0000' );
       `);
       await db.query(`
         INSERT INTO opportunities (

--- a/src/database/migrations/0010-alter-canonical_fields-data_type.sql
+++ b/src/database/migrations/0010-alter-canonical_fields-data_type.sql
@@ -1,0 +1,3 @@
+ALTER TABLE canonical_fields
+  ALTER COLUMN data_type TYPE jsonb
+  USING to_jsonb(data_type);

--- a/src/handlers/canonicalFieldsHandlers.ts
+++ b/src/handlers/canonicalFieldsHandlers.ts
@@ -11,6 +11,7 @@ import {
   InputValidationError,
   InternalValidationError,
 } from '../errors';
+import { jsonSchemaObject } from '../types/JsonSchemaObject';
 import type { JSONSchemaType } from 'ajv';
 import type {
   Request,
@@ -63,9 +64,7 @@ const postCanonicalFieldBodySchema: JSONSchemaType<Omit<CanonicalField, 'created
     shortCode: {
       type: 'string',
     },
-    dataType: {
-      type: 'string',
-    },
+    dataType: jsonSchemaObject,
   },
   required: [
     'label',

--- a/src/types/CanonicalField.ts
+++ b/src/types/CanonicalField.ts
@@ -1,11 +1,13 @@
 import { ajv } from '../ajv';
+import { jsonSchemaObject } from './JsonSchemaObject';
+import type { JsonSchemaObject } from './JsonSchemaObject';
 import type { JSONSchemaType } from 'ajv';
 
 export interface CanonicalField {
   id: number;
   label: string;
   shortCode: string;
-  dataType: string;
+  dataType: JsonSchemaObject;
   createdAt: Date;
 }
 
@@ -21,9 +23,7 @@ export const canonicalFieldSchema: JSONSchemaType<CanonicalField> = {
     shortCode: {
       type: 'string',
     },
-    dataType: {
-      type: 'string',
-    },
+    dataType: jsonSchemaObject,
     createdAt: {
       type: 'object',
       required: [],

--- a/src/types/JsonSchemaObject.ts
+++ b/src/types/JsonSchemaObject.ts
@@ -1,0 +1,27 @@
+import { ajv } from '../ajv';
+import type { JSONSchemaType } from 'ajv';
+
+// The goal is to test an object is a valid JSON Schema (not against a schema, IS a schema).
+// This is a temporary interface. There is likely a better JSON Schema interface from ajv.
+export interface JsonSchemaObject {
+  type: string;
+  format?: string;
+}
+
+export const jsonSchemaObject: JSONSchemaType<JsonSchemaObject> = {
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string',
+    },
+    format: {
+      type: 'string',
+      nullable: true,
+    },
+  },
+  required: [
+    'type',
+  ],
+};
+
+export const isJsonSchemaObject = ajv.compile(jsonSchemaObject);


### PR DESCRIPTION
The goal is to use the values of `dataType` for a given base field to validate values of `value` for given proposal field values. The change in this commit is a stepping stone along the way to that goal by first validating the value of `dataType`. We would like `dataType` to be a valid JSON Schema validation value. An example validation value is `{ "type": "string", "format: "date" }`. See other valid values at https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times

In order to validate the `dataType` values, we can first exploit the `jsonb` postgresql type. The database itself will therefore validate that the value for `dataType` is JSON. All JSON Schema values are JSON but not all JSON values are JSON Schemas. At the application level, we use Ajv to validate that the `dataType` is not only valid JSON but also a valid JSON Schema.

Issue #308 Validate proposal field values using base field JSON Schema type