### PR TITLE
Log database migrations

### DIFF
--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -1,7 +1,10 @@
 import path from 'path';
 import { migrate as pgMigrate } from 'postgres-schema-migrations';
 import { runJobQueueMigrations } from '../jobQueue';
+import { getLogger } from '../logger';
 import { db } from './db';
+
+const logger = getLogger(__filename);
 
 export const migrate = async (schema = 'public'): Promise<void> => {
   const client = await db.getClient();
@@ -9,7 +12,10 @@ export const migrate = async (schema = 'public'): Promise<void> => {
     await pgMigrate(
       { client },
       path.resolve(__dirname, 'migrations'),
-      { schema },
+      {
+        logger: (msg) => logger.info(msg),
+        schema,
+      },
     );
     await runJobQueueMigrations();
   } finally {


### PR DESCRIPTION
Our database migration manager supports logging progress by passing in a simple logging function. Call it with our logger so that we can see fine-grain migration progress detail.

Inspired by reviewing #630 (where we discussed logging for graphile-worker) and #639 (which introduces a database migration).

Example output:

```
$ npm run migrate:dev

> @pdc/service@0.3.0 migrate:dev
> ts-node -r dotenv/config src/scripts/migrate.ts | pino-pretty

[2023-11-30T00:08:15.855Z] INFO (378990): Starting migrations...
    source: "src/scripts/migrate.ts"
[2023-11-30T00:08:15.862Z] INFO (378990): Loading migrations from: src/database/migrations
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.863Z] INFO (378990): Found migration files: 0001-create-canonical_fields.sql,0002-create-opportunities.sql,0003-create-applicants.sql,0004-create-application_forms.sql,0005-create-application_form_fields.sql,0006-create-proposals.sql,0007-create-proposal_versions.sql,0008-create-proposal_field_values.sql,0009-alter-proposal_field_values-position.sql,0010-alter-proposal_field_values-value_search.sql,0011-rename-canonical_fields.sql,0012-create-platform_provider_responses.sql,0013-create-bulk_uploads.sql,0014-alter-base_fields-description.sql
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.865Z] INFO (378990): Acquiring advisory lock...
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.866Z] INFO (378990): ... acquired advisory lock
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.866Z] INFO (378990): Starting migrations
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.868Z] INFO (378990): Migrations table with name 'public.migrations' exists, filtering not applied migrations.
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.870Z] INFO (378990): Starting migration: 14 alter-base_fields-description
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.870Z] INFO (378990): Running migration in transaction: true
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.879Z] INFO (378990): Ran migration 0014-alter-base_fields-description.sql
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.879Z] INFO (378990): Saving migration to 'public.migrations': 14 | alter-base_fields-description | bb14a65dd01bb6fd3132e2125d4c838bc94be3af
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.880Z] INFO (378990): inserted migration in migrations tablepublic.migrations
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.880Z] INFO (378990): Finished migration: 14 alter-base_fields-description
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.880Z] INFO (378990): Successfully applied migrations: alter-base_fields-description
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.880Z] INFO (378990): Finished migrations
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.880Z] INFO (378990): Releasing advisory lock...
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.882Z] INFO (378990): ... released advisory lock
    source: "src/database/migrate.ts"
[2023-11-30T00:08:15.883Z] INFO (378990): Migrations complete.
    source: "src/scripts/migrate.ts"
```