### PR TITLE
Log task errors

### DIFF
--- a/src/jobQueue.ts
+++ b/src/jobQueue.ts
@@ -19,19 +19,19 @@ export const jobQueueLogger = new Logger((scope) => (
   (level, message, meta) => {
     switch (level.valueOf()) {
       case 'error':
-        logger.error({ meta, scope }, message);
+        logger.error({ ...meta, scope }, message);
         break;
       case 'warn':
-        logger.warn({ meta, scope }, message);
+        logger.warn({ ...meta, scope }, message);
         break;
       case 'info':
-        logger.info({ meta, scope }, message);
+        logger.info({ ...meta, scope }, message);
         break;
       case 'debug':
-        logger.debug({ meta, scope }, message);
+        logger.debug({ ...meta, scope }, message);
         break;
       default:
-        logger.info({ meta, scope }, message);
+        logger.info({ ...meta, scope }, message);
     }
   }
 ));

--- a/src/tasks/processBulkUpload.ts
+++ b/src/tasks/processBulkUpload.ts
@@ -366,17 +366,17 @@ export const processBulkUpload = async (
         },
       ));
     });
-  } catch (error) {
-    helpers.logger.info('Bulk upload is being marked as failed', { error });
+  } catch (err) {
+    helpers.logger.info('Bulk upload is being marked as failed', { err });
     await updateBulkUploadStatus(bulkUpload.id, BulkUploadStatus.FAILED);
     return;
   }
   try {
     await bulkUploadFile.cleanup();
-  } catch (error) {
+  } catch (err) {
     helpers.logger.warn(
       `Cleanup of a temporary file failed (${bulkUploadFile.path})`,
-      { error },
+      { err },
     );
   }
   await updateBulkUploadStatus(bulkUpload.id, BulkUploadStatus.COMPLETED);


### PR DESCRIPTION
[Pino has special handling for logging `Error`s provided under the key `err`](https://github.com/pinojs/pino/blob/HEAD/docs/api.md#errors). Update the logger we're creating for the task to flatten the object passed to the graphile-worker logger into Pino's `mergingObject`, and update the errors we're catching and logging to use the special key name Pino expects.

Before:

```
[2023-12-09T01:10:37.993Z] INFO (701308): Bulk upload is being marked as failed
    source: "src/jobQueue.ts"
    meta: {
      "error": {}
    }
    scope: {
      "label": "job",
      "workerId": "worker-8d82e5200d2411e6e6",
      "taskIdentifier": "processBulkUpload",
      "jobId": "7"
    }
```

After:

```
[2023-12-09T01:13:23.148Z] INFO (702898): Bulk upload is being marked as failed
    source: "src/jobQueue.ts"
    scope: {
      "label": "job",
      "workerId": "worker-b6d03352b45f725521",
      "taskIdentifier": "processBulkUpload",
      "jobId": "8"
    }
    err: {
      "type": "Error",
      "message": " organization_phone is not a valid BaseField short code.",
      "stack":
          Error:  organization_phone is not a valid BaseField short code.
              at src/tasks/processBulkUpload.ts:131:13
              at Array.forEach (<anonymous>)
              at assertShortCodesAreValid (src/tasks/processBulkUpload.ts:126:14)
              at processTicksAndRejections (node:internal/process/task_queues:95:5)
              at async assertCsvContainsValidShortCodes (src/tasks/processBulkUpload.ts:141:3)
              at async assertBulkUploadCsvIsValid (src/tasks/processBulkUpload.ts:159:3)
              at async processBulkUpload (src/tasks/processBulkUpload.ts:317:5)
              at async doNext (node_modules/graphile-worker/src/worker.ts:214:18)
    }
```

(I originally made this change against #658 to help me test it, but am targeting `main` with this PR. There will be merge conflicts with #658, whichever is merged second.)