### PR TITLE
Only publish to NPM if the NPM_TOKEN secret is set

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   typescript:
     runs-on: ubuntu-latest
+    env:
+      npm_token_exists: ${{ secrets.NPM_TOKEN != '' }}
     steps:
       - name: Check out our code
         uses: actions/checkout@v4
@@ -32,6 +34,7 @@ jobs:
         working-directory: sdk/build/typescript
         run: npm run build
       - name: Publish to NPM if there is a new version
+        if: ${{ env.npm_token_exists }}
         uses: JS-DevTools/npm-publish@v3
         with:
           package: sdk/build/typescript


### PR DESCRIPTION
This PR fixes an issue where PRs from third parties would have a broken CI state because the NPM token is not available to them.

Resolves #771