### PR TITLE
Use JSON result sets when creating / updating / loading BaseFields

### DIFF
--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -260,7 +260,7 @@ describe('/baseFields', () => {
 				description: '😍',
 				shortCode: '🩳',
 				dataType: '📊',
-				createdAt: expect.any(Date) as Date,
+				createdAt: expectTimestamp,
 			});
 		});
 

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -1,6 +1,25 @@
 import path from 'path';
+import fs from 'fs/promises';
 import { TinyPg } from 'tinypg';
 
-export const db = new TinyPg({
+const initializationDirectory = path.join(__dirname, 'initialization');
+
+const db = new TinyPg({
 	root_dir: [path.resolve(__dirname, 'queries')],
 });
+
+const initializeDatabase = async () => {
+	const initializationFiles = (
+		await fs.readdir(initializationDirectory)
+	).filter((file) => file.endsWith('.sql'));
+
+	await Promise.all(
+		initializationFiles.map(async (file) => {
+			const filePath = path.join(initializationDirectory, file);
+			const sql = (await fs.readFile(filePath)).toString();
+			await db.query(sql);
+		}),
+	);
+};
+
+export { initializeDatabase, db };

--- a/src/database/initialization/README.md
+++ b/src/database/initialization/README.md
@@ -1,0 +1,5 @@
+Any `.sql` files in this folder will be invoked on application startup.
+
+These files are NOT migration files, but rather are files to initialize the database once per session.
+
+Specifically, they can be edited over time.

--- a/src/database/initialization/base_field_to_json.sql
+++ b/src/database/initialization/base_field_to_json.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION base_field_to_json(base_field base_fields)
+RETURNS JSONB AS $$
+BEGIN
+  RETURN jsonb_build_object(
+    'id', base_field.id,
+    'label', base_field.label,
+    'description', base_field.description,
+    'shortCode', base_field.short_code,
+    'dataType', base_field.data_type,
+    'createdAt', to_json(base_field.created_at)::jsonb
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/operations/create/createBaseField.ts
+++ b/src/database/operations/create/createBaseField.ts
@@ -1,0 +1,27 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import type {
+	BaseField,
+	JsonResultSet,
+	WritableBaseField,
+} from '../../../types';
+
+export const createBaseField = async (
+	createValues: WritableBaseField,
+): Promise<BaseField> => {
+	const { label, description, shortCode, dataType } = createValues;
+	const result = await db.sql<JsonResultSet<BaseField>>(
+		'baseFields.insertOne',
+		{
+			label,
+			description,
+			shortCode,
+			dataType,
+		},
+	);
+	const baseField = result.rows[0]?.object;
+	if (baseField === undefined) {
+		throw new NotFoundError('The base field could not be created.');
+	}
+	return baseField;
+};

--- a/src/database/operations/create/index.ts
+++ b/src/database/operations/create/index.ts
@@ -1,1 +1,2 @@
+export * from './createBaseField';
 export * from './createOrganization';

--- a/src/database/operations/load/loadBaseFields.ts
+++ b/src/database/operations/load/loadBaseFields.ts
@@ -1,5 +1,7 @@
 import { db } from '../../db';
-import type { BaseField } from '../../../types';
+import type { BaseField, JsonResultSet } from '../../../types';
 
 export const loadBaseFields = async (): Promise<BaseField[]> =>
-	(await db.sql<BaseField>('baseFields.selectAll')).rows;
+	(await db.sql<JsonResultSet<BaseField>>('baseFields.selectAll')).rows.map(
+		(row) => row.object,
+	);

--- a/src/database/operations/update/updateBaseField.ts
+++ b/src/database/operations/update/updateBaseField.ts
@@ -1,20 +1,27 @@
 import { db } from '../../db';
 import { NotFoundError } from '../../../errors';
-import type { BaseField, WritableBaseField } from '../../../types';
+import type {
+	BaseField,
+	JsonResultSet,
+	WritableBaseField,
+} from '../../../types';
 
 export const updateBaseField = async (
 	id: number,
 	updateValues: WritableBaseField,
 ): Promise<BaseField> => {
 	const { label, description, shortCode, dataType } = updateValues;
-	const result = await db.sql<BaseField>('baseFields.updateById', {
-		id,
-		label,
-		description,
-		shortCode,
-		dataType,
-	});
-	const baseField = result.rows[0];
+	const result = await db.sql<JsonResultSet<BaseField>>(
+		'baseFields.updateById',
+		{
+			id,
+			label,
+			description,
+			shortCode,
+			dataType,
+		},
+	);
+	const baseField = result.rows[0]?.object;
 	if (baseField === undefined) {
 		throw new NotFoundError('This base field does not exist.');
 	}

--- a/src/database/operations/update/updateBaseField.ts
+++ b/src/database/operations/update/updateBaseField.ts
@@ -1,10 +1,10 @@
 import { db } from '../../db';
 import { NotFoundError } from '../../../errors';
-import type { BaseField, BaseFieldWrite } from '../../../types';
+import type { BaseField, WritableBaseField } from '../../../types';
 
 export const updateBaseField = async (
 	id: number,
-	updateValues: BaseFieldWrite,
+	updateValues: WritableBaseField,
 ): Promise<BaseField> => {
 	const { label, description, shortCode, dataType } = updateValues;
 	const result = await db.sql<BaseField>('baseFields.updateById', {

--- a/src/database/queries/baseFields/insertOne.sql
+++ b/src/database/queries/baseFields/insertOne.sql
@@ -10,10 +10,4 @@ VALUES (
   :shortCode,
   :dataType
 )
-RETURNING
-  id as "id",
-  label as "label",
-  description as "description",
-  short_code as "shortCode",
-  data_type as "dataType",
-  created_at as "createdAt"
+RETURNING base_field_to_json(base_fields) AS "object";

--- a/src/database/queries/baseFields/selectAll.sql
+++ b/src/database/queries/baseFields/selectAll.sql
@@ -1,8 +1,2 @@
-SELECT
-  id,
-  label,
-  description,
-  short_code as "shortCode",
-  data_type as "dataType",
-  created_at as "createdAt"
+SELECT base_field_to_json(base_fields.*) as "object"
 FROM base_fields;

--- a/src/database/queries/baseFields/updateById.sql
+++ b/src/database/queries/baseFields/updateById.sql
@@ -4,10 +4,4 @@ UPDATE base_fields SET
   short_code = :shortCode,
   data_type = :dataType
 WHERE id = :id
-RETURNING
-  id,
-  label,
-  description,
-  short_code as "shortCode",
-  data_type as "dataType",
-  created_at as "createdAt"
+RETURNING base_field_to_json(base_fields) AS "object";

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -1,6 +1,6 @@
 import { getLogger } from '../logger';
 import { db, updateBaseField } from '../database';
-import { isTinyPgErrorWithQueryContext, isBaseFieldWrite } from '../types';
+import { isTinyPgErrorWithQueryContext, isWritableBaseField } from '../types';
 import { DatabaseError, InputValidationError } from '../errors';
 import type { Request, Response, NextFunction } from 'express';
 import type { Result } from 'tinypg';
@@ -33,11 +33,11 @@ const postBaseField = (
 	res: Response,
 	next: NextFunction,
 ): void => {
-	if (!isBaseFieldWrite(req.body)) {
+	if (!isWritableBaseField(req.body)) {
 		next(
 			new InputValidationError(
 				'Invalid request body.',
-				isBaseFieldWrite.errors ?? [],
+				isWritableBaseField.errors ?? [],
 			),
 		);
 		return;
@@ -69,11 +69,11 @@ const putBaseField = (
 		return;
 	}
 	const body = req.body as unknown;
-	if (!isBaseFieldWrite(body)) {
+	if (!isWritableBaseField(body)) {
 		next(
 			new InputValidationError(
 				'Invalid request body.',
-				isBaseFieldWrite.errors ?? [],
+				isWritableBaseField.errors ?? [],
 			),
 		);
 		return;

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -1,12 +1,7 @@
-import { getLogger } from '../logger';
-import { db, loadBaseFields, updateBaseField } from '../database';
+import { createBaseField, loadBaseFields, updateBaseField } from '../database';
 import { isTinyPgErrorWithQueryContext, isWritableBaseField } from '../types';
 import { DatabaseError, InputValidationError } from '../errors';
 import type { Request, Response, NextFunction } from 'express';
-import type { Result } from 'tinypg';
-import type { BaseField } from '../types';
-
-const logger = getLogger(__filename);
 
 const getBaseFields = (
 	req: Request,
@@ -41,10 +36,8 @@ const postBaseField = (
 		return;
 	}
 
-	db.sql('baseFields.insertOne', req.body)
-		.then((baseFieldsQueryResult: Result<BaseField>) => {
-			logger.debug(baseFieldsQueryResult);
-			const baseField = baseFieldsQueryResult.rows[0];
+	createBaseField(req.body)
+		.then((baseField) => {
 			res.status(201).contentType('application/json').send(baseField);
 		})
 		.catch((error: unknown) => {

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -1,5 +1,5 @@
 import { getLogger } from '../logger';
-import { db, updateBaseField } from '../database';
+import { db, loadBaseFields, updateBaseField } from '../database';
 import { isTinyPgErrorWithQueryContext, isWritableBaseField } from '../types';
 import { DatabaseError, InputValidationError } from '../errors';
 import type { Request, Response, NextFunction } from 'express';
@@ -13,10 +13,8 @@ const getBaseFields = (
 	res: Response,
 	next: NextFunction,
 ): void => {
-	db.sql('baseFields.selectAll')
-		.then((baseFieldsQueryResult: Result<BaseField>) => {
-			logger.debug(baseFieldsQueryResult);
-			const { rows: baseFields } = baseFieldsQueryResult;
+	loadBaseFields()
+		.then((baseFields) => {
 			res.status(200).contentType('application/json').send(baseFields);
 		})
 		.catch((error: unknown) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,33 @@
+import { initializeDatabase } from './database';
 import { app } from './app';
 import { startJobQueue } from './jobQueue';
 import { getLogger } from './logger';
 
 const logger = getLogger(__filename);
 
-// The .env file is loaded in 'logger' to ensure correct order of events. See
-// more discussion in the 'logger.ts' code.
-
 const port = Number(process.env.PORT ?? 3001);
 const host = process.env.HOST ?? 'localhost';
 
-app.listen(port, host, () => {
-	logger.info(`Server running on http://${host}:${port}`);
-});
+const start = async () => {
+	try {
+		await initializeDatabase();
+	} catch (err) {
+		logger.error(err, 'Database failed to initialize');
+		throw err;
+	}
+	try {
+		await startJobQueue();
+	} catch (err) {
+		logger.error(err, 'Job queue failed to start');
+		throw err;
+	}
+	app.listen(port, host, () => {
+		logger.info(`Server running on http://${host}:${port}`);
+	});
+};
 
-startJobQueue().catch((err) => {
-	logger.error(err, 'Job queue failed to start');
+start().catch(() => {
+	logger.error(
+		'The PDC service was not started. Please check the logs for more information.',
+	);
 });

--- a/src/jobQueue.ts
+++ b/src/jobQueue.ts
@@ -40,7 +40,9 @@ export const startJobQueue = async () => {
 			processBulkUpload,
 		},
 	});
-	await runner.promise;
+	runner.promise.catch((err) => {
+		logger.error(err, 'The queue worker failed.');
+	})
 };
 
 export const runJobQueueMigrations = async () =>

--- a/src/jobQueue.ts
+++ b/src/jobQueue.ts
@@ -42,7 +42,7 @@ export const startJobQueue = async () => {
 	});
 	runner.promise.catch((err) => {
 		logger.error(err, 'The queue worker failed.');
-	})
+	});
 };
 
 export const runJobQueueMigrations = async () =>

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import { requireEnv } from 'require-env-variable';
-import { db, loadBulkUpload } from '../../database';
+import { db, createBaseField, loadBulkUpload } from '../../database';
 import { s3Client } from '../../s3Client';
 import { getMockJobHelpers } from '../../test/mockGraphileWorker';
 import { processBulkUpload } from '../processBulkUpload';
@@ -58,17 +58,13 @@ const createTestBulkUpload = async (
 };
 
 const createTestBaseFields = async (): Promise<[BaseField, BaseField]> => {
-	const {
-		rows: [proposalSubmitterEmailBaseField],
-	} = await db.sql<BaseField>('baseFields.insertOne', {
+	const proposalSubmitterEmailBaseField = await createBaseField({
 		label: 'Proposal Submitter Email',
 		description: 'The email address of the person who submitted the proposal.',
 		shortCode: 'proposal_submitter_email',
 		dataType: 'string',
 	});
-	const {
-		rows: [organizationNameBaseField],
-	} = await db.sql<BaseField>('baseFields.insertOne', {
+	const organizationNameBaseField = await createBaseField({
 		label: 'Organization Name',
 		description: 'The name of the applying organization.',
 		shortCode: 'organization_name',

--- a/src/test/harnessFunctions.ts
+++ b/src/test/harnessFunctions.ts
@@ -1,4 +1,4 @@
-import { db, migrate } from '../database';
+import { db, migrate, initializeDatabase } from '../database';
 
 const generateSchemaName = (workerId: string): string => `test_${workerId}`;
 
@@ -44,6 +44,7 @@ export const prepareDatabaseForCurrentWorker = async (): Promise<void> => {
 	await createSchema(schemaName);
 	await setSchema(schemaName);
 	await migrate(schemaName);
+	await initializeDatabase();
 };
 
 export const cleanupDatabaseForCurrentWorker = async (): Promise<void> => {

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,5 +1,5 @@
 export const isoTimestampPattern =
-	/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+	/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(Z|(\+|-)\d{2}:\d{2})$/;
 
 export const expectTimestamp = expect.stringMatching(
 	isoTimestampPattern,

--- a/src/types/BaseField.ts
+++ b/src/types/BaseField.ts
@@ -1,18 +1,19 @@
 import { ajv } from '../ajv';
 import type { JSONSchemaType } from 'ajv';
+import type { Writable } from './Writable';
 
-export interface BaseField {
-	id: number;
+interface BaseField {
+	readonly id: number;
 	label: string;
 	description: string;
 	shortCode: string;
 	dataType: string;
-	createdAt: Date;
+	readonly createdAt: Date;
 }
 
-export type BaseFieldWrite = Omit<BaseField, 'createdAt' | 'id'>;
+type WritableBaseField = Writable<BaseField>;
 
-export const baseFieldWriteSchema: JSONSchemaType<BaseFieldWrite> = {
+const writableBaseFieldSchema: JSONSchemaType<WritableBaseField> = {
 	type: 'object',
 	properties: {
 		label: {
@@ -31,4 +32,11 @@ export const baseFieldWriteSchema: JSONSchemaType<BaseFieldWrite> = {
 	required: ['label', 'description', 'shortCode', 'dataType'],
 };
 
-export const isBaseFieldWrite = ajv.compile(baseFieldWriteSchema);
+const isWritableBaseField = ajv.compile(writableBaseFieldSchema);
+
+export {
+	BaseField,
+	isWritableBaseField,
+	WritableBaseField,
+	writableBaseFieldSchema,
+};

--- a/src/types/JsonResultSet.ts
+++ b/src/types/JsonResultSet.ts
@@ -1,0 +1,5 @@
+interface JsonResultSet<T> {
+	object: T;
+}
+
+export { JsonResultSet };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export * from './BulkUpload';
 export * from './Bundle';
 export * from './IdParameters';
 export * from './JsonObject';
+export * from './JsonResultSet';
 export * from './Opportunity';
 export * from './Organization';
 export * from './PaginationParameters';


### PR DESCRIPTION
This PR creates a new approach for loading data from psql, and uses that approach for loading base fields.  The reasoning for starting with base fields is that they have no "child" relationships / represent one of the simplest entities in our system.

Making this change also required improving some of the related base field code to reflect our latest best practices.

Related to #821 