### PR TITLE
Allow schema specification when migrating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "jwks-rsa": "^3.1.0",
         "pino": "^8.16.2",
         "pino-http": "^8.5.1",
-        "postgres-migrations": "^5.3.0",
+        "postgres-schema-migrations": "^6.1.0",
         "require-env-variable": "^4.0.2",
         "swagger-ui-express": "^5.0.0",
         "tinypg": "^7.0.0",
@@ -8562,10 +8562,16 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/postgres-migrations": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/postgres-migrations/-/postgres-migrations-5.3.0.tgz",
-      "integrity": "sha512-gnTHWJZVWbW8T3mXIxJm1JRU853TqBVWkhgfsTJr7zqT3VexjRmJj9kNi96rVhfTezDU4FVW6pf701kLOZiKIA==",
+    "node_modules/postgres-range": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
+      "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
+      "dev": true
+    },
+    "node_modules/postgres-schema-migrations": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-schema-migrations/-/postgres-schema-migrations-6.1.0.tgz",
+      "integrity": "sha512-d1LJ+A9Lg4kAwuh91S8ozF8q3adFNJlStbpUF/sbjMTzSIzJClpmg4D6qyd9nvKt2el0rnZJjXZQ2r01Y5OpzA==",
       "dependencies": {
         "pg": "^8.6.0",
         "sql-template-strings": "^2.2.2"
@@ -8576,12 +8582,6 @@
       "engines": {
         "node": ">10.17.0"
       }
-    },
-    "node_modules/postgres-range": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
-      "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
-      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -16878,20 +16878,20 @@
         "xtend": "^4.0.0"
       }
     },
-    "postgres-migrations": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/postgres-migrations/-/postgres-migrations-5.3.0.tgz",
-      "integrity": "sha512-gnTHWJZVWbW8T3mXIxJm1JRU853TqBVWkhgfsTJr7zqT3VexjRmJj9kNi96rVhfTezDU4FVW6pf701kLOZiKIA==",
-      "requires": {
-        "pg": "^8.6.0",
-        "sql-template-strings": "^2.2.2"
-      }
-    },
     "postgres-range": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
       "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
       "dev": true
+    },
+    "postgres-schema-migrations": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-schema-migrations/-/postgres-schema-migrations-6.1.0.tgz",
+      "integrity": "sha512-d1LJ+A9Lg4kAwuh91S8ozF8q3adFNJlStbpUF/sbjMTzSIzJClpmg4D6qyd9nvKt2el0rnZJjXZQ2r01Y5OpzA==",
+      "requires": {
+        "pg": "^8.6.0",
+        "sql-template-strings": "^2.2.2"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "jwks-rsa": "^3.1.0",
     "pino": "^8.16.2",
     "pino-http": "^8.5.1",
-    "postgres-migrations": "^5.3.0",
+    "postgres-schema-migrations": "^6.1.0",
     "require-env-variable": "^4.0.2",
     "swagger-ui-express": "^5.0.0",
     "tinypg": "^7.0.0",

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -1,13 +1,14 @@
 import path from 'path';
-import { migrate as pgMigrate } from 'postgres-migrations';
+import { migrate as pgMigrate } from 'postgres-schema-migrations';
 import { db } from './db';
 
-export const migrate = async (): Promise<void> => {
+export const migrate = async (schema = 'public'): Promise<void> => {
   const client = await db.getClient();
   try {
     await pgMigrate(
       { client },
       path.resolve(__dirname, 'migrations'),
+      { schema },
     );
   } finally {
     client.release();

--- a/src/test/harnessFunctions.ts
+++ b/src/test/harnessFunctions.ts
@@ -40,7 +40,7 @@ export const prepareDatabaseForCurrentWorker = async (): Promise<void> => {
   const schemaName = getSchemaNameForCurrentTestWorker();
   await createSchema(schemaName);
   await setSchema(schemaName);
-  await migrate();
+  await migrate(schemaName);
 };
 
 export const cleanupDatabaseForCurrentWorker = async (): Promise<void> => {


### PR DESCRIPTION
This PR replaces our migration tool with one that supports multiple schemas, and utilizes that tool when running tests.

Resolves #609