### PR TITLE
Return deep proposals for GET `/proposals`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,7 +39,10 @@
     {
       "files": [ "**/index.ts" ],
       "rules": {
-        "sort-exports/sort-exports": ["error", { "sortDir": "asc" }]
+        "sort-exports/sort-exports": ["error", {
+          "sortDir": "asc",
+          "ignoreCase": true
+        }]
       }
     }
   ],

--- a/src/__tests__/applicants.int.test.ts
+++ b/src/__tests__/applicants.int.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../database';
 import { getLogger } from '../logger';
 import { PostgresErrorCode } from '../types';
-import { isoTimestampPattern } from '../test/utils';
+import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import type { Result } from 'tinypg';
 
@@ -141,7 +141,7 @@ describe('/applicants', () => {
         id: expect.any(Number) as number,
         externalId: '🆔',
         optedIn: false,
-        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+        createdAt: expectTimestamp,
       });
       expect(after.count).toEqual(1);
     });

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../database';
 import { getLogger } from '../logger';
 import { PostgresErrorCode } from '../types';
-import { isoTimestampPattern } from '../test/utils';
+import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import type { Result } from 'tinypg';
 
@@ -422,7 +422,7 @@ describe('/applicationForms', () => {
         id: 1,
         opportunityId: 1,
         version: 1,
-        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+        createdAt: expectTimestamp,
       });
       expect(after.count).toEqual(1);
     });
@@ -465,12 +465,12 @@ describe('/applicationForms', () => {
         fields: [{
           applicationFormId: 1,
           canonicalFieldId: 1,
-          createdAt: expect.stringMatching(isoTimestampPattern) as string,
+          createdAt: expectTimestamp,
           id: 1,
           label: 'Your First Name',
           position: 1,
         }],
-        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+        createdAt: expectTimestamp,
       });
       expect(after.count).toEqual(1);
     });
@@ -507,7 +507,7 @@ describe('/applicationForms', () => {
         id: 3,
         opportunityId: 1,
         version: 3,
-        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+        createdAt: expectTimestamp,
       });
     });
 

--- a/src/__tests__/canonicalFields.int.test.ts
+++ b/src/__tests__/canonicalFields.int.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../database';
 import { getLogger } from '../logger';
 import { PostgresErrorCode } from '../types';
-import { isoTimestampPattern } from '../test/utils';
+import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import type { Result } from 'tinypg';
 
@@ -137,7 +137,7 @@ describe('/canonicalFields', () => {
         label: '🏷️',
         shortCode: '🩳',
         dataType: '📊',
-        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+        createdAt: expectTimestamp,
       });
       expect(after.count).toEqual(1);
     });

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -6,7 +6,7 @@ import {
   loadTableMetrics,
 } from '../database';
 import { getLogger } from '../logger';
-import { isoTimestampPattern } from '../test/utils';
+import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import { PostgresErrorCode } from '../types/PostgresErrorCode';
 import type { Result } from 'tinypg';
@@ -251,7 +251,7 @@ describe('/opportunities', () => {
       expect(result.body).toMatchObject({
         id: 1,
         title: '🎆',
-        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+        createdAt: expectTimestamp,
       });
       expect(after.count).toEqual(1);
     });

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -6,7 +6,7 @@ import {
   loadTableMetrics,
 } from '../database';
 import { getLogger } from '../logger';
-import { isoTimestampPattern } from '../test/utils';
+import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import { PostgresErrorCode } from '../types/PostgresErrorCode';
 import type { Result } from 'tinypg';
@@ -171,14 +171,14 @@ describe('/proposalVersions', () => {
             applicationFormFieldId: 1,
             position: 1,
             value: 'Gronald',
-            createdAt: expect.stringMatching(isoTimestampPattern) as string,
+            createdAt: expectTimestamp,
           },
           {
             id: 2,
             applicationFormFieldId: 2,
             position: 1,
             value: 'Plorp',
-            createdAt: expect.stringMatching(isoTimestampPattern) as string,
+            createdAt: expectTimestamp,
           },
         ],
       });

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -35,6 +35,11 @@ describe('/proposals', () => {
         externalId: '12345',
         optedIn: true,
       });
+      await db.sql('canonicalFields.insertOne', {
+        label: 'Summary',
+        shortCode: 'summary',
+        dataType: 'string',
+      });
       await db.sql('proposals.insertOne', {
         applicantId: 1,
         externalId: 'proposal-1',
@@ -45,6 +50,26 @@ describe('/proposals', () => {
         externalId: 'proposal-2',
         opportunityId: 1,
       });
+      await db.sql('applicationForms.insertOne', {
+        opportunityId: 1,
+      });
+      await db.sql('proposalVersions.insertOne', {
+        proposalId: 1,
+        applicationFormId: 1,
+      });
+      await db.sql('applicationFormFields.insertOne', {
+        applicationFormId: 1,
+        canonicalFieldId: 1,
+        position: 1,
+        label: 'Short summary',
+      });
+      await db.sql('proposalFieldValues.insertOne', {
+        proposalVersionId: 1,
+        applicationFormFieldId: 1,
+        position: 1,
+        value: 'This is a summary',
+      });
+
       await agent
         .get('/proposals')
         .set(authHeader)
@@ -60,6 +85,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  versions: [],
                 },
                 {
                   id: 1,
@@ -67,6 +93,29 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  versions: [{
+                    id: 1,
+                    proposalId: 1,
+                    version: 1,
+                    applicationFormId: 1,
+                    createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                    fieldValues: [{
+                      id: 1,
+                      applicationFormFieldId: 1,
+                      proposalVersionId: 1,
+                      position: 1,
+                      value: 'This is a summary',
+                      createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                      applicationFormField: {
+                        id: 1,
+                        applicationFormId: 1,
+                        canonicalFieldId: 1,
+                        label: 'Short summary',
+                        position: 1,
+                        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                      },
+                    }],
+                  }],
                 },
               ],
             },
@@ -108,6 +157,7 @@ describe('/proposals', () => {
                   externalId: 'proposal-15',
                   applicantId: 1,
                   opportunityId: 1,
+                  versions: [],
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
                 },
                 {
@@ -115,6 +165,7 @@ describe('/proposals', () => {
                   externalId: 'proposal-14',
                   applicantId: 1,
                   opportunityId: 1,
+                  versions: [],
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
                 },
                 {
@@ -122,6 +173,7 @@ describe('/proposals', () => {
                   externalId: 'proposal-13',
                   applicantId: 1,
                   opportunityId: 1,
+                  versions: [],
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
                 },
                 {
@@ -129,6 +181,7 @@ describe('/proposals', () => {
                   externalId: 'proposal-12',
                   applicantId: 1,
                   opportunityId: 1,
+                  versions: [],
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
                 },
                 {
@@ -136,6 +189,7 @@ describe('/proposals', () => {
                   externalId: 'proposal-11',
                   applicantId: 1,
                   opportunityId: 1,
+                  versions: [],
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
                 },
               ],

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -6,7 +6,7 @@ import {
   loadTableMetrics,
 } from '../database';
 import { getLogger } from '../logger';
-import { isoTimestampPattern } from '../test/utils';
+import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import { PostgresErrorCode } from '../types/PostgresErrorCode';
 import type { Result } from 'tinypg';
@@ -84,7 +84,7 @@ describe('/proposals', () => {
                   externalId: 'proposal-2',
                   applicantId: 1,
                   opportunityId: 1,
-                  createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  createdAt: expectTimestamp,
                   versions: [],
                 },
                 {
@@ -92,27 +92,27 @@ describe('/proposals', () => {
                   externalId: 'proposal-1',
                   applicantId: 1,
                   opportunityId: 1,
-                  createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  createdAt: expectTimestamp,
                   versions: [{
                     id: 1,
                     proposalId: 1,
                     version: 1,
                     applicationFormId: 1,
-                    createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                    createdAt: expectTimestamp,
                     fieldValues: [{
                       id: 1,
                       applicationFormFieldId: 1,
                       proposalVersionId: 1,
                       position: 1,
                       value: 'This is a summary',
-                      createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                      createdAt: expectTimestamp,
                       applicationFormField: {
                         id: 1,
                         applicationFormId: 1,
                         canonicalFieldId: 1,
                         label: 'Short summary',
                         position: 1,
-                        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                        createdAt: expectTimestamp,
                       },
                     }],
                   }],
@@ -158,7 +158,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   versions: [],
-                  createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  createdAt: expectTimestamp,
                 },
                 {
                   id: 14,
@@ -166,7 +166,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   versions: [],
-                  createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  createdAt: expectTimestamp,
                 },
                 {
                   id: 13,
@@ -174,7 +174,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   versions: [],
-                  createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  createdAt: expectTimestamp,
                 },
                 {
                   id: 12,
@@ -182,7 +182,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   versions: [],
-                  createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  createdAt: expectTimestamp,
                 },
                 {
                   id: 11,
@@ -190,7 +190,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   versions: [],
-                  createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  createdAt: expectTimestamp,
                 },
               ],
             },
@@ -741,7 +741,7 @@ describe('/proposals', () => {
         applicantId: 1,
         externalId: 'proposal123',
         opportunityId: 1,
-        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+        createdAt: expectTimestamp,
       });
       expect(after.count).toEqual(1);
     });

--- a/src/database/enrichers/enrichProposalFieldValues.ts
+++ b/src/database/enrichers/enrichProposalFieldValues.ts
@@ -1,0 +1,24 @@
+import { loadObjects } from '../accessors/loadObjects';
+import { isApplicationFormField } from '../../types';
+import type { ProposalFieldValue } from '../../types';
+
+export const enrichProposalFieldValues = async (
+  proposalFieldValues: ProposalFieldValue[],
+): Promise<ProposalFieldValue[]> => {
+  const applicationFormFields = await loadObjects(
+    'applicationFormFields.selectByIds',
+    {
+      ids: proposalFieldValues.map(
+        (proposalFieldValue) => proposalFieldValue.applicationFormFieldId,
+      ),
+    },
+    isApplicationFormField,
+  );
+
+  return proposalFieldValues.map((proposalFieldValue) => ({
+    ...proposalFieldValue,
+    applicationFormField: applicationFormFields.find(
+      ({ id }) => id === proposalFieldValue.applicationFormFieldId,
+    ),
+  }));
+};

--- a/src/database/enrichers/enrichProposalVersions.ts
+++ b/src/database/enrichers/enrichProposalVersions.ts
@@ -1,0 +1,25 @@
+import { loadObjects } from '../accessors/loadObjects';
+import { isProposalFieldValue } from '../../types';
+import { enrichProposalFieldValues } from './enrichProposalFieldValues';
+import type { ProposalVersion } from '../../types';
+
+export const enrichProposalVersions = async (
+  proposalVersions: ProposalVersion[],
+): Promise<ProposalVersion[]> => {
+  const proposalFieldValues = await enrichProposalFieldValues(
+    await loadObjects(
+      'proposalFieldValues.selectByProposalVersionIds',
+      {
+        proposalVersionIds: proposalVersions.map((proposalVersion) => proposalVersion.id),
+      },
+      isProposalFieldValue,
+    ),
+  );
+
+  return proposalVersions.map((proposalVersion) => ({
+    ...proposalVersion,
+    fieldValues: proposalFieldValues.filter(
+      ({ proposalVersionId }) => proposalVersionId === proposalVersion.id,
+    ),
+  }));
+};

--- a/src/database/enrichers/enrichProposals.ts
+++ b/src/database/enrichers/enrichProposals.ts
@@ -1,0 +1,23 @@
+import { loadObjects } from '../accessors/loadObjects';
+import { isProposalVersion } from '../../types';
+import { enrichProposalVersions } from './enrichProposalVersions';
+import type { Proposal } from '../../types';
+
+export const enrichProposals = async (proposals: Proposal[]): Promise<Proposal[]> => {
+  const proposalVersions = await enrichProposalVersions(
+    await loadObjects(
+      'proposalVersions.selectByProposalIds',
+      {
+        proposalIds: proposals.map((proposal) => proposal.id),
+      },
+      isProposalVersion,
+    ),
+  );
+
+  return proposals.map((proposal) => ({
+    ...proposal,
+    versions: proposalVersions.filter(
+      ({ proposalId }) => proposalId === proposal.id,
+    ),
+  }));
+};

--- a/src/database/enrichers/index.ts
+++ b/src/database/enrichers/index.ts
@@ -1,0 +1,3 @@
+export * from './enrichProposalFieldValues';
+export * from './enrichProposals';
+export * from './enrichProposalVersions';

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,4 +1,5 @@
 export * from './accessors';
 export * from './db';
+export * from './enrichers';
 export * from './migrate';
 export * from './parameters';

--- a/src/database/queries/applicationFormFields/selectByIds.sql
+++ b/src/database/queries/applicationFormFields/selectByIds.sql
@@ -1,0 +1,9 @@
+SELECT
+  id,
+  application_form_id as "applicationFormId",
+  canonical_field_id as "canonicalFieldId",
+  position,
+  label,
+  created_at as "createdAt"
+FROM application_form_fields
+WHERE id = ANY(:ids);

--- a/src/database/queries/proposalFieldValues/selectByProposalVersionIds.sql
+++ b/src/database/queries/proposalFieldValues/selectByProposalVersionIds.sql
@@ -1,0 +1,9 @@
+SELECT id,
+  proposal_version_id AS "proposalVersionId",
+  application_form_field_id AS "applicationFormFieldId",
+  value,
+  position,
+  created_at AS "createdAt"
+FROM proposal_field_values
+WHERE proposal_version_id = ANY(:proposalVersionIds)
+ORDER BY position;

--- a/src/database/queries/proposalVersions/selectByProposalIds.sql
+++ b/src/database/queries/proposalVersions/selectByProposalIds.sql
@@ -1,0 +1,8 @@
+SELECT id,
+  proposal_id AS "proposalId",
+  application_form_id AS "applicationFormId",
+  version,
+  created_at AS "createdAt"
+FROM proposal_versions
+WHERE proposal_id = ANY(:proposalIds)
+ORDER BY version DESC;

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -3,6 +3,7 @@ import {
   db,
   getLimitValues,
   loadProposalBundle,
+  enrichProposals,
 } from '../database';
 import {
   isProposalWrite,
@@ -47,9 +48,14 @@ const getProposals = (
     const proposalBundle = await loadProposalBundle({
       ...getLimitValues(paginationParameters),
     });
+    const enrichedProposalBundle = {
+      ...proposalBundle,
+      entries: await enrichProposals(proposalBundle.entries),
+    };
+
     res.status(200)
       .contentType('application/json')
-      .send(proposalBundle);
+      .send(enrichedProposalBundle);
   })()
     .catch((error: unknown) => {
       if (isTinyPgErrorWithQueryContext(error)) {

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -173,6 +173,9 @@
             "type": "integer",
             "example": 3613
           },
+          "applicationFormField": {
+            "$ref": "#/components/schemas/ApplicationFormField"
+          },
           "position": {
             "type": "integer",
             "example": 23

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -357,8 +357,8 @@
         "properties": {
           "entries": {
             "type": "array",
-            "description": "The collection of requested resources.",
-            "example": []
+            "items": {},
+            "description": "The collection of requested resources."
           },
           "total": {
             "type": "integer",

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,1 +1,3 @@
 export const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+export const expectTimestamp = expect.stringMatching(isoTimestampPattern) as string;


### PR DESCRIPTION
This PR introduces the concept of `enrichers` to convert shallow objects of various types into deep objects.

It also applies the enrichers to the `/proposals` endpoint.

Resolves #274 