### PR TITLE
Revert "Build(deps-dev): bump typescript from 5.2.2 to 5.3.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "swagger-spec-validator": "^5.0.0",
         "ts-jest": "^28.0.5",
         "ts-node": "^10.8.1",
-        "typescript": "^5.3.2"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": "18"
@@ -9509,9 +9509,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -17104,9 +17104,9 @@
       }
     },
     "typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "swagger-spec-validator": "^5.0.0",
     "ts-jest": "^28.0.5",
     "ts-node": "^10.8.1",
-    "typescript": "^5.3.2"
+    "typescript": "^5.2.2"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.454.0",


### PR DESCRIPTION
TypeScript 5.3 seems to break ts-node:

- https://github.com/TypeStrong/ts-node/issues/2076
- https://github.com/microsoft/TypeScript/issues/56492

Reverts PhilanthropyDataCommons/service#621