### PR TITLE
Remove `dotenv` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
 				"ajv-keywords": "^5.1.0",
 				"cors": "^2.8.5",
 				"csv-parse": "^5.5.3",
-				"dotenv": "^16.3.1",
 				"express": "^4.18.2",
 				"express-jwt": "^8.4.1",
 				"graphile-worker": "^0.16.1",
@@ -4558,17 +4557,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "16.3.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-			"integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/motdotla/dotenv?sponsor=1"
 			}
 		},
 		"node_modules/eastasianwidth": {
@@ -13568,11 +13556,6 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
-		},
-		"dotenv": {
-			"version": "16.3.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-			"integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
 		},
 		"eastasianwidth": {
 			"version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
 		"ajv-keywords": "^5.1.0",
 		"cors": "^2.8.5",
 		"csv-parse": "^5.5.3",
-		"dotenv": "^16.3.1",
 		"express": "^4.18.2",
 		"express-jwt": "^8.4.1",
 		"graphile-worker": "^0.16.1",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,13 +1,5 @@
-import dotenv from 'dotenv';
 import pino from 'pino';
 import type { Logger } from 'pino';
-
-// Calling dotenv.config() prior to creating a logger ensures that environment
-// variable LOG_LEVEL can be loaded from .env files. See
-// https://github.com/PhilanthropyDataCommons/service/issues/59#issuecomment-1197227254
-// and following. There may be a better place than including and calling dotenv
-// here in the logger code.
-dotenv.config();
 
 // To prevent replays with JWT, we can redact the signature. This invalidates the JWT.
 export const redactToPreventAuthReplay = (secret: string): string =>

--- a/src/test/globalSetup.ts
+++ b/src/test/globalSetup.ts
@@ -1,18 +1,6 @@
 // Jest expects a single default function to be exported from this file.
 /* eslint-disable import/no-default-export */
-import dotenv from 'dotenv';
 import type { Config } from 'jest';
-
-// TODO: reconsider use of '.env.test' if or when
-// https://github.com/ThomWright/postgres-migrations/pull/93 gets merged/fixed.
-dotenv.config({ path: '.env.test' });
-
-// Production code will run dotenv.config() anyway, so make clear that it
-// happens by running the same explicitly here. If '.env.test' has any variables
-// set, they will override the later/inner set variables such as those in the
-// '.env' file. There might be a better way to manage 'dotenv' and pino logger
-// setup.
-dotenv.config();
 
 export default (globalConfig: Config, projectConfig: Config): void => {
 	if (


### PR DESCRIPTION
This PR removes dotenv from the repository.  Developers who don't want to manually source their `.env` file might consider populating required variables themselves using a tool like [direnv](https://direnv.net/).

To test:

0. make sure your environment variables are loaded into your shell (`source .env`)
1. run `npm i`
2. idk man... uh... run tests? or run the program?
3. yeah that's it!  run `npm run test`
4. run `npm run start:dev`

Resolves #640