### PR TITLE
Add prefix to presigned posts

### DIFF
--- a/src/handlers/presignedPostRequestsHandlers.ts
+++ b/src/handlers/presignedPostRequestsHandlers.ts
@@ -24,7 +24,7 @@ const generatePresignedPost = async (
   s3Client,
   {
     Bucket: S3_BUCKET,
-    Key: `${uuidv4()}`,
+    Key: `unprocessed/${uuidv4()}`,
     Expires: 3600, // 1 hour
     Conditions: [
       ['eq', '$Content-Type', fileType],

--- a/src/handlers/presignedPostRequestsHandlers.ts
+++ b/src/handlers/presignedPostRequestsHandlers.ts
@@ -20,18 +20,18 @@ const {
 const generatePresignedPost = async (
   fileType: string,
   fileSize: number,
-): Promise<PresignedPost> => {
-  const key = `${uuidv4()}`;
-  return createPresignedPost(s3Client, {
+): Promise<PresignedPost> => createPresignedPost(
+  s3Client,
+  {
     Bucket: S3_BUCKET,
-    Key: key,
+    Key: `${uuidv4()}`,
     Expires: 3600, // 1 hour
     Conditions: [
       ['eq', '$Content-Type', fileType],
       ['content-length-range', fileSize, fileSize],
     ],
-  });
-};
+  },
+);
 
 const createPresignedPostRequest = (
   req: Request,


### PR DESCRIPTION
The presigned post API determines the key of the object that the client will upload to S3. Previously, the intent was to have separate buckets for processed and unprocessed files, but we later decided to have only a single bucket for both. That change was partially implemented by PR #635, but that PR did not update the key generation.

Add a prefix to the object keys generated by the presigned post API, both to keep the objects in our bucket better organized, and to allow us to (later) implement a object lifecycle policy that will automatically delete old unprocessed objects.

Issue https://github.com/PhilanthropyDataCommons/service/issues/564 Create "buckets" on DigitalOcean for file upload
Issue https://github.com/PhilanthropyDataCommons/service/issues/597 Expire unregistered uploads