### PR TITLE
Specify swagger-ui-dist version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"pino-http": "^9.0.0",
 				"postgres-schema-migrations": "^6.1.0",
 				"require-env-variable": "^4.0.2",
+				"swagger-ui-dist": "^5.12.3",
 				"swagger-ui-express": "^5.0.0",
 				"tinypg": "^7.0.0",
 				"tmp-promise": "^3.0.3",
@@ -9281,9 +9282,9 @@
 			}
 		},
 		"node_modules/swagger-ui-dist": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.3.1.tgz",
-			"integrity": "sha512-El78OvXp9zMasfPrshtkW1CRx8AugAKoZuGGOTW+8llJzOV1RtDJYqQRz/6+2OakjeWWnZuRlN2Qj1Y0ilux3w=="
+			"version": "5.12.3",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.12.3.tgz",
+			"integrity": "sha512-UAFxQSzxVkY/yfmipeMLj4LwH6I/ZGcfezwSquPm2U9CqOiHp8L6fD7TcyPDYfCZuHFaPw5y4io+fny37Ov9NQ=="
 		},
 		"node_modules/swagger-ui-express": {
 			"version": "5.0.0",
@@ -17165,9 +17166,9 @@
 			}
 		},
 		"swagger-ui-dist": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.3.1.tgz",
-			"integrity": "sha512-El78OvXp9zMasfPrshtkW1CRx8AugAKoZuGGOTW+8llJzOV1RtDJYqQRz/6+2OakjeWWnZuRlN2Qj1Y0ilux3w=="
+			"version": "5.12.3",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.12.3.tgz",
+			"integrity": "sha512-UAFxQSzxVkY/yfmipeMLj4LwH6I/ZGcfezwSquPm2U9CqOiHp8L6fD7TcyPDYfCZuHFaPw5y4io+fny37Ov9NQ=="
 		},
 		"swagger-ui-express": {
 			"version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"pino-http": "^9.0.0",
 		"postgres-schema-migrations": "^6.1.0",
 		"require-env-variable": "^4.0.2",
+		"swagger-ui-dist": "^5.12.3",
 		"swagger-ui-express": "^5.0.0",
 		"tinypg": "^7.0.0",
 		"tmp-promise": "^3.0.3",


### PR DESCRIPTION
This PR specifies the version of swagger-ui we want to use; it also updates the version that was being used before.

Going forward we'll benefit from dependabot updates.

You can test this by running `npm i` and then `npm run start` and looking at the swagger page.  You should notice it's on the latest version.

Resolves #851 