### PR TITLE
Support search on GET `/proposals`

### DIFF
--- a/src/database/migrations/0010-alter-proposal_field_values-value_search.sql
+++ b/src/database/migrations/0010-alter-proposal_field_values-value_search.sql
@@ -1,0 +1,5 @@
+ALTER TABLE proposal_field_values
+  ADD COLUMN value_search tsvector
+    GENERATED ALWAYS AS (to_tsvector('english', value)) STORED;
+
+CREATE INDEX idx_value_search ON proposal_field_values USING GIN(value_search);

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -4,5 +4,15 @@ SELECT p.id AS "id",
   p.opportunity_id AS "opportunityId",
   p.created_at AS "createdAt"
 FROM proposals p
+  LEFT JOIN proposal_versions pv ON pv.proposal_id = p.id
+  LEFT JOIN proposal_field_values pfv on pfv.proposal_version_id = pv.id
+WHERE
+  CASE
+    WHEN :search::text != '' THEN
+      pfv.value_search @@ websearch_to_tsquery(:search::text)
+    ELSE
+      true
+    END
+GROUP BY p.id
 ORDER BY p.id DESC
 OFFSET :offset FETCH NEXT :limit ROWS ONLY

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -21,6 +21,7 @@ import {
 } from '../errors';
 import {
   extractPaginationParameters,
+  extractSearchParameters,
 } from '../queryParameters';
 import type {
   Request,
@@ -44,9 +45,11 @@ const getProposals = (
   next: NextFunction,
 ): void => {
   const paginationParameters = extractPaginationParameters(req);
+  const searchParameters = extractSearchParameters(req);
   (async () => {
     const proposalBundle = await loadProposalBundle({
       ...getLimitValues(paginationParameters),
+      ...searchParameters,
     });
     const enrichedProposalBundle = {
       ...proposalBundle,

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -28,6 +28,16 @@
         "name": "_count",
         "required": false,
         "description": "The maximum number of items that should appear per page or request."
+      },
+      "searchParam": {
+        "schema": {
+          "type": "string",
+          "default": ""
+        },
+        "in": "query",
+        "name": "_content",
+        "required": false,
+        "description": "A web-search formatted string to select specific entities returned."
       }
     },
     "securitySchemes": {
@@ -708,7 +718,8 @@
         ],
         "parameters": [
           { "$ref": "#/components/parameters/pageParam" },
-          { "$ref": "#/components/parameters/countParam" }
+          { "$ref": "#/components/parameters/countParam" },
+          { "$ref": "#/components/parameters/searchParam" }
         ],
         "responses": {
           "200": {

--- a/src/queryParameters/extractSearchParameters.ts
+++ b/src/queryParameters/extractSearchParameters.ts
@@ -1,0 +1,13 @@
+import apiSpecification from '../openapi.json';
+import type {
+  Request,
+} from 'express';
+
+export const extractSearchParameters = (
+  request: Request,
+) => ({
+  /* eslint-disable no-underscore-dangle */
+  search: request.query._content
+    ?? apiSpecification.components.parameters.searchParam.schema.default,
+  /* eslint-enable no-underscore-dangle */
+});

--- a/src/queryParameters/index.ts
+++ b/src/queryParameters/index.ts
@@ -1,1 +1,2 @@
 export * from './extractPaginationParameters';
+export * from './extractSearchParameters';


### PR DESCRIPTION
This PR adds a new `_q` parameter to GET `/proposals`.

This does NOT attempt to optimize anything about full text search (that should happen next!).

Issue #277 Search capability for proposal data
