### PR TITLE
Implement GET /applicants by externalId

### DIFF
--- a/src/database/queries/applicants/selectByExternalId.sql
+++ b/src/database/queries/applicants/selectByExternalId.sql
@@ -1,0 +1,6 @@
+SELECT id,
+  external_id AS "externalId",
+  opted_in AS "optedIn",
+  created_at AS "createdAt"
+FROM applicants
+WHERE external_id = :externalId;

--- a/src/handlers/applicantsHandlers.ts
+++ b/src/handlers/applicantsHandlers.ts
@@ -27,7 +27,14 @@ const getApplicants = (
   res: Response,
   next: NextFunction,
 ): void => {
-  db.sql('applicants.selectAll')
+  let dbQuery = 'applicants.selectAll';
+  let dbParams = {};
+  if (req.query.externalId !== undefined) {
+    dbQuery = 'applicants.selectByExternalId';
+    dbParams = { externalId: req.query.externalId };
+  }
+
+  db.sql(dbQuery, dbParams)
     .then((applicantsQueryResult: Result<Applicant>) => {
       logger.debug(applicantsQueryResult);
       const { rows: applicants } = applicantsQueryResult;

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -488,9 +488,20 @@
             "auth": []
           }
         ],
+        "parameters": [
+          {
+            "name": "externalId",
+            "description": "The external identifier of an applicant, usually an EIN.",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "All applicants currently registered in the PDC.",
+            "description": "Applicants currently registered in the PDC meeting the given criteria.",
             "content": {
               "application/json": {
                 "schema": {
@@ -537,52 +548,6 @@
         "responses": {
           "201": {
             "description": "The new applicant that was created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Applicant"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication was not provided or was invalid.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/applicants/{externalId}": {
-      "get": {
-        "summary": "Get a specific applicant, including all known field values associated with the applicant. (In Development)",
-        "tags": [
-          "Applicants"
-        ],
-        "security": [
-          {
-            "auth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "externalId",
-            "description": "The external identifier of an applicant.",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The populated applicant.",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
It is convenient to check whether applicants already exist before trying to post them (and getting a failure, for example). We use the path parameter `{id}` for PDC internal IDs, not external IDs, so use a query parameter `externalId`

Issue #121 GET /applicants by externalId not working