### PR TITLE
Group some dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+    groups:
+      aws-sdk:
+        patterns:
+        - "@aws-sdk/*"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       aws-sdk:
         patterns:
         - "@aws-sdk/*"
+      eslint:
+        patterns:
+        - "*eslint*"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
This PR uses dependabot's [group functionality](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) which should help related updates within a single ecosystem to map to a single PR instead of a series of PRs.  This should save us some time but ALSO it should help prevent rare situations where PRs have to be merged / rebased in a specific order.

I identified two sets that I feel are low hanging fruit (aws-sdk, and eslint), but there may be other groups worth considering either for this PR or a future PR.