### PR TITLE
Specify the PG TS config `'english'` on search

### DIFF
--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -175,7 +175,6 @@ describe('/proposals', () => {
         position: 1,
         value: 'This is a pair of pants',
       });
-
       await agent
         .get('/proposals?_content=summary')
         .set(authHeader)
@@ -209,6 +208,106 @@ describe('/proposals', () => {
                         applicationFormId: 1,
                         canonicalFieldId: 1,
                         label: 'Short summary',
+                        position: 1,
+                        createdAt: expectTimestamp,
+                      },
+                    }],
+                  }],
+                },
+              ],
+            },
+          ),
+        );
+    });
+
+    it('returns a subset of proposals present in the database when search is provided - tscfg simple', async () => {
+      // This should pass even if the default text search config is 'simple'.
+      // See https://github.com/PhilanthropyDataCommons/service/issues/336
+      await db.query('set default_text_search_config = \'simple\';');
+      await db.sql('opportunities.insertOne', {
+        title: 'Grand opportunity',
+      });
+      await db.sql('applicants.insertOne', {
+        externalId: '4993',
+        optedIn: true,
+      });
+      await db.sql('canonicalFields.insertOne', {
+        label: 'Summary',
+        shortCode: 'summary',
+        dataType: 'string',
+      });
+      await db.sql('proposals.insertOne', {
+        applicantId: 1,
+        externalId: 'proposal-4999',
+        opportunityId: 1,
+      });
+      await db.sql('proposals.insertOne', {
+        applicantId: 1,
+        externalId: 'proposal-5003',
+        opportunityId: 1,
+      });
+      await db.sql('applicationForms.insertOne', {
+        opportunityId: 1,
+      });
+      await db.sql('proposalVersions.insertOne', {
+        proposalId: 1,
+        applicationFormId: 1,
+      });
+      await db.sql('proposalVersions.insertOne', {
+        proposalId: 2,
+        applicationFormId: 1,
+      });
+      await db.sql('applicationFormFields.insertOne', {
+        applicationFormId: 1,
+        canonicalFieldId: 1,
+        position: 1,
+        label: 'Concise summary',
+      });
+      await db.sql('proposalFieldValues.insertOne', {
+        proposalVersionId: 1,
+        applicationFormFieldId: 1,
+        position: 1,
+        value: 'This is a summary',
+      });
+      await db.sql('proposalFieldValues.insertOne', {
+        proposalVersionId: 2,
+        applicationFormFieldId: 1,
+        position: 1,
+        value: 'This is a pair of pants',
+      });
+      await agent
+        .get('/proposals?_content=summary')
+        .set(authHeader)
+        .expect(200)
+        .expect(
+          (res) => expect(res.body).toEqual(
+            {
+              total: 2,
+              entries: [
+                {
+                  id: 1,
+                  externalId: 'proposal-4999',
+                  applicantId: 1,
+                  opportunityId: 1,
+                  createdAt: expectTimestamp,
+                  versions: [{
+                    id: 1,
+                    proposalId: 1,
+                    version: 1,
+                    applicationFormId: 1,
+                    createdAt: expectTimestamp,
+                    fieldValues: [{
+                      id: 1,
+                      applicationFormFieldId: 1,
+                      proposalVersionId: 1,
+                      position: 1,
+                      value: 'This is a summary',
+                      createdAt: expectTimestamp,
+                      applicationFormField: {
+                        id: 1,
+                        applicationFormId: 1,
+                        canonicalFieldId: 1,
+                        label: 'Concise summary',
                         position: 1,
                         createdAt: expectTimestamp,
                       },

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -9,7 +9,7 @@ FROM proposals p
 WHERE
   CASE
     WHEN :search::text != '' THEN
-      pfv.value_search @@ websearch_to_tsquery(:search::text)
+      pfv.value_search @@ websearch_to_tsquery('english', :search::text)
     ELSE
       true
     END


### PR DESCRIPTION
While the postgres (PG) text search (TS) config 'english' is specified when building the text search column and index in the migration script `0010-alter-proposal_field_values-value_search.sql`, when the postgres `default_text_search_config` is set to `pg_catalog.simple` rather than to `pg_catalog.english`, the test named `returns a subset of proposals present in the database when search is provided` in file `proposals.int.test.ts` will fail. For consistency in search results across instances, this commit sets the query with search to use the same `english`. Without this commit, tests will fail with different PG settings for default text search config and inconsistent search results will appear between instances.

Issue #336 Test failure on different pg text search settings