### PR TITLE
Remove package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
 	"packages": {
 		"": {
 			"name": "@pdc/service",
-			"version": "0.3.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.525.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@pdc/service",
-	"version": "0.3.0",
 	"description": "The service backend for the Philanthropy Data Commons",
 	"main": "dist/index.js",
 	"scripts": {


### PR DESCRIPTION
This PR removes a redundant (and obsolete) version definition for the service project.  We're only versioning the API specification, not the API implementation.

Resolves #807 