### PR TITLE
Use the TSConfig for Node.js 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "tinypg": "^7.0.0"
       },
       "devDependencies": {
-        "@tsconfig/node16": "^1.0.3",
+        "@tsconfig/node18": "^2.0.1",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/jest": "^28.1.2",
@@ -1313,6 +1313,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-2.0.1.tgz",
+      "integrity": "sha512-UqdfvuJK0SArA2CxhKWwwAWfnVSXiYe63bVpMutc27vpngCntGUZQETO24pEJ46zU6XM+7SpqYoMgcO3bM11Ew==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -8831,6 +8837,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "@tsconfig/node18": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-2.0.1.tgz",
+      "integrity": "sha512-UqdfvuJK0SArA2CxhKWwwAWfnVSXiYe63bVpMutc27vpngCntGUZQETO24pEJ46zU6XM+7SpqYoMgcO3bM11Ew==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node" : "18"
   },
   "devDependencies": {
-    "@tsconfig/node16": "^1.0.3",
+    "@tsconfig/node18": "^2.0.1",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jest": "^28.1.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "dist",


### PR DESCRIPTION
The TSConfig project hosts recommendations for configuring TypeScript. We were using the recommended configuration for Node.js 16, but we are targetting Node.js 18. Use the recommended configuration for our environment.

Found while reviewing #355.