### PR TITLE
Move processed csvs to final destination after processing

### DIFF
--- a/src/database/queries/bulkUploads/updateSourceKeyById.sql
+++ b/src/database/queries/bulkUploads/updateSourceKeyById.sql
@@ -1,0 +1,3 @@
+UPDATE bulk_uploads SET
+  source_key = :sourceKey
+WHERE id = :id

--- a/src/handlers/bulkUploadsHandlers.ts
+++ b/src/handlers/bulkUploadsHandlers.ts
@@ -1,4 +1,7 @@
 import {
+  S3_UNPROCESSED_KEY_PREFIX,
+} from '../s3Client';
+import {
   db,
   getLimitValues,
   loadBulkUploadBundle,
@@ -41,9 +44,9 @@ const createBulkUpload = (
     return;
   }
 
-  if (!body.sourceKey.startsWith('unprocessed/')) {
+  if (!body.sourceKey.startsWith(`${S3_UNPROCESSED_KEY_PREFIX}/`)) {
     next(new InputValidationError(
-      'sourceKey must be unprocessed, and begin with `unprocessed/`.',
+      `sourceKey must be unprocessed, and begin with '${S3_UNPROCESSED_KEY_PREFIX}/'.`,
       [],
     ));
     return;

--- a/src/s3Client.ts
+++ b/src/s3Client.ts
@@ -26,3 +26,4 @@ export const s3Client = new S3({
 });
 
 export const S3_UNPROCESSED_KEY_PREFIX = 'unprocessed';
+export const S3_BULK_UPLOADS_KEY_PREFIX = 'bulk-uploads';

--- a/src/s3Client.ts
+++ b/src/s3Client.ts
@@ -24,3 +24,5 @@ export const s3Client = new S3({
     secretAccessKey: S3_ACCESS_SECRET,
   },
 });
+
+export const S3_UNPROCESSED_KEY_PREFIX = 'unprocessed';

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -429,7 +429,6 @@ describe('processBulkUpload', () => {
       },
       {
         applicationFormFieldId: 2,
-        id: 2,
         position: 1,
         proposalVersionId: firstProposalVersion.id,
         value: 'Foo LLC.',

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -23,6 +23,8 @@ const {
   'S3_PATH_STYLE',
 );
 
+const TEST_UNPROCESSED_SOURCE_KEY = 'unprocessed/550e8400-e29b-41d4-a716-446655440000';
+
 const getS3Endpoint = async () => {
   if (s3Client.config.endpoint === undefined) {
     throw new Error('The S3 client is not configured with an endpoint');
@@ -49,7 +51,7 @@ const getS3KeyPath = (key: string) => (
 const createTestBulkUpload = async (overrideValues?: Partial<BulkUpload>): Promise<BulkUpload> => {
   const defaultValues = {
     fileName: 'bar.csv',
-    sourceKey: '550e8400-e29b-41d4-a716-446655440000',
+    sourceKey: TEST_UNPROCESSED_SOURCE_KEY,
     status: BulkUploadStatus.PENDING,
   };
   const bulkUploadsQueryResult = await db.sql<BulkUpload>('bulkUploads.insertOne', {
@@ -144,7 +146,7 @@ const getProposalsByExternalIds = async (externalIds: string[]): Promise<Proposa
 
 describe('processBulkUpload', () => {
   it('should attempt to access the contents of the sourceKey associated with the specified bulk upload', async () => {
-    const sourceKey = 'unprocessed/550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
       sourceKey,
@@ -161,7 +163,7 @@ describe('processBulkUpload', () => {
 
   it('should attempt to copy the contents of the sourceKey associated with the specified bulk upload to a processed location', async () => {
     await createTestBaseFields();
-    const sourceKey = 'unprocessed/550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
       sourceKey,
@@ -178,7 +180,7 @@ describe('processBulkUpload', () => {
 
   it('should attempt to delete the unprocessed file of the sourceKey associated with the specified bulk upload', async () => {
     await createTestBaseFields();
-    const sourceKey = 'unprocessed/550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
       sourceKey,
@@ -194,7 +196,7 @@ describe('processBulkUpload', () => {
   });
 
   it('should set the status of the upload to FAILED if the sourceKey is not accessible', async () => {
-    const sourceKey = '550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const sourceRequest = nock(await getS3Endpoint())
       .get(getS3KeyPath(sourceKey))
@@ -213,7 +215,7 @@ describe('processBulkUpload', () => {
 
   it('should set the status of the upload to FAILED if the csv does not have a proposal_submitter_email field', async () => {
     await createTestBaseFields();
-    const sourceKey = '550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     await mockS3ResponsesForBulkUploadProcessing(
       sourceKey,
@@ -232,7 +234,7 @@ describe('processBulkUpload', () => {
 
   it('should move the csv file to processed location if the csv does not have a proposal_submitter_email field', async () => {
     await createTestBaseFields();
-    const sourceKey = '550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
       sourceKey,
@@ -251,7 +253,7 @@ describe('processBulkUpload', () => {
 
   it('should set the status of the upload to FAILED if the csv contains an invalid short code', async () => {
     await createTestBaseFields();
-    const sourceKey = '550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     await mockS3ResponsesForBulkUploadProcessing(
       sourceKey,
@@ -269,7 +271,7 @@ describe('processBulkUpload', () => {
 
   it('should move the csv file to processed location if the csv contains an invalid short code', async () => {
     await createTestBaseFields();
-    const sourceKey = '550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
       sourceKey,
@@ -287,7 +289,7 @@ describe('processBulkUpload', () => {
 
   it('should set the status of the upload to FAILED if the csv is empty', async () => {
     await createTestBaseFields();
-    const sourceKey = '550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     await mockS3ResponsesForBulkUploadProcessing(
       sourceKey,
@@ -306,7 +308,7 @@ describe('processBulkUpload', () => {
 
   it('should download, process, and resolve the bulk upload if the sourceKey is accessible and contains a valid CSV bulk upload', async () => {
     await createTestBaseFields();
-    const sourceKey = '550e8400-e29b-41d4-a716-446655440000';
+    const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
       sourceKey,

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import nock from 'nock';
 import { requireEnv } from 'require-env-variable';
 import {
@@ -105,18 +104,17 @@ const mockS3DeleteObjectReply = async (sourceKey: string) => nock(await getS3End
   .reply(204);
 
 const mockS3ResponsesForBulkUploadProcessing = async (
-  sourceKey: string,
+  bulkUpload: BulkUpload,
   bulkUploadFilePath: string,
 ) => {
-  const keyBasename = path.basename(sourceKey);
   const getRequest = await mockS3GetObjectReplyWithFile(
-    sourceKey,
+    bulkUpload.sourceKey,
     bulkUploadFilePath,
   );
   const copyRequest = await mockS3CopyObjectReply(
-    `bulk-uploads/${keyBasename}`,
+    `bulk-uploads/${bulkUpload.id}`,
   );
-  const deleteRequest = await mockS3DeleteObjectReply(sourceKey);
+  const deleteRequest = await mockS3DeleteObjectReply(bulkUpload.sourceKey);
   return {
     getRequest,
     copyRequest,
@@ -149,7 +147,7 @@ describe('processBulkUpload', () => {
     const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
-      sourceKey,
+      bulkUpload,
       `${__dirname}/fixtures/processBulkUpload/validCsvTemplate.csv`,
     );
     await processBulkUpload(
@@ -166,7 +164,7 @@ describe('processBulkUpload', () => {
     const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
-      sourceKey,
+      bulkUpload,
       `${__dirname}/fixtures/processBulkUpload/validCsvTemplate.csv`,
     );
     await processBulkUpload(
@@ -183,7 +181,7 @@ describe('processBulkUpload', () => {
     const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
-      sourceKey,
+      bulkUpload,
       `${__dirname}/fixtures/processBulkUpload/validCsvTemplate.csv`,
     );
     await processBulkUpload(
@@ -218,7 +216,7 @@ describe('processBulkUpload', () => {
     const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     await mockS3ResponsesForBulkUploadProcessing(
-      sourceKey,
+      bulkUpload,
       `${__dirname}/fixtures/processBulkUpload/missingEmail.csv`,
     );
 
@@ -237,7 +235,7 @@ describe('processBulkUpload', () => {
     const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
-      sourceKey,
+      bulkUpload,
       `${__dirname}/fixtures/processBulkUpload/missingEmail.csv`,
     );
 
@@ -256,7 +254,7 @@ describe('processBulkUpload', () => {
     const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     await mockS3ResponsesForBulkUploadProcessing(
-      sourceKey,
+      bulkUpload,
       `${__dirname}/fixtures/processBulkUpload/invalidShortCode.csv`,
     );
     await processBulkUpload(
@@ -274,7 +272,7 @@ describe('processBulkUpload', () => {
     const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
-      sourceKey,
+      bulkUpload,
       `${__dirname}/fixtures/processBulkUpload/invalidShortCode.csv`,
     );
     await processBulkUpload(
@@ -292,7 +290,7 @@ describe('processBulkUpload', () => {
     const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     await mockS3ResponsesForBulkUploadProcessing(
-      sourceKey,
+      bulkUpload,
       `${__dirname}/fixtures/processBulkUpload/empty.csv`,
     );
 
@@ -311,7 +309,7 @@ describe('processBulkUpload', () => {
     const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
     const bulkUpload = await createTestBulkUpload({ sourceKey });
     const requests = await mockS3ResponsesForBulkUploadProcessing(
-      sourceKey,
+      bulkUpload,
       `${__dirname}/fixtures/processBulkUpload/validCsvTemplate.csv`,
     );
 

--- a/src/tasks/processBulkUpload.ts
+++ b/src/tasks/processBulkUpload.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import fs from 'fs';
 import { finished } from 'stream/promises';
 import { parse } from 'csv-parse';
@@ -318,9 +317,10 @@ const createProposalFieldValueForBulkUploadCsvRecord = async (
   return proposalFieldValue;
 };
 
-const getProcessedKey = (unprocessedKey: string): string => (
-  `${S3_BULK_UPLOADS_KEY_PREFIX}/${path.basename(unprocessedKey)}`
-
+const getProcessedKey = (
+  bulkUpload: BulkUpload,
+): string => (
+  `${S3_BULK_UPLOADS_KEY_PREFIX}/${bulkUpload.id}`
 );
 
 export const processBulkUpload = async (
@@ -412,7 +412,7 @@ export const processBulkUpload = async (
 
   try {
     const copySource = `${S3_BUCKET}/${bulkUpload.sourceKey}`;
-    const copyDestination = getProcessedKey(bulkUpload.sourceKey);
+    const copyDestination = getProcessedKey(bulkUpload);
     await s3Client.copyObject({
       Bucket: S3_BUCKET,
       CopySource: copySource,

--- a/src/tasks/processBulkUpload.ts
+++ b/src/tasks/processBulkUpload.ts
@@ -79,10 +79,10 @@ const downloadS3ObjectToTemporaryStorage = async (
     if (s3Response.Body === undefined) {
       throw new Error('S3 did not return a body');
     }
-  } catch (error) {
+  } catch (err) {
     logger.error(
       'Failed to load an object from S3',
-      { error, key },
+      { err, key },
     );
     await temporaryFile.cleanup();
     throw new Error('Unable to load the s3 object');
@@ -318,6 +318,13 @@ export const processBulkUpload = async (
       bulkUpload.sourceKey,
       helpers.logger,
     );
+  } catch (err) {
+    helpers.logger.warn('Download of bulk upload file from S3 failed', { err });
+    await updateBulkUploadStatus(bulkUpload.id, BulkUploadStatus.FAILED);
+    return;
+  }
+
+  try {
     await assertBulkUploadCsvIsValid(bulkUploadFile.path);
     const opportunity = await createOpportunityForBulkUpload(bulkUpload);
     const applicationForm = await createApplicationFormForBulkUpload(opportunity.id);

--- a/src/test/integrationSuiteSetup.ts
+++ b/src/test/integrationSuiteSetup.ts
@@ -1,3 +1,4 @@
+import nock from 'nock';
 /**
  * This file is loaded by jest, as specified by the integration test jest configuration file
  * via `setupFilesAfterEnv`.
@@ -20,20 +21,18 @@ import { mockJwks } from './mockJwt';
 // setting the schema / path.
 jest.mock('graphile-worker');
 
-beforeAll(async () => {
-  mockJwks.start();
-});
-
 afterAll(async () => {
-  mockJwks.stop();
   await db.close();
 });
 
 beforeEach(async () => {
+  mockJwks.start();
   await prepareDatabaseForCurrentWorker();
 });
 
 afterEach(async () => {
   await cleanupDatabaseForCurrentWorker();
   jest.restoreAllMocks();
+  mockJwks.stop();
+  nock.cleanAll();
 });


### PR DESCRIPTION
This PR adds logic to move processed CSV upload files to a final destination after the processing is complete.  As part of this PR I had to think a little harder about what to do with data in various failure cases.

You'll see that data is moved to a permanent location even in the failure cases UNLESS the failure was due to being unable to access the S3 file.

This PR also updates the retry logic in the case of being unable to download the file from S3.

Resolves #678 