### PR TITLE
Update to node 18.16.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build with node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.12.1
+          node-version: 18.16.0
       - run: npm ci
       - run: npm run build
       - run: npm prune --omit=dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.12.1
+        node-version: 18.16.0
     - run: npm ci
     - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.12.1
+          node-version: 18.16.0
 
       - name: Install dependencies
         run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/node:18.12.1-debian-11-r15
+FROM bitnami/node:18.16.0-debian-11-r15
 
 RUN adduser --home /opt/philanthropy-data-commons --uid 902 \
     --disabled-login web


### PR DESCRIPTION
Dependabot noticed the need to update in the Dockerfile, but not in the automated build, lint, and test scripts. This change updates the (minor) Active LTS version of node.