### PR TITLE
Log 5XX errors appropriately

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -113,9 +113,13 @@ export const errorHandler = (
   res: Response,
   next: NextFunction, // eslint-disable-line @typescript-eslint/no-unused-vars
 ): void => {
-  logger.debug(err);
   logger.trace(req.body);
   const statusCode = getHttpStatusCodeForError(err);
+  if (statusCode >= 500) {
+    logger.error({ err, statusCode });
+  } else {
+    logger.debug({ err, statusCode });
+  }
   res.status(statusCode)
     .contentType('application/json')
     .send({


### PR DESCRIPTION
Our error handler is invoked in both routine and exceptional circumstances. The [HTTP status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) is a handy proxy for what should be logged: 1XX, 2XX, and 3XX codes should not invoke the error handler, 4XX codes are expected and should not be logged as an error, and 5XX codes are serious. Log such errors at the `error` level, which should be enabled in all environments.

Resolves #350 Error logs do not contain useful information