### PR TITLE
Add sdk build to ci

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ indent_size = 2
 indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_style = space

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -22,12 +22,19 @@ jobs:
           path: 'sdk'
       - name: Copy API definition
         run: cp service/src/openapi.json sdk/openapi.json
-      - name: Invoke the typescript generator
+      - name: Invoke the TypeScript generator
         working-directory: sdk
         run: ./gradlew generateSwaggerCode
-      - name: Install dependencies for the typescript sdk
+      - name: Install dependencies for the TypeScript SDK
         working-directory: sdk/build/typescript
         run: npm ci
-      - name: Build the typescript sdk
+      - name: Build the TypeScript SDK
         working-directory: sdk/build/typescript
         run: npm run build
+      - name: Publish to NPM if there is a new version
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          package: sdk/build/typescript
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public
+          dry-run: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,0 +1,33 @@
+name: Build (sdk)
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out our code
+        uses: actions/checkout@v4
+        with:
+          path: 'service'
+      - name: Check out sdk generators
+        uses: actions/checkout@v4
+        with:
+          repository: 'PhilanthropyDataCommons/sdk'
+          path: 'sdk'
+      - name: Copy API definition
+        run: cp service/src/openapi.json sdk/openapi.json
+      - name: Invoke the typescript generator
+        working-directory: sdk
+        run: ./gradlew generateSwaggerCode
+      - name: Install dependencies for the typescript sdk
+        working-directory: sdk/build/typescript
+        run: npm ci
+      - name: Build the typescript sdk
+        working-directory: sdk/build/typescript
+        run: npm run build


### PR DESCRIPTION
This PR creates a "first step" github action that will use our codegen templates to generate and publish a typescript SDK whenever versions change.

Related to #497 