### PR TITLE
Add file size to bulk uploads

### DIFF
--- a/src/__tests__/bulkUploads.int.test.ts
+++ b/src/__tests__/bulkUploads.int.test.ts
@@ -38,6 +38,7 @@ describe('GET /bulkUploads', () => {
 						{
 							id: 2,
 							fileName: 'bar.csv',
+							fileSize: null,
 							sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 							status: BulkUploadStatus.COMPLETED,
 							createdAt: expectTimestamp,
@@ -45,6 +46,7 @@ describe('GET /bulkUploads', () => {
 						{
 							id: 1,
 							fileName: 'foo.csv',
+							fileSize: null,
 							sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 							status: BulkUploadStatus.PENDING,
 							createdAt: expectTimestamp,
@@ -79,6 +81,7 @@ describe('GET /bulkUploads', () => {
 						{
 							id: 15,
 							fileName: 'bar-15.csv',
+							fileSize: null,
 							sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 							status: BulkUploadStatus.COMPLETED,
 							createdAt: expectTimestamp,
@@ -86,6 +89,7 @@ describe('GET /bulkUploads', () => {
 						{
 							id: 14,
 							fileName: 'bar-14.csv',
+							fileSize: null,
 							sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 							status: BulkUploadStatus.COMPLETED,
 							createdAt: expectTimestamp,
@@ -93,6 +97,7 @@ describe('GET /bulkUploads', () => {
 						{
 							id: 13,
 							fileName: 'bar-13.csv',
+							fileSize: null,
 							sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 							status: BulkUploadStatus.COMPLETED,
 							createdAt: expectTimestamp,
@@ -100,6 +105,7 @@ describe('GET /bulkUploads', () => {
 						{
 							id: 12,
 							fileName: 'bar-12.csv',
+							fileSize: null,
 							sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 							status: BulkUploadStatus.COMPLETED,
 							createdAt: expectTimestamp,
@@ -107,6 +113,7 @@ describe('GET /bulkUploads', () => {
 						{
 							id: 11,
 							fileName: 'bar-11.csv',
+							fileSize: null,
 							sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 							status: BulkUploadStatus.COMPLETED,
 							createdAt: expectTimestamp,

--- a/src/database/migrations/0016-alter-bulk_uploads-file_size.sql
+++ b/src/database/migrations/0016-alter-bulk_uploads-file_size.sql
@@ -1,0 +1,5 @@
+ALTER TABLE bulk_uploads
+  ADD COLUMN file_size INTEGER;
+
+COMMENT ON COLUMN bulk_uploads.file_size IS
+  'The file size, in bytes, of a bulk upload CSV.';

--- a/src/database/operations/load/loadObjects.ts
+++ b/src/database/operations/load/loadObjects.ts
@@ -9,7 +9,6 @@ export const loadObjects = async <T extends object>(
 	objectValidator: ValidateFunction<T>,
 ): Promise<T[]> => {
 	const { rows } = await db.sql<T>(tinyPgQueryName, tinyPgQueryParameters);
-
 	rows.forEach((row) => {
 		if (!objectValidator(row)) {
 			throw new InternalValidationError(

--- a/src/database/queries/bulkUploads/insertOne.sql
+++ b/src/database/queries/bulkUploads/insertOne.sql
@@ -13,4 +13,5 @@ RETURNING
   file_name as "fileName",
   source_key as "sourceKey",
   status as "status",
+  file_size as "fileSize",
   created_at AS "createdAt"

--- a/src/database/queries/bulkUploads/selectById.sql
+++ b/src/database/queries/bulkUploads/selectById.sql
@@ -3,6 +3,7 @@ SELECT
   file_name as "fileName",
   source_key as "sourceKey",
   status as "status",
+  file_size as "fileSize",
   created_at AS "createdAt"
 FROM bulk_uploads
 WHERE id = :id;

--- a/src/database/queries/bulkUploads/selectWithPagination.sql
+++ b/src/database/queries/bulkUploads/selectWithPagination.sql
@@ -3,6 +3,7 @@ SELECT
   file_name as "fileName",
   source_key as "sourceKey",
   status as "status",
+  file_size as "fileSize",
   created_at AS "createdAt"
 FROM bulk_uploads
 ORDER BY id DESC

--- a/src/database/queries/bulkUploads/updateFileSizeById.sql
+++ b/src/database/queries/bulkUploads/updateFileSizeById.sql
@@ -1,0 +1,3 @@
+UPDATE bulk_uploads SET
+  file_size = :fileSize
+WHERE id = :id

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -95,6 +95,14 @@
 						"example": "upload.csv",
 						"pattern": "^.+\\.csv$"
 					},
+					"fileSize": {
+						"description": "File size in bytes",
+						"type": "integer",
+						"nullable": true,
+						"readOnly": true,
+						"example": 42,
+						"minimum": 0
+					},
 					"sourceKey": {
 						"type": "string",
 						"example": "550e8400-e29b-41d4-a716-446655440000",

--- a/src/types/BulkUpload.ts
+++ b/src/types/BulkUpload.ts
@@ -14,6 +14,7 @@ export interface BulkUpload {
 	fileName: string;
 	sourceKey: string;
 	status: BulkUploadStatus;
+	fileSize?: number | null; // see https://github.com/ajv-validator/ajv/issues/2163
 	readonly createdAt: Date;
 }
 
@@ -32,6 +33,10 @@ export const bulkUploadSchema: JSONSchemaType<BulkUpload> = {
 		status: {
 			type: 'string',
 		},
+		fileSize: {
+			type: 'integer',
+			nullable: true,
+		},
 		createdAt: {
 			type: 'object',
 			required: [],
@@ -43,7 +48,10 @@ export const bulkUploadSchema: JSONSchemaType<BulkUpload> = {
 
 export const isBulkUpload = ajv.compile(bulkUploadSchema);
 
-export type BulkUploadCreate = Omit<BulkUpload, 'createdAt' | 'status' | 'id'>;
+export type BulkUploadCreate = Omit<
+	BulkUpload,
+	'createdAt' | 'status' | 'id' | 'fileSize'
+>;
 
 export const bulkUploadCreateSchema: JSONSchemaType<BulkUploadCreate> = {
 	type: 'object',


### PR DESCRIPTION
This PR adds the `fileSize` attribute to our `BulkUpload` entity.

It also updates the bulk upload processing task to actually populate the value.

Resolves #697