### PR TITLE
Remove auth check for GET `/baseFields`

### DIFF
--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -26,7 +26,6 @@ describe('/baseFields', () => {
     it('returns an empty array when no data is present', async () => {
       await agent
         .get('/baseFields')
-        .set(authHeader)
         .expect(200, []);
     });
 
@@ -45,7 +44,6 @@ describe('/baseFields', () => {
       });
       const result = await agent
         .get('/baseFields')
-        .set(authHeader)
         .expect(200);
       expect(result.body).toMatchObject([
         {
@@ -74,7 +72,6 @@ describe('/baseFields', () => {
         });
       const result = await agent
         .get('/baseFields')
-        .set(authHeader)
         .expect(500);
       expect(result.body).toMatchObject({
         name: 'UnknownError',
@@ -97,7 +94,6 @@ describe('/baseFields', () => {
         });
       const result = await agent
         .get('/baseFields')
-        .set(authHeader)
         .expect(503);
       expect(result.body).toMatchObject({
         name: 'DatabaseError',

--- a/src/routers/baseFieldsRouter.ts
+++ b/src/routers/baseFieldsRouter.ts
@@ -4,7 +4,7 @@ import { verifyJwt as verifyAuth } from '../middleware/verifyJwt';
 
 const baseFieldsRouter = express.Router();
 
-baseFieldsRouter.get('/', verifyAuth, baseFieldsHandlers.getBaseFields);
+baseFieldsRouter.get('/', baseFieldsHandlers.getBaseFields);
 baseFieldsRouter.post('/', verifyAuth, baseFieldsHandlers.postBaseField);
 baseFieldsRouter.put('/:id', verifyAuth, baseFieldsHandlers.putBaseField);
 


### PR DESCRIPTION
This PR removes the authorization check when accessing `GET /baseFields`

Resolves #702 