### PR TITLE
Implement `GET /proposals` by opportunity ID

### DIFF
--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -13,6 +13,12 @@ WHERE
     ELSE
       true
     END
+  AND CASE
+    WHEN :opportunityId != 0 THEN
+      p.opportunity_id = :opportunityId
+    ELSE
+      true
+    END
 GROUP BY p.id
 ORDER BY p.id DESC
 OFFSET :offset FETCH NEXT :limit ROWS ONLY

--- a/src/errors/SimpleInputValidationError.ts
+++ b/src/errors/SimpleInputValidationError.ts
@@ -1,0 +1,9 @@
+// In the case of non-ajv input validation, use this for input errors.
+export class SimpleInputValidationError extends Error {
+  public constructor(
+    message: string,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,3 +3,4 @@ export * from './InputConflictError';
 export * from './InputValidationError';
 export * from './InternalValidationError';
 export * from './NotFoundError';
+export * from './SimpleInputValidationError';

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -20,6 +20,7 @@ import {
   NotFoundError,
 } from '../errors';
 import {
+  extractOpportunityIdParameter,
   extractPaginationParameters,
   extractSearchParameters,
 } from '../queryParameters';
@@ -46,10 +47,12 @@ const getProposals = (
 ): void => {
   const paginationParameters = extractPaginationParameters(req);
   const searchParameters = extractSearchParameters(req);
+  const opportunityIdParameter = extractOpportunityIdParameter(req);
   (async () => {
     const proposalBundle = await loadProposalBundle({
       ...getLimitValues(paginationParameters),
       ...searchParameters,
+      ...opportunityIdParameter,
     });
     const enrichedProposalBundle = {
       ...proposalBundle,

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -5,6 +5,7 @@ import {
   InputValidationError,
   InputConflictError,
   NotFoundError,
+  SimpleInputValidationError,
 } from '../errors';
 import { PostgresErrorCode } from '../types';
 import { getLogger } from '../logger';
@@ -58,7 +59,7 @@ const getHttpStatusCodeForError = (error: unknown): number => {
   if (error instanceof InternalValidationError) {
     return 500;
   }
-  if (error instanceof InputValidationError) {
+  if (error instanceof InputValidationError || error instanceof SimpleInputValidationError) {
     return 400;
   }
   if (error instanceof InputConflictError) {

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -38,6 +38,16 @@
         "name": "_content",
         "required": false,
         "description": "A web-search formatted string to select specific entities returned."
+      },
+      "opportunityIdParam": {
+        "schema": {
+          "type": "integer",
+          "default": 0
+        },
+        "in": "query",
+        "name": "opportunityId",
+        "required": false,
+        "description": "The PDC-generated ID of an opportunity by which to filter results."
       }
     },
     "securitySchemes": {
@@ -719,11 +729,12 @@
         "parameters": [
           { "$ref": "#/components/parameters/pageParam" },
           { "$ref": "#/components/parameters/countParam" },
-          { "$ref": "#/components/parameters/searchParam" }
+          { "$ref": "#/components/parameters/searchParam" },
+          { "$ref": "#/components/parameters/opportunityIdParam" }
         ],
         "responses": {
           "200": {
-            "description": "All proposals currently registered in the PDC.",
+            "description": "Proposals currently registered in the PDC matching the given criteria.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/queryParameters/extractOpportunityIdParameter.ts
+++ b/src/queryParameters/extractOpportunityIdParameter.ts
@@ -1,0 +1,19 @@
+import apiSpecification from '../openapi.json';
+import { SimpleInputValidationError } from '../errors';
+import type { Request } from 'express';
+
+export const extractOpportunityIdParameter = (
+  request: Request,
+) => {
+  if (request.query.opportunityId !== undefined
+    && request.query.opportunityId !== '') {
+    const id = Number(request.query.opportunityId);
+    if (!Number.isSafeInteger(id)) {
+      throw new SimpleInputValidationError(`opportunityId must be an integer, got '${id}'.`);
+    }
+    return { opportunityId: id };
+  }
+  return {
+    opportunityId: apiSpecification.components.parameters.opportunityIdParam.schema.default,
+  };
+};

--- a/src/queryParameters/index.ts
+++ b/src/queryParameters/index.ts
@@ -1,2 +1,3 @@
+export * from './extractOpportunityIdParameter';
 export * from './extractPaginationParameters';
 export * from './extractSearchParameters';


### PR DESCRIPTION
When posting new proposal data via the API, one gets existing proposal data before attempting to add a new one. Then one must filter through a lot of proposal data locally. This change allows filtering by opportunity ID on the server-side. This reduces the amount of client data filtering required and reduces overall data transfer.

Issue #323  Implement GET /proposals by opportunity ID