### PR TITLE
Order deep proposal queries by another column

### DIFF
--- a/src/database/queries/applicationFormFields/selectByProposalId.sql
+++ b/src/database/queries/applicationFormFields/selectByProposalId.sql
@@ -10,4 +10,4 @@ INNER JOIN proposal_field_values pfv
 INNER JOIN proposal_versions pv
   ON pv.id = pfv.proposal_version_id
 WHERE pv.proposal_id = :proposalId
-ORDER BY pv.version DESC, pfv.position;
+ORDER BY pv.version DESC, pfv.position, pfv.id;

--- a/src/database/queries/proposalFieldValues/selectByProposalId.sql
+++ b/src/database/queries/proposalFieldValues/selectByProposalId.sql
@@ -8,4 +8,4 @@ FROM proposal_field_values pfv
 INNER JOIN proposal_versions pv
   ON pv.id = pfv.proposal_version_id
 WHERE pv.proposal_id = :proposalId
-ORDER BY pv.version DESC, pfv.position;
+ORDER BY pv.version DESC, pfv.position, pfv.id;


### PR DESCRIPTION
Without this change, a non-deterministic sort order can cause an HTTP 500 response with message "...values and fields must be sorted...".

With this change, the sort order is first by position (as before) and then also by proposal field value (pfv) ID because there can be many pfv rows for a given application form field (aff) row. This should be sufficient to guarantee deterministic order such that the application join will succeed.

Issue #381 Unexpected 500 response: "values and fields must be sorted"

See also https://github.com/PhilanthropyDataCommons/service/pull/198 and https://github.com/PhilanthropyDataCommons/service/pull/210.