### PR TITLE
Rename `dev` scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ source .env
 3. Run migrations
 
 ```bash
-npm run migrate:dev
+npm run migrate
 ```
 
 ### Common Commands
@@ -109,7 +109,7 @@ npm start
 To start the server in a development environment:
 
 ```bash
-npm run start:dev
+npm run start
 ```
 
 ### Logging

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-npm run migrate
-exec npm run start
+node dist/scripts/migrate.js
+exec node dist/index.js

--- a/package.json
+++ b/package.json
@@ -13,14 +13,12 @@
 		"lint:ts": "eslint ./src --ext .ts",
 		"lint:swagger": "swagger-spec-validator src/openapi.json",
 		"lint:prettier": "prettier . --check",
-		"migrate": "node dist/scripts/migrate.js",
-		"migrate:dev": "ts-node src/scripts/migrate.ts | pino-pretty",
+		"migrate": "ts-node src/scripts/migrate.ts | pino-pretty",
 		"test": "npm run test:unit && npm run test:integration",
 		"test:unit": "jest --config=jest.config.unit.js",
 		"test:integration": "jest --config=jest.config.int.js --runInBand",
 		"test:ci": "jest --config=jest.config.ci.js --runInBand",
-		"start": "node dist/index.js",
-		"start:dev": "ts-node src/index.ts | pino-pretty"
+		"start": "ts-node src/index.ts | pino-pretty"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
 		"lint:swagger": "swagger-spec-validator src/openapi.json",
 		"lint:prettier": "prettier . --check",
 		"migrate": "ts-node src/scripts/migrate.ts | pino-pretty",
+		"start": "ts-node src/index.ts | pino-pretty",
 		"test": "npm run test:unit && npm run test:integration",
 		"test:unit": "jest --config=jest.config.unit.js",
 		"test:integration": "jest --config=jest.config.int.js --runInBand",
-		"test:ci": "jest --config=jest.config.ci.js --runInBand",
-		"start": "ts-node src/index.ts | pino-pretty"
+		"test:ci": "jest --config=jest.config.ci.js --runInBand"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This PR removes the "production" versions of `start` and `migrate` as they are not actually being used in production.

Since those are gone we can now remove the `dev` prefix.

Resolves #788 