### PR TITLE
Uninstall TypeScript definitions for pg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@types/express": "^4.17.17",
         "@types/jest": "^28.1.2",
         "@types/node": "^18.16.16",
-        "@types/pg": "^8.10.1",
         "@types/supertest": "^2.0.12",
         "@types/swagger-ui-express": "^4.1.3",
         "@typescript-eslint/eslint-plugin": "^5.59.9",
@@ -1593,74 +1592,6 @@
       "version": "18.16.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
       "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
-    },
-    "node_modules/@types/pg": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.10.1.tgz",
-      "integrity": "sha512-AmEHA/XxMxemQom5iDwP62FYNkv+gDDnetRG7v2N2dPtju7UKI7FknUimcZo7SodKTHtckYPzaTqUEvUKbVJEA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^4.0.1"
-      }
-    },
-    "node_modules/@types/pg/node_modules/pg-types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.1.tgz",
-      "integrity": "sha512-hRCSDuLII9/LE3smys1hRHcu5QGcLs9ggT7I/TCs0IE+2Eesxi9+9RWAAwZ0yaGjxoWICF/YHLOEjydGujoJ+g==",
-      "dev": true,
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "pg-numeric": "1.0.2",
-        "postgres-array": "~3.0.1",
-        "postgres-bytea": "~3.0.0",
-        "postgres-date": "~2.0.1",
-        "postgres-interval": "^3.0.0",
-        "postgres-range": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@types/pg/node_modules/postgres-array": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
-      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@types/pg/node_modules/postgres-bytea": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
-      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
-      "dev": true,
-      "dependencies": {
-        "obuf": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@types/pg/node_modules/postgres-date": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.0.1.tgz",
-      "integrity": "sha512-YtMKdsDt5Ojv1wQRvUhnyDJNSr2dGIC96mQVKz7xufp07nfuFONzdaowrMHjlAzY6GDLd4f+LUHHAAM1h4MdUw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@types/pg/node_modules/postgres-interval": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
-      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -5994,12 +5925,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "dev": true
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
@@ -6245,15 +6170,6 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pg-numeric": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
-      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/pg-pool": {
@@ -6532,12 +6448,6 @@
       "engines": {
         "node": ">10.17.0"
       }
-    },
-    "node_modules/postgres-range": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
-      "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
-      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -9367,61 +9277,6 @@
       "version": "18.16.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
       "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
-    },
-    "@types/pg": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.10.1.tgz",
-      "integrity": "sha512-AmEHA/XxMxemQom5iDwP62FYNkv+gDDnetRG7v2N2dPtju7UKI7FknUimcZo7SodKTHtckYPzaTqUEvUKbVJEA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^4.0.1"
-      },
-      "dependencies": {
-        "pg-types": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.1.tgz",
-          "integrity": "sha512-hRCSDuLII9/LE3smys1hRHcu5QGcLs9ggT7I/TCs0IE+2Eesxi9+9RWAAwZ0yaGjxoWICF/YHLOEjydGujoJ+g==",
-          "dev": true,
-          "requires": {
-            "pg-int8": "1.0.1",
-            "pg-numeric": "1.0.2",
-            "postgres-array": "~3.0.1",
-            "postgres-bytea": "~3.0.0",
-            "postgres-date": "~2.0.1",
-            "postgres-interval": "^3.0.0",
-            "postgres-range": "^1.1.1"
-          }
-        },
-        "postgres-array": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
-          "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
-          "dev": true
-        },
-        "postgres-bytea": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
-          "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
-          "dev": true,
-          "requires": {
-            "obuf": "~1.1.2"
-          }
-        },
-        "postgres-date": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.0.1.tgz",
-          "integrity": "sha512-YtMKdsDt5Ojv1wQRvUhnyDJNSr2dGIC96mQVKz7xufp07nfuFONzdaowrMHjlAzY6GDLd4f+LUHHAAM1h4MdUw==",
-          "dev": true
-        },
-        "postgres-interval": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
-          "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
-          "dev": true
-        }
-      }
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -12650,12 +12505,6 @@
         "es-abstract": "^1.20.4"
       }
     },
-    "obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "dev": true
-    },
     "on-exit-leak-free": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
@@ -12830,12 +12679,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
-    },
-    "pg-numeric": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
-      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
-      "dev": true
     },
     "pg-pool": {
       "version": "3.5.2",
@@ -13057,12 +12900,6 @@
         "pg": "^8.6.0",
         "sql-template-strings": "^2.2.2"
       }
-    },
-    "postgres-range": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
-      "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
-      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@types/express": "^4.17.17",
     "@types/jest": "^28.1.2",
     "@types/node": "^18.16.16",
-    "@types/pg": "^8.10.1",
     "@types/supertest": "^2.0.12",
     "@types/swagger-ui-express": "^4.1.3",
     "@typescript-eslint/eslint-plugin": "^5.59.9",


### PR DESCRIPTION
The dependency on the `@types/pg` package was added in commit 7dd9d58930244799b1643effbe6ce4fa1420a445. However, we are - happily! - using TinyPg to interact with PostgreSQL, rather than working directly with the pg library.

Remove the dependency so that we don't have to keep it up to date:

```sh
npm uninstall --save-dev @types/pg
```

Found while reviewing #393.
