### PR TITLE
Add `operationId` to operations

### DIFF
--- a/src/openapi.json
+++ b/src/openapi.json
@@ -484,6 +484,7 @@
 	"paths": {
 		"/applicants": {
 			"get": {
+				"operationId": "getApplicants",
 				"summary": "Get a list of applicants.",
 				"tags": ["Applicants"],
 				"security": [
@@ -518,6 +519,7 @@
 				}
 			},
 			"post": {
+				"operationId": "addApplicant",
 				"summary": "Add a new applicant.",
 				"tags": ["Applicants"],
 				"security": [
@@ -561,6 +563,7 @@
 		},
 		"/applicants/{externalId}": {
 			"get": {
+				"operationId": "getApplicantByExternalId",
 				"summary": "Get a specific applicant, including all known field values associated with the applicant. (In Development)",
 				"tags": ["Applicants"],
 				"security": [
@@ -605,6 +608,7 @@
 		},
 		"/applicationForms": {
 			"get": {
+				"operationId": "getApplicationForms",
 				"summary": "Get a list of application forms.",
 				"tags": ["Application Forms"],
 				"security": [
@@ -642,6 +646,7 @@
 				}
 			},
 			"post": {
+				"operationId": "addApplicationForm",
 				"summary": "Add a new application form.",
 				"tags": ["Application Forms"],
 				"security": [
@@ -695,6 +700,7 @@
 		},
 		"/applicationForms/{applicationFormId}": {
 			"get": {
+				"operationId": "getApplicationFormById",
 				"summary": "Get a specific application form.",
 				"tags": ["Application Forms"],
 				"security": [
@@ -771,6 +777,7 @@
 		},
 		"/bulkUploads": {
 			"get": {
+				"operationId": "getBulkUploads",
 				"summary": "Get a list of bulk uploads.",
 				"tags": ["Bulk Uploads"],
 				"security": [
@@ -806,6 +813,7 @@
 				}
 			},
 			"post": {
+				"operationId": "addBulkUpload",
 				"summary": "Register a bulk upload.",
 				"tags": ["Bulk Uploads"],
 				"security": [
@@ -849,6 +857,7 @@
 		},
 		"/presignedPostRequests": {
 			"post": {
+				"operationId": "addPresignedPostRequest",
 				"summary": "Request a presigned post URL.",
 				"tags": ["Presigned Posts"],
 				"security": [
@@ -892,6 +901,7 @@
 		},
 		"/proposals": {
 			"get": {
+				"operationId": "getProposals",
 				"summary": "Get a list of proposals.",
 				"tags": ["Proposals"],
 				"security": [
@@ -928,6 +938,7 @@
 				}
 			},
 			"post": {
+				"operationId": "addProposal",
 				"summary": "Add a new proposal.",
 				"tags": ["Proposals"],
 				"security": [
@@ -981,6 +992,7 @@
 		},
 		"/proposals/{proposalId}": {
 			"get": {
+				"operationId": "getProposalById",
 				"summary": "Get a specific proposal.",
 				"tags": ["Proposals"],
 				"security": [
@@ -1073,6 +1085,7 @@
 		},
 		"/proposalVersions": {
 			"post": {
+				"operationId": "addProposalVersion",
 				"summary": "Add a new proposal version.",
 				"tags": ["Proposals"],
 				"security": [
@@ -1126,6 +1139,7 @@
 		},
 		"/baseFields": {
 			"get": {
+				"operationId": "getBaseFields",
 				"summary": "Get a list of base fields.",
 				"tags": ["Base Fields"],
 				"security": [
@@ -1150,6 +1164,7 @@
 				}
 			},
 			"post": {
+				"operationId": "addBaseField",
 				"summary": "Add a new base field.",
 				"tags": ["Base Fields"],
 				"security": [
@@ -1203,6 +1218,7 @@
 		},
 		"/baseFields/{baseFieldId}": {
 			"put": {
+				"operationId": "updateBaseFieldById",
 				"summary": "Update a base field.",
 				"tags": ["Base Fields"],
 				"security": [
@@ -1260,6 +1276,7 @@
 		},
 		"/opportunities": {
 			"get": {
+				"operationId": "getOpportunities",
 				"summary": "Get a list of opportunities.",
 				"tags": ["Opportunities"],
 				"security": [
@@ -1284,6 +1301,7 @@
 				}
 			},
 			"post": {
+				"operationId": "addOpportunity",
 				"summary": "Add a new opportunity. (In Development)",
 				"tags": ["Opportunities"],
 				"security": [
@@ -1327,6 +1345,7 @@
 		},
 		"/opportunities/{opportunityId}": {
 			"get": {
+				"operationId": "getOpportunityById",
 				"summary": "Get a specific opportunity.",
 				"tags": ["Opportunities"],
 				"security": [
@@ -1361,6 +1380,7 @@
 		},
 		"/platformProviderResponses": {
 			"get": {
+				"operationId": "getPlatformProviderResponses",
 				"summary": "Get a list of platform provider responses.",
 				"tags": ["Internal Use Only"],
 				"security": [
@@ -1396,6 +1416,7 @@
 				}
 			},
 			"post": {
+				"operationId": "addPlatformProviderResponse",
 				"summary": "Add a new platform provider response.",
 				"tags": ["Internal Use Only"],
 				"security": [

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -485,7 +485,7 @@
 		"/applicants": {
 			"get": {
 				"operationId": "getApplicants",
-				"summary": "Get a list of applicants.",
+				"summary": "Gets a list of applicants.",
 				"tags": ["Applicants"],
 				"security": [
 					{
@@ -520,7 +520,7 @@
 			},
 			"post": {
 				"operationId": "addApplicant",
-				"summary": "Add a new applicant.",
+				"summary": "Adds a new applicant.",
 				"tags": ["Applicants"],
 				"security": [
 					{
@@ -564,7 +564,7 @@
 		"/applicants/{externalId}": {
 			"get": {
 				"operationId": "getApplicantByExternalId",
-				"summary": "Get a specific applicant, including all known field values associated with the applicant. (In Development)",
+				"summary": "Gets a specific applicant, including all known field values associated with the applicant.",
 				"tags": ["Applicants"],
 				"security": [
 					{
@@ -609,7 +609,7 @@
 		"/applicationForms": {
 			"get": {
 				"operationId": "getApplicationForms",
-				"summary": "Get a list of application forms.",
+				"summary": "Gets a list of application forms.",
 				"tags": ["Application Forms"],
 				"security": [
 					{
@@ -647,7 +647,7 @@
 			},
 			"post": {
 				"operationId": "addApplicationForm",
-				"summary": "Add a new application form.",
+				"summary": "Adds a new application form.",
 				"tags": ["Application Forms"],
 				"security": [
 					{
@@ -701,7 +701,7 @@
 		"/applicationForms/{applicationFormId}": {
 			"get": {
 				"operationId": "getApplicationFormById",
-				"summary": "Get a specific application form.",
+				"summary": "Gets a specific application form.",
 				"tags": ["Application Forms"],
 				"security": [
 					{
@@ -778,7 +778,7 @@
 		"/bulkUploads": {
 			"get": {
 				"operationId": "getBulkUploads",
-				"summary": "Get a list of bulk uploads.",
+				"summary": "Gets a list of bulk uploads.",
 				"tags": ["Bulk Uploads"],
 				"security": [
 					{
@@ -814,7 +814,7 @@
 			},
 			"post": {
 				"operationId": "addBulkUpload",
-				"summary": "Register a bulk upload.",
+				"summary": "Registers a bulk upload.",
 				"tags": ["Bulk Uploads"],
 				"security": [
 					{
@@ -858,7 +858,7 @@
 		"/presignedPostRequests": {
 			"post": {
 				"operationId": "addPresignedPostRequest",
-				"summary": "Request a presigned post URL.",
+				"summary": "Requests a presigned post URL.",
 				"tags": ["Presigned Posts"],
 				"security": [
 					{
@@ -902,7 +902,7 @@
 		"/proposals": {
 			"get": {
 				"operationId": "getProposals",
-				"summary": "Get a list of proposals.",
+				"summary": "Gets a list of proposals.",
 				"tags": ["Proposals"],
 				"security": [
 					{
@@ -939,7 +939,7 @@
 			},
 			"post": {
 				"operationId": "addProposal",
-				"summary": "Add a new proposal.",
+				"summary": "Adds a new proposal.",
 				"tags": ["Proposals"],
 				"security": [
 					{
@@ -993,7 +993,7 @@
 		"/proposals/{proposalId}": {
 			"get": {
 				"operationId": "getProposalById",
-				"summary": "Get a specific proposal.",
+				"summary": "Gets a specific proposal.",
 				"tags": ["Proposals"],
 				"security": [
 					{
@@ -1086,7 +1086,7 @@
 		"/proposalVersions": {
 			"post": {
 				"operationId": "addProposalVersion",
-				"summary": "Add a new proposal version.",
+				"summary": "Adds a new proposal version.",
 				"tags": ["Proposals"],
 				"security": [
 					{
@@ -1140,7 +1140,7 @@
 		"/baseFields": {
 			"get": {
 				"operationId": "getBaseFields",
-				"summary": "Get a list of base fields.",
+				"summary": "Gets a list of base fields.",
 				"tags": ["Base Fields"],
 				"security": [
 					{
@@ -1165,7 +1165,7 @@
 			},
 			"post": {
 				"operationId": "addBaseField",
-				"summary": "Add a new base field.",
+				"summary": "Adds a new base field.",
 				"tags": ["Base Fields"],
 				"security": [
 					{
@@ -1219,7 +1219,7 @@
 		"/baseFields/{baseFieldId}": {
 			"put": {
 				"operationId": "updateBaseFieldById",
-				"summary": "Update a base field.",
+				"summary": "Updates a base field.",
 				"tags": ["Base Fields"],
 				"security": [
 					{
@@ -1277,7 +1277,7 @@
 		"/opportunities": {
 			"get": {
 				"operationId": "getOpportunities",
-				"summary": "Get a list of opportunities.",
+				"summary": "Gets a list of opportunities.",
 				"tags": ["Opportunities"],
 				"security": [
 					{
@@ -1302,7 +1302,7 @@
 			},
 			"post": {
 				"operationId": "addOpportunity",
-				"summary": "Add a new opportunity. (In Development)",
+				"summary": "Adds a new opportunity.",
 				"tags": ["Opportunities"],
 				"security": [
 					{
@@ -1346,7 +1346,7 @@
 		"/opportunities/{opportunityId}": {
 			"get": {
 				"operationId": "getOpportunityById",
-				"summary": "Get a specific opportunity.",
+				"summary": "Gets a specific opportunity.",
 				"tags": ["Opportunities"],
 				"security": [
 					{
@@ -1381,7 +1381,7 @@
 		"/platformProviderResponses": {
 			"get": {
 				"operationId": "getPlatformProviderResponses",
-				"summary": "Get a list of platform provider responses.",
+				"summary": "Gets a list of platform provider responses.",
 				"tags": ["Internal Use Only"],
 				"security": [
 					{
@@ -1417,7 +1417,7 @@
 			},
 			"post": {
 				"operationId": "addPlatformProviderResponse",
-				"summary": "Add a new platform provider response.",
+				"summary": "Adds a new platform provider response.",
 				"tags": ["Internal Use Only"],
 				"security": [
 					{


### PR DESCRIPTION
This PR updates our swagger specification to:

1. Add operation Ids to our operations (these are used in codegen and other places so we want them)
2. Update the conjugation of our summaries!  This doesn't matter but it was easy to do.

Resolves #725