### PR TITLE
Single Query Approach: Return deep proposals from GET `/proposals`

### DIFF
--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -35,6 +35,11 @@ describe('/proposals', () => {
         externalId: '12345',
         optedIn: true,
       });
+      await db.sql('canonicalFields.insertOne', {
+        label: 'Summary',
+        shortCode: 'summary',
+        dataType: 'string',
+      });
       await db.sql('proposals.insertOne', {
         applicantId: 1,
         externalId: 'proposal-1',
@@ -44,6 +49,25 @@ describe('/proposals', () => {
         applicantId: 1,
         externalId: 'proposal-2',
         opportunityId: 1,
+      });
+      await db.sql('applicationForms.insertOne', {
+        opportunityId: 1,
+      });
+      await db.sql('proposalVersions.insertOne', {
+        proposalId: 1,
+        applicationFormId: 1,
+      });
+      await db.sql('applicationFormFields.insertOne', {
+        applicationFormId: 1,
+        canonicalFieldId: 1,
+        position: 1,
+        label: 'Short summary',
+      });
+      await db.sql('proposalFieldValues.insertOne', {
+        proposalVersionId: 1,
+        applicationFormFieldId: 1,
+        position: 1,
+        value: 'This is a summary',
       });
       await agent
         .get('/proposals')
@@ -60,6 +84,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  versions: [],
                 },
                 {
                   id: 1,
@@ -67,6 +92,29 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  versions: [{
+                    id: 1,
+                    proposalId: 1,
+                    version: 1,
+                    applicationFormId: 1,
+                    createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                    fieldValues: [{
+                      id: 1,
+                      applicationFormFieldId: 1,
+                      proposalVersionId: 1,
+                      position: 1,
+                      value: 'This is a summary',
+                      createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                      applicationFormField: {
+                        id: 1,
+                        applicationFormId: 1,
+                        canonicalFieldId: 1,
+                        label: 'Short summary',
+                        position: 1,
+                        createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                      },
+                    }],
+                  }],
                 },
               ],
             },
@@ -109,6 +157,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  versions: [],
                 },
                 {
                   id: 14,
@@ -116,6 +165,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  versions: [],
                 },
                 {
                   id: 13,
@@ -123,6 +173,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  versions: [],
                 },
                 {
                   id: 12,
@@ -130,6 +181,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  versions: [],
                 },
                 {
                   id: 11,
@@ -137,6 +189,7 @@ describe('/proposals', () => {
                   applicantId: 1,
                   opportunityId: 1,
                   createdAt: expect.stringMatching(isoTimestampPattern) as string,
+                  versions: [],
                 },
               ],
             },

--- a/src/database/accessors/__test__/loadBundle.int.test.ts
+++ b/src/database/accessors/__test__/loadBundle.int.test.ts
@@ -1,5 +1,4 @@
 import { loadBundle } from '..';
-import { isApplicant } from '../../../types';
 import { db } from '../..';
 
 describe('loadBundle', () => {
@@ -12,7 +11,6 @@ describe('loadBundle', () => {
       'applicants.selectAll',
       {},
       'applicants',
-      isApplicant,
     );
     expect(objects).toMatchObject({
       total: 1,

--- a/src/database/accessors/__test__/loadObjects.int.test.ts
+++ b/src/database/accessors/__test__/loadObjects.int.test.ts
@@ -1,9 +1,4 @@
 import { loadObjects } from '..';
-import {
-  isApplicant,
-  isProposal,
-} from '../../../types';
-import { InternalValidationError } from '../../../errors';
 import { db } from '../..';
 
 describe('loadObjects', () => {
@@ -15,7 +10,6 @@ describe('loadObjects', () => {
     const objects = await loadObjects(
       'applicants.selectAll',
       {},
-      isApplicant,
     );
     expect(objects).toMatchObject([{
       createdAt: expect.any(Date) as Date,
@@ -23,17 +17,5 @@ describe('loadObjects', () => {
       id: 1,
       optedIn: true,
     }]);
-  });
-
-  it('Should throw an error if the format returned by the database does not align with the expected schema', async () => {
-    await db.sql('applicants.insertOne', {
-      externalId: '12345',
-      optedIn: true,
-    });
-    await expect(loadObjects(
-      'applicants.selectAll',
-      {},
-      isProposal,
-    )).rejects.toBeInstanceOf(InternalValidationError);
   });
 });

--- a/src/database/accessors/loadBundle.ts
+++ b/src/database/accessors/loadBundle.ts
@@ -1,7 +1,6 @@
 import { loadTableMetrics } from './loadTableMetrics';
 import { loadObjects } from './loadObjects';
 import type { TinyPgParams } from 'tinypg';
-import type { ValidateFunction } from 'ajv';
 import type {
   Bundle,
 } from '../../types';
@@ -10,12 +9,10 @@ export const loadBundle = async <T extends object>(
   tinyPgQueryName: string,
   tinyPgQueryParameters: TinyPgParams,
   tableName: string,
-  entryValidator: ValidateFunction<T>,
 ): Promise<Bundle<T>> => {
-  const entries = await loadObjects(
+  const entries = await loadObjects<T>(
     tinyPgQueryName,
     tinyPgQueryParameters,
-    entryValidator,
   );
   const metrics = await loadTableMetrics(tableName);
 

--- a/src/database/accessors/loadObjects.ts
+++ b/src/database/accessors/loadObjects.ts
@@ -1,26 +1,14 @@
 import { db } from '../db';
-import { InternalValidationError } from '../../errors';
 import type { TinyPgParams } from 'tinypg';
-import type { ValidateFunction } from 'ajv';
 
 export const loadObjects = async <T extends object>(
   tinyPgQueryName: string,
   tinyPgQueryParameters: TinyPgParams,
-  objectValidator: ValidateFunction<T>,
 ): Promise<T[]> => {
   const { rows } = await db.sql<T>(
     tinyPgQueryName,
     tinyPgQueryParameters,
   );
-
-  rows.forEach((row) => {
-    if (!objectValidator(row)) {
-      throw new InternalValidationError(
-        'The database responded with an unexpected format.',
-        objectValidator.errors ?? [],
-      );
-    }
-  });
 
   return rows;
 };

--- a/src/database/accessors/loadProposalBundle.ts
+++ b/src/database/accessors/loadProposalBundle.ts
@@ -1,16 +1,222 @@
-import { isProposal } from '../../types';
 import { loadBundle } from './loadBundle';
 import type { TinyPgParams } from 'tinypg';
 import type {
   Bundle,
   Proposal,
+  ProposalVersion,
+  ProposalFieldValue,
+  ApplicationFormField,
 } from '../../types';
+
+/* eslint-disable @typescript-eslint/no-type-alias */
+type AddPrefixToObject<T, P extends string> = {
+  [K in keyof T as K extends string ? `${P}${K}` : never]: T[K]
+};
+/* eslint-enable @typescript-eslint/no-type-alias */
+
+const filterByDistinctId = (
+  candidateItem: { id: number },
+  index: number,
+  self: { id: number }[],
+) => index === self.findIndex(
+  (item) => item.id === candidateItem.id,
+);
+
+// See https://github.com/typescript-eslint/typescript-eslint/issues/1824
+/* eslint-disable @typescript-eslint/indent */
+type ProposalPiece = AddPrefixToObject<Proposal, 'proposal_'>;
+type ProposalVersionPiece = AddPrefixToObject<ProposalVersion, 'proposalVersion_'>;
+type ProposalFieldValuePiece = AddPrefixToObject<ProposalFieldValue, 'proposalFieldValue_'>;
+type ApplicationFormFieldPiece = AddPrefixToObject<ApplicationFormField, 'applicationFormField_'>;
+/* eslint-enable @typescript-eslint/indent */
+
+const isApplicationFormFieldPiece = (
+  o: Record<string, unknown>,
+): o is ApplicationFormFieldPiece => (
+  'applicationFormField_id' in o
+);
+const isProposalFieldValuePiece = (
+  o: Record<string, unknown>,
+): o is ProposalFieldValuePiece => (
+  'proposalFieldValue_id' in o
+);
+const isProposalVersionPiece = (
+  o: Record<string, unknown>,
+): o is ProposalVersionPiece => (
+  'proposalVersion_id' in o
+);
+const isProposalPiece = (
+  o: Record<string, unknown>,
+): o is ProposalPiece => (
+  'proposal_id' in o
+);
+
+const extractApplicationFormFields = (
+  applicationFormFieldPieces: ApplicationFormFieldPiece[],
+): ApplicationFormField[] => (
+  applicationFormFieldPieces.reduce<ApplicationFormField[]>(
+    (applicationFormFields, applicationFormFieldPiece) => [
+      ...applicationFormFields,
+      {
+        id: applicationFormFieldPiece.applicationFormField_id,
+        applicationFormId: applicationFormFieldPiece.applicationFormField_applicationFormId,
+        canonicalFieldId: applicationFormFieldPiece.applicationFormField_canonicalFieldId,
+        position: applicationFormFieldPiece.applicationFormField_position,
+        label: applicationFormFieldPiece.applicationFormField_label,
+        createdAt: applicationFormFieldPiece.applicationFormField_createdAt,
+      },
+    ],
+    [],
+  ).filter(filterByDistinctId)
+);
+
+const extractProposalFieldValues = (
+  proposalFieldValuePieces: ProposalFieldValuePiece[],
+): ProposalFieldValue[] => (
+  proposalFieldValuePieces.reduce<ProposalFieldValue[]>(
+    (proposalFieldValues, proposalFieldValuePiece) => [
+      ...proposalFieldValues,
+      {
+        id: proposalFieldValuePiece.proposalFieldValue_id,
+        proposalVersionId: proposalFieldValuePiece.proposalFieldValue_proposalVersionId,
+        applicationFormFieldId: proposalFieldValuePiece.proposalFieldValue_applicationFormFieldId,
+        position: proposalFieldValuePiece.proposalFieldValue_position,
+        value: proposalFieldValuePiece.proposalFieldValue_value,
+        createdAt: proposalFieldValuePiece.proposalFieldValue_createdAt,
+      },
+    ],
+    [],
+  ).filter(filterByDistinctId)
+);
+
+const extractProposalVersions = (
+  proposalVersionPieces: ProposalVersionPiece[],
+): ProposalVersion[] => (
+  proposalVersionPieces.reduce<ProposalVersion[]>(
+    (proposalVersions, proposalVersionPiece) => [
+      ...proposalVersions,
+      {
+        id: proposalVersionPiece.proposalVersion_id,
+        proposalId: proposalVersionPiece.proposalVersion_proposalId,
+        applicationFormId: proposalVersionPiece.proposalVersion_applicationFormId,
+        version: proposalVersionPiece.proposalVersion_version,
+        createdAt: proposalVersionPiece.proposalVersion_createdAt,
+      },
+    ],
+    [],
+  ).filter(filterByDistinctId)
+);
+
+const extractProposals = (
+  proposalPieces: ProposalPiece[],
+): Proposal[] => (
+  proposalPieces.reduce<Proposal[]>(
+    (proposals, proposalPiece) => [
+      ...proposals,
+      {
+        id: proposalPiece.proposal_id,
+        applicantId: proposalPiece.proposal_applicantId,
+        opportunityId: proposalPiece.proposal_opportunityId,
+        externalId: proposalPiece.proposal_externalId,
+        createdAt: proposalPiece.proposal_createdAt,
+      },
+    ],
+    [],
+  ).filter(filterByDistinctId)
+);
+
+const joinProposalFieldValuesWithApplicationFormFields = (
+  proposalFieldValues: ProposalFieldValue[],
+  applicationFormFields: ApplicationFormField[],
+): ProposalFieldValue[] => (
+  proposalFieldValues.map((proposalFieldValue) => ({
+    ...proposalFieldValue,
+    applicationFormField: applicationFormFields.find(
+      (applicationFormField) => (
+        applicationFormField.id === proposalFieldValue.applicationFormFieldId
+      ),
+    ),
+  }))
+);
+
+const joinProposalVersionsWithProposalFieldValues = (
+  proposalVersions: ProposalVersion[],
+  proposalFieldValues: ProposalFieldValue[],
+): ProposalVersion[] => (
+  proposalVersions.map((proposalVersion) => ({
+    ...proposalVersion,
+    fieldValues: proposalFieldValues.filter(
+      (proposalFieldValue) => proposalFieldValue.proposalVersionId === proposalVersion.id,
+    ),
+  }))
+);
+
+const joinProposalsWithProposalVersions = (
+  proposals: Proposal[],
+  proposalVersions: ProposalVersion[],
+): Proposal[] => (
+  proposals.map((proposal) => ({
+    ...proposal,
+    versions: proposalVersions.filter(
+      (proposalVersion) => proposalVersion.proposalId === proposal.id,
+    ),
+  }))
+);
+
+export const joinProposalFieldValuesToProposalVersion = (
+  proposalVersion: ProposalVersion,
+  values: ProposalFieldValue[],
+): ProposalVersion => {
+  const newVersion = structuredClone(proposalVersion);
+  values.forEach((proposalFieldValue) => {
+    if (newVersion.fieldValues === undefined) {
+      newVersion.fieldValues = [];
+    }
+    if (proposalFieldValue.proposalVersionId === newVersion.id) {
+      newVersion.fieldValues.push(proposalFieldValue);
+    }
+  });
+  return newVersion;
+};
 
 export const loadProposalBundle = async (
   queryParameters: TinyPgParams,
-): Promise<Bundle<Proposal>> => loadBundle(
-  'proposals.selectWithPagination',
-  queryParameters,
-  'proposals',
-  isProposal,
-);
+): Promise<Bundle<Proposal>> => {
+  // See https://github.com/typescript-eslint/typescript-eslint/issues/1824
+  /* eslint-disable @typescript-eslint/indent */
+  const unprocessedBundle = await loadBundle<ProposalPiece
+    | ProposalVersionPiece
+    | ProposalFieldValuePiece
+    | ApplicationFormFieldPiece>(
+  /* eslint-enable @typescript-eslint/indent */
+    'proposals.selectWithPagination',
+    queryParameters,
+    'proposals',
+  );
+  const deepProposalPieces = unprocessedBundle.entries;
+  const applicationFormFields = extractApplicationFormFields(
+    deepProposalPieces.filter(isApplicationFormFieldPiece),
+  );
+  const proposalFieldValues = joinProposalFieldValuesWithApplicationFormFields(
+    extractProposalFieldValues(
+      deepProposalPieces.filter(isProposalFieldValuePiece),
+    ),
+    applicationFormFields,
+  );
+  const proposalVersions = joinProposalVersionsWithProposalFieldValues(
+    extractProposalVersions(
+      deepProposalPieces.filter(isProposalVersionPiece),
+    ),
+    proposalFieldValues,
+  );
+  const proposals = joinProposalsWithProposalVersions(
+    extractProposals(
+      deepProposalPieces.filter(isProposalPiece),
+    ),
+    proposalVersions,
+  );
+  return {
+    ...unprocessedBundle,
+    entries: proposals,
+  };
+};

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -1,8 +1,33 @@
-SELECT p.id AS "id",
-  p.applicant_id AS "applicantId",
-  p.external_id AS "externalId",
-  p.opportunity_id AS "opportunityId",
-  p.created_at AS "createdAt"
+SELECT p.id AS "proposal_id",
+  p.applicant_id AS "proposal_applicantId",
+  p.external_id AS "proposal_externalId",
+  p.opportunity_id AS "proposal_opportunityId",
+  p.created_at AS "proposal_createdAt",
+  pv.id AS "proposalVersion_id",
+  pv.proposal_id AS "proposalVersion_proposalId",
+  pv.application_form_id AS "proposalVersion_applicationFormId",
+  pv.version AS "proposalVersion_version",
+  pv.created_at AS "proposalVersion_createdAt",
+  pfv.id AS "proposalFieldValue_id",
+  pfv.proposal_version_id AS "proposalFieldValue_proposalVersionId",
+  pfv.application_form_field_id AS "proposalFieldValue_applicationFormFieldId",
+  pfv.value AS "proposalFieldValue_value",
+  pfv.position AS "proposalFieldValue_position",
+  pfv.created_at AS "proposalFieldValue_createdAt",
+  aff.id as "applicationFormField_id",
+  aff.application_form_id as "applicationFormField_applicationFormId",
+  aff.canonical_field_id as "applicationFormField_canonicalFieldId",
+  aff.position as "applicationFormField_position",
+  aff.label as "applicationFormField_label",
+  aff.created_at as "applicationFormField_createdAt"
 FROM proposals p
+  LEFT JOIN proposal_versions pv on pv.proposal_id = p.id
+  LEFT JOIN proposal_field_values pfv on pfv.proposal_version_id = pv.id
+  LEFT JOIN application_form_fields aff on pfv.application_form_field_id = aff.id
+WHERE p.id = ANY(
+  SELECT inner_p.id
+  FROM proposals inner_p
+  ORDER BY inner_p.id DESC
+  OFFSET :offset FETCH NEXT :limit ROWS ONLY
+)
 ORDER BY p.id DESC
-OFFSET :offset FETCH NEXT :limit ROWS ONLY


### PR DESCRIPTION
This PR changes the way we load proposal data to load all related data alongside, and then manually join the results into a single deep object.

Resolve #274