### PR TITLE
Rename `Error` in openapi spec

### DIFF
--- a/src/openapi.json
+++ b/src/openapi.json
@@ -387,7 +387,7 @@
 				},
 				"required": ["id", "label", "shortCode", "dataType", "createdAt"]
 			},
-			"Error": {
+			"PdcError": {
 				"type": "object",
 				"properties": {
 					"message": {
@@ -511,7 +511,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -553,7 +553,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -598,7 +598,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -680,7 +680,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -690,7 +690,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -805,7 +805,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -847,7 +847,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -891,7 +891,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -930,7 +930,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -972,7 +972,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -982,7 +982,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -1119,7 +1119,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -1129,7 +1129,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -1198,7 +1198,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -1208,7 +1208,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -1263,7 +1263,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -1335,7 +1335,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -1450,7 +1450,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}
@@ -1460,7 +1460,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Error"
+									"$ref": "#/components/schemas/PdcError"
 								}
 							}
 						}


### PR DESCRIPTION
The `Error` schema type creates warnings when using code generators since `Error` is a reserved word in some languages (i.e. typescript). We might as well use something that is more clearly defined by the PDC.

Resolves #726