### PR TITLE
Change default port to 3001

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const logger = getLogger(__filename);
 // The .env file is loaded in 'logger' to ensure correct order of events. See
 // more discussion in the 'logger.ts' code.
 
-const port = Number(process.env.PORT ?? 3000);
+const port = Number(process.env.PORT ?? 3001);
 const host = process.env.HOST ?? 'localhost';
 
 app.listen(port, host, () => {


### PR DESCRIPTION
Prior to this change, the server’s default port (when not configured in the env vars) was 3000. This happens to conflict with the default port of the front end — which is set by the `create-react-app` machinery.

While this conflict can be avoided with individual configurations, it makes sense that our stack is internally compatible out of the box.

**Testing:**
1.. Verify your `.env` has no `PORT` configured
2. `> npm run start:dev`
3. ✅ Verify the server is running on localhost:3001

Closes #740