### PR TITLE
Remove test keys setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ In order to run this software you need to set up a [Postgres 14](https://www.pos
   ```bash
   cp .env.example .env.test
   edit .env.test
-  # Along with the other variables, be sure to set `API_KEYS_FILE=test_keys.txt`
   ```
 
 4. Run migrations

--- a/test_keys.txt
+++ b/test_keys.txt
@@ -1,2 +1,0 @@
-rEkwnrmqgTTr06ftJFZLYUPSythzIDkdbPg1yrGed3SajHr38V
-HM8UMHK7bCX3vmQ6y6tNYLrG3RKtObAZ9TIs2HGwhvfapvtJww


### PR DESCRIPTION
When pairing with @reefdog we noticed that the test_keys auth setup was still in the documentation and had an old artifact.  This takes both items out.