### PR TITLE
Update application form queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 2024-04-29
+
+### Changed
+
+- The `/applicationForms` endpoint now returns an `ApplicationFormBundle`.
+- The `/applicationForms` endpoint now returns deep `ApplicationForm` objects.
+- The `/applicationForms/:id` endpoint now returns a deep `ApplicationForm object.
+
+### Removed
+
+- The `/applicationForms/:id` endpoint no longer has a `includeFields` query parameter, as it always includes deep fields.
+
 ## 0.5.0 - 2024-04-27
 
 ### Added

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -27,7 +27,14 @@ const createTestBaseFields = async () => {
 describe('/applicationForms', () => {
 	describe('GET /', () => {
 		it('returns an empty array when no data is present', async () => {
-			await agent.get('/applicationForms').set(authHeader).expect(200, []);
+			const response = await agent
+				.get('/applicationForms')
+				.set(authHeader)
+				.expect(200);
+			expect(response.body).toMatchObject({
+				entries: [],
+				total: 0,
+			});
 		});
 
 		it('returns all application forms present in the database', async () => {
@@ -48,10 +55,12 @@ describe('/applicationForms', () => {
           ( 1, 2, '2022-08-20 12:00:00+0000' ),
           ( 2, 1, '2022-09-20 12:00:00+0000' )
       `);
-			await agent
+			const response = await agent
 				.get('/applicationForms')
 				.set(authHeader)
-				.expect(200, [
+				.expect(200);
+			expect(response.body).toMatchObject({
+				entries: [
 					{
 						createdAt: '2022-07-20T12:00:00.000Z',
 						id: 1,
@@ -70,7 +79,9 @@ describe('/applicationForms', () => {
 						opportunityId: 2,
 						version: 1,
 					},
-				]);
+				],
+				total: 3,
+			});
 		});
 
 		it('returns an application form without its fields', async () => {

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -62,52 +62,25 @@ describe('/applicationForms', () => {
 			expect(response.body).toMatchObject({
 				entries: [
 					{
-						createdAt: '2022-07-20T12:00:00.000Z',
+						createdAt: expectTimestamp,
 						id: 1,
 						opportunityId: 1,
 						version: 1,
 					},
 					{
-						createdAt: '2022-08-20T12:00:00.000Z',
+						createdAt: expectTimestamp,
 						id: 2,
 						opportunityId: 1,
 						version: 2,
 					},
 					{
-						createdAt: '2022-09-20T12:00:00.000Z',
+						createdAt: expectTimestamp,
 						id: 3,
 						opportunityId: 2,
 						version: 1,
 					},
 				],
 				total: 3,
-			});
-		});
-
-		it('returns an application form without its fields', async () => {
-			await db.query(`
-        INSERT INTO opportunities (title)
-        VALUES
-          ( 'Summer opportunity 🩴' ),
-          ( 'Spring opportunity 🌺' );
-      `);
-			await db.query(`
-        INSERT INTO application_forms (
-          opportunity_id,
-          version,
-          created_at
-        )
-        VALUES
-          ( 1, 1, '2510-02-02 00:00:01+0000' ),
-          ( 1, 2, '2510-02-02 00:00:02+0000' ),
-          ( 2, 1, '2510-02-02 00:00:03+0000' )
-      `);
-			await createTestBaseFields();
-			await agent.get('/applicationForms/2').set(authHeader).expect(200, {
-				id: 2,
-				opportunityId: 1,
-				version: 2,
-				createdAt: '2510-02-02T00:00:02.000Z',
 			});
 		});
 
@@ -146,7 +119,6 @@ describe('/applicationForms', () => {
       `);
 			const result = await agent
 				.get('/applicationForms/2')
-				.query({ includeFields: 'true' })
 				.set(authHeader)
 				.expect(200);
 
@@ -234,12 +206,12 @@ describe('/applicationForms', () => {
 				})
 				.expect(201);
 			const after = await loadTableMetrics('application_forms');
-			logger.debug('after: %o', after);
 			expect(before.count).toEqual(0);
 			expect(result.body).toMatchObject({
 				id: 1,
 				opportunityId: 1,
 				version: 1,
+				fields: [],
 				createdAt: expectTimestamp,
 			});
 			expect(after.count).toEqual(1);

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -12,6 +12,7 @@ import { getLogger } from '../logger';
 import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import { PostgresErrorCode } from '../types/PostgresErrorCode';
+import { createApplicationForm } from '../database/operations/create/createApplicationForm';
 
 const logger = getLogger(__filename);
 const agent = request.agent(app);
@@ -58,7 +59,7 @@ describe('/proposals', () => {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 			});
-			await db.sql('applicationForms.insertOne', {
+			await createApplicationForm({
 				opportunityId: 1,
 			});
 			await db.sql('proposalVersions.insertOne', {
@@ -202,7 +203,7 @@ describe('/proposals', () => {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 			});
-			await db.sql('applicationForms.insertOne', {
+			await createApplicationForm({
 				opportunityId: 1,
 			});
 			await db.sql('proposalVersions.insertOne', {
@@ -299,7 +300,7 @@ describe('/proposals', () => {
 				externalId: 'proposal-5003',
 				opportunityId: 1,
 			});
-			await db.sql('applicationForms.insertOne', {
+			await createApplicationForm({
 				opportunityId: 1,
 			});
 			await db.sql('proposalVersions.insertOne', {

--- a/src/database/initialization/application_form_to_json.sql
+++ b/src/database/initialization/application_form_to_json.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION application_form_to_json(application_form application_forms)
+RETURNS JSONB AS $$
+DECLARE
+  application_form_fields_json JSONB;
+BEGIN
+  SELECT jsonb_agg(
+    application_form_field_to_json(application_form_fields.*)
+    ORDER BY application_form_fields.position, application_form_fields.id
+  )
+  INTO application_form_fields_json
+  FROM application_form_fields
+  WHERE application_form_fields.application_form_id = application_form.id;
+
+  RETURN jsonb_build_object(
+    'id', application_form.id,
+    'opportunityId', application_form.opportunity_id,
+    'version', application_form.version,
+    'fields', COALESCE(application_form_fields_json, '[]'::JSONB),
+    'createdAt', application_form.created_at
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/operations/create/createApplicationForm.ts
+++ b/src/database/operations/create/createApplicationForm.ts
@@ -1,0 +1,18 @@
+import { db } from '../../db';
+import type { ApplicationForm, WritableApplicationForm } from '../../../types';
+
+export const createApplicationForm = async (
+	createValues: WritableApplicationForm,
+): Promise<ApplicationForm> => {
+	const { opportunityId } = createValues;
+	const result = await db.sql<ApplicationForm>('applicationForms.insertOne', {
+		opportunityId,
+	});
+	const applicationForm = result.rows[0];
+	if (applicationForm === undefined) {
+		throw new Error(
+			'The application form creation did not appear to fail, but no data was returned by the operation.',
+		);
+	}
+	return applicationForm;
+};

--- a/src/database/operations/create/createApplicationForm.ts
+++ b/src/database/operations/create/createApplicationForm.ts
@@ -1,14 +1,21 @@
 import { db } from '../../db';
-import type { ApplicationForm, WritableApplicationForm } from '../../../types';
+import type {
+	JsonResultSet,
+	ApplicationForm,
+	WritableApplicationForm,
+} from '../../../types';
 
 export const createApplicationForm = async (
 	createValues: WritableApplicationForm,
 ): Promise<ApplicationForm> => {
 	const { opportunityId } = createValues;
-	const result = await db.sql<ApplicationForm>('applicationForms.insertOne', {
-		opportunityId,
-	});
-	const applicationForm = result.rows[0];
+	const result = await db.sql<JsonResultSet<ApplicationForm>>(
+		'applicationForms.insertOne',
+		{
+			opportunityId,
+		},
+	);
+	const applicationForm = result.rows[0]?.object;
 	if (applicationForm === undefined) {
 		throw new Error(
 			'The application form creation did not appear to fail, but no data was returned by the operation.',

--- a/src/database/operations/create/index.ts
+++ b/src/database/operations/create/index.ts
@@ -1,3 +1,4 @@
+export * from './createApplicationForm';
 export * from './createApplicationFormField';
 export * from './createBaseField';
 export * from './createOrganization';

--- a/src/database/operations/load/index.ts
+++ b/src/database/operations/load/index.ts
@@ -1,3 +1,5 @@
+export * from './loadApplicationForm';
+export * from './loadApplicationFormBundle';
 export * from './loadApplicationFormField';
 export * from './loadApplicationFormFieldBundle';
 export * from './loadBaseFields';

--- a/src/database/operations/load/loadApplicationForm.ts
+++ b/src/database/operations/load/loadApplicationForm.ts
@@ -1,14 +1,17 @@
 import { db } from '../../db';
 import { NotFoundError } from '../../../errors';
-import type { ApplicationForm } from '../../../types';
+import type { JsonResultSet, ApplicationForm } from '../../../types';
 
 export const loadApplicationForm = async (
 	id: number,
 ): Promise<ApplicationForm> => {
-	const result = await db.sql<ApplicationForm>('applicationForms.selectById', {
-		id,
-	});
-	const object = result.rows[0];
+	const result = await db.sql<JsonResultSet<ApplicationForm>>(
+		'applicationForms.selectById',
+		{
+			id,
+		},
+	);
+	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
 		throw new NotFoundError(`Application Form not found (id: ${id})`);
 	}

--- a/src/database/operations/load/loadApplicationForm.ts
+++ b/src/database/operations/load/loadApplicationForm.ts
@@ -1,0 +1,16 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import type { ApplicationForm } from '../../../types';
+
+export const loadApplicationForm = async (
+	id: number,
+): Promise<ApplicationForm> => {
+	const result = await db.sql<ApplicationForm>('applicationForms.selectById', {
+		id,
+	});
+	const object = result.rows[0];
+	if (object === undefined) {
+		throw new NotFoundError(`Application Form not found (id: ${id})`);
+	}
+	return object;
+};

--- a/src/database/operations/load/loadApplicationFormBundle.ts
+++ b/src/database/operations/load/loadApplicationFormBundle.ts
@@ -1,0 +1,23 @@
+import { loadBundle } from './loadBundle';
+import type { Bundle, ApplicationForm } from '../../../types';
+
+export const loadApplicationFormBundle = async (
+	queryParameters: {
+		offset?: number;
+		limit?: number;
+	} = {},
+): Promise<Bundle<ApplicationForm>> => {
+	const defaultQueryParameters = {
+		offset: 0,
+		limit: 0,
+	};
+	const bundle = await loadBundle<ApplicationForm>(
+		'applicationForms.selectWithPagination',
+		{
+			...defaultQueryParameters,
+			...queryParameters,
+		},
+		'application_forms',
+	);
+	return bundle;
+};

--- a/src/database/operations/load/loadApplicationFormBundle.ts
+++ b/src/database/operations/load/loadApplicationFormBundle.ts
@@ -1,5 +1,5 @@
 import { loadBundle } from './loadBundle';
-import type { Bundle, ApplicationForm } from '../../../types';
+import type { JsonResultSet, Bundle, ApplicationForm } from '../../../types';
 
 export const loadApplicationFormBundle = async (
 	queryParameters: {
@@ -11,7 +11,7 @@ export const loadApplicationFormBundle = async (
 		offset: 0,
 		limit: 0,
 	};
-	const bundle = await loadBundle<ApplicationForm>(
+	const bundle = await loadBundle<JsonResultSet<ApplicationForm>>(
 		'applicationForms.selectWithPagination',
 		{
 			...defaultQueryParameters,
@@ -19,5 +19,9 @@ export const loadApplicationFormBundle = async (
 		},
 		'application_forms',
 	);
-	return bundle;
+	const entries = bundle.entries.map((entry) => entry.object);
+	return {
+		...bundle,
+		entries,
+	};
 };

--- a/src/database/queries/applicationForms/insertOne.sql
+++ b/src/database/queries/applicationForms/insertOne.sql
@@ -12,8 +12,4 @@ INSERT INTO application_forms (
     1
   )
 )
-RETURNING
-  id as "id",
-  opportunity_id as "opportunityId",
-  version as "version",
-  created_at as "createdAt"
+RETURNING application_form_to_json(application_forms) AS "object";

--- a/src/database/queries/applicationForms/selectAll.sql
+++ b/src/database/queries/applicationForms/selectAll.sql
@@ -1,6 +1,0 @@
-SELECT af.id AS "id",
-  af.opportunity_id as "opportunityId",
-  af.version AS "version",
-  af.created_at AS "createdAt"
-FROM application_forms af;
-

--- a/src/database/queries/applicationForms/selectById.sql
+++ b/src/database/queries/applicationForms/selectById.sql
@@ -1,7 +1,4 @@
-SELECT af.id AS "id",
-  af.opportunity_id as "opportunityId",
-  af.version AS "version",
-  af.created_at AS "createdAt"
-FROM application_forms af
-WHERE af.id = :id;
+SELECT application_form_to_json(application_forms) AS "object"
+FROM application_forms
+WHERE id = :id;
 

--- a/src/database/queries/applicationForms/selectWithPagination.sql
+++ b/src/database/queries/applicationForms/selectWithPagination.sql
@@ -1,9 +1,6 @@
-SELECT af.id AS "id",
-  af.opportunity_id as "opportunityId",
-  af.version AS "version",
-  af.created_at AS "createdAt"
-FROM application_forms af
-ORDER BY af.id
+SELECT application_form_to_json(application_forms) AS "object"
+FROM application_forms
+ORDER BY id
 LIMIT
   CASE WHEN :limit != 0 THEN
     :limit

--- a/src/database/queries/applicationForms/selectWithPagination.sql
+++ b/src/database/queries/applicationForms/selectWithPagination.sql
@@ -1,0 +1,13 @@
+SELECT af.id AS "id",
+  af.opportunity_id as "opportunityId",
+  af.version AS "version",
+  af.created_at AS "createdAt"
+FROM application_forms af
+ORDER BY af.id
+LIMIT
+  CASE WHEN :limit != 0 THEN
+    :limit
+  ELSE
+    NULL
+  END
+OFFSET :offset

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -1,35 +1,25 @@
-import { getLogger } from '../logger';
 import {
+	createApplicationForm,
 	createApplicationFormField,
-	db,
+	loadApplicationForm,
+	loadApplicationFormBundle,
 	loadApplicationFormFieldBundle,
 } from '../database';
 import {
-	isApplicationFormWrite,
-	isId,
 	isTinyPgErrorWithQueryContext,
+	isWritableApplicationFormWithFields,
+	isId,
 } from '../types';
-import {
-	DatabaseError,
-	InputValidationError,
-	InternalValidationError,
-	NotFoundError,
-} from '../errors';
+import { DatabaseError, InputValidationError } from '../errors';
 import type { Request, Response, NextFunction } from 'express';
-import type { Result } from 'tinypg';
-import type { ApplicationForm, ApplicationFormWrite } from '../types';
-
-const logger = getLogger(__filename);
 
 const getApplicationForms = (
 	req: Request,
 	res: Response,
 	next: NextFunction,
 ): void => {
-	db.sql('applicationForms.selectAll')
-		.then((applicationFormsQueryResult: Result<ApplicationForm>) => {
-			logger.debug(applicationFormsQueryResult);
-			const { rows: applicationForms } = applicationFormsQueryResult;
+	loadApplicationFormBundle()
+		.then((applicationForms) => {
 			res.status(200).contentType('application/json').send(applicationForms);
 		})
 		.catch((error: unknown) => {
@@ -46,20 +36,13 @@ const getShallowApplicationForm = (
 	res: Response,
 	next: NextFunction,
 ): void => {
-	db.sql('applicationForms.selectById', { id: req.params.id })
-		.then((applicationFormsQueryResult: Result<ApplicationForm>) => {
-			if (applicationFormsQueryResult.row_count === 0) {
-				throw new NotFoundError(
-					'Not found. Find existing application forms by calling with no parameters.',
-				);
-			}
-			const applicationForm = applicationFormsQueryResult.rows[0];
-			if (applicationForm === undefined) {
-				throw new InternalValidationError(
-					'The database responded with an unexpected format.',
-					[],
-				);
-			}
+	const { id: applicationFormId } = req.params;
+	if (!isId(applicationFormId)) {
+		next(new InputValidationError('Invalid request.', isId.errors ?? []));
+		return;
+	}
+	loadApplicationForm(applicationFormId)
+		.then((applicationForm) => {
 			res.status(200).contentType('application/json').send(applicationForm);
 		})
 		.catch((error: unknown) => {
@@ -81,20 +64,8 @@ const getApplicationFormWithFields = (
 		next(new InputValidationError('Invalid request body.', isId.errors ?? []));
 		return;
 	}
-	db.sql('applicationForms.selectById', { id: req.params.id })
-		.then((applicationFormsQueryResult: Result<ApplicationForm>) => {
-			if (applicationFormsQueryResult.row_count === 0) {
-				throw new NotFoundError(
-					'Not found. Find existing application forms by calling with no parameters.',
-				);
-			}
-			const baseApplicationForm = applicationFormsQueryResult.rows[0];
-			if (baseApplicationForm === undefined) {
-				throw new InternalValidationError(
-					'The database responded with an unexpected format.',
-					[],
-				);
-			}
+	loadApplicationForm(applicationFormId)
+		.then((baseApplicationForm) => {
 			loadApplicationFormFieldBundle({
 				applicationFormId,
 			})
@@ -140,61 +111,46 @@ const getApplicationForm = (
 };
 
 const postApplicationForms = (
-	req: Request<unknown, unknown, ApplicationFormWrite>,
+	req: Request,
 	res: Response,
 	next: NextFunction,
 ): void => {
-	if (!isApplicationFormWrite(req.body)) {
+	if (!isWritableApplicationFormWithFields(req.body)) {
 		next(
 			new InputValidationError(
 				'Invalid request body.',
-				isApplicationFormWrite.errors ?? [],
+				isWritableApplicationFormWithFields.errors ?? [],
 			),
 		);
 		return;
 	}
+	const { fields } = req.body;
 
-	db.sql('applicationForms.insertOne', {
-		...req.body,
-		optedIn: false,
-	})
-		.then((applicationFormsQueryResult: Result<ApplicationForm>) => {
-			logger.debug(applicationFormsQueryResult);
-			const applicationForm = applicationFormsQueryResult.rows[0];
-			if (applicationForm !== undefined) {
-				const queries = req.body.fields.map(async (field) =>
-					createApplicationFormField({
-						...field,
-						applicationFormId: applicationForm.id,
-					}),
-				);
-				Promise.all(queries)
-					.then((applicationFormFields) => {
-						res
-							.status(201)
-							.contentType('application/json')
-							.send({
-								...applicationForm,
-								fields: applicationFormFields,
-							});
-					})
-					.catch((error: unknown) => {
-						if (isTinyPgErrorWithQueryContext(error)) {
-							next(
-								new DatabaseError('Error creating application form.', error),
-							);
-							return;
-						}
-						next(error);
-					});
-			} else {
-				next(
-					new InternalValidationError(
-						'The database responded with an unexpected format when creating the form.',
-						[],
-					),
-				);
-			}
+	createApplicationForm(req.body)
+		.then((applicationForm) => {
+			const queries = fields.map(async (field) =>
+				createApplicationFormField({
+					...field,
+					applicationFormId: applicationForm.id,
+				}),
+			);
+			Promise.all(queries)
+				.then((applicationFormFields) => {
+					res
+						.status(201)
+						.contentType('application/json')
+						.send({
+							...applicationForm,
+							fields: applicationFormFields,
+						});
+				})
+				.catch((error: unknown) => {
+					if (isTinyPgErrorWithQueryContext(error)) {
+						next(new DatabaseError('Error creating application form.', error));
+						return;
+					}
+					next(error);
+				});
 		})
 		.catch((error: unknown) => {
 			if (isTinyPgErrorWithQueryContext(error)) {

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -1,5 +1,10 @@
 import { getLogger } from '../logger';
-import { db, loadApplicationFormField, loadProposal } from '../database';
+import {
+	db,
+	loadApplicationForm,
+	loadApplicationFormField,
+	loadProposal,
+} from '../database';
 import {
 	isProposalVersionWrite,
 	isTinyPgErrorWithQueryContext,
@@ -13,12 +18,12 @@ import {
 } from '../errors';
 import type { Request, Response, NextFunction } from 'express';
 import type {
-	ApplicationForm,
 	ProposalVersion,
 	ProposalVersionWrite,
 	ProposalFieldValue,
 	ProposalFieldValueWrite,
 	Proposal,
+	ApplicationForm,
 } from '../types';
 
 const logger = getLogger(__filename);
@@ -27,12 +32,10 @@ const assertApplicationFormExistsForProposal = async (
 	applicationFormId: number,
 	proposalId: number,
 ): Promise<void> => {
-	const applicationFormsQueryResult = await db.sql<ApplicationForm>(
-		'applicationForms.selectById',
-		{ id: applicationFormId },
-	);
-	const applicationForm = applicationFormsQueryResult.rows[0];
-	if (applicationForm === undefined) {
+	let applicationForm: ApplicationForm;
+	try {
+		applicationForm = await loadApplicationForm(applicationFormId);
+	} catch {
 		throw new InputConflictError('The Application Form does not exist.', {
 			entityType: 'ApplicationForm',
 			entityId: applicationFormId,

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for organizations seeking grants.",
-		"version": "0.5.0"
+		"version": "0.6.0"
 	},
 	"components": {
 		"parameters": {
@@ -687,57 +687,15 @@
 						"schema": {
 							"type": "integer"
 						}
-					},
-					{
-						"name": "includeFields",
-						"in": "query",
-						"description": "Include the fields associated with the application form when `true`, otherwise do not include them.",
-						"required": false,
-						"schema": {
-							"type": "boolean"
-						}
 					}
 				],
 				"responses": {
 					"200": {
-						"description": "All application forms currently registered in the PDC.",
+						"description": "The requested application form.",
 						"content": {
 							"application/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/ApplicationForm"
-									}
-								},
-								"examples": {
-									"default": {
-										"summary": "The default, shallow response with no parameters or where `includeFields=false`.",
-										"value": {
-											"id": 3529,
-											"opportunityId": 3203,
-											"version": 13,
-											"createdAt": "2022-09-13T14:45:06.139Z"
-										}
-									},
-									"includeFields": {
-										"summary": "The response when `includeFields` is set to `true`.",
-										"value": {
-											"id": 3529,
-											"opportunityId": 3203,
-											"version": 13,
-											"createdAt": "2022-09-13T14:45:06.139Z",
-											"fields": [
-												{
-													"id": 3613,
-													"applicationFormId": 3529,
-													"baseFieldId": 3011,
-													"position": 29,
-													"label": "Your First Name",
-													"createdAt": "2022-12-12T17:54:24.988Z"
-												}
-											]
-										}
-									}
+									"$ref": "#/components/schemas/ApplicationForm"
 								}
 							}
 						}

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -513,6 +513,25 @@
 				},
 				"required": ["entries", "total"]
 			},
+			"ApplicationFormBundle": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Bundle"
+					},
+					{
+						"type": "object",
+						"properties": {
+							"entries": {
+								"type": "array",
+								"items": {
+									"$ref": "#/components/schemas/ApplicationForm"
+								}
+							}
+						},
+						"required": ["entries"]
+					}
+				]
+			},
 			"OrganizationBundle": {
 				"allOf": [
 					{
@@ -589,23 +608,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/ApplicationForm"
-									}
-								},
-								"examples": {
-									"default": {
-										"summary": "The default is a shallow response. To get deep objects, request by applicationFormId.",
-										"value": [
-											{
-												"id": 3529,
-												"opportunityId": 3203,
-												"version": 13,
-												"createdAt": "2022-09-13T14:45:06.139Z"
-											}
-										]
-									}
+									"$ref": "#/components/schemas/ApplicationFormBundle"
 								}
 							}
 						}

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -399,7 +399,7 @@ describe('processBulkUpload', () => {
 		expect(applicationForm).toMatchObject({
 			opportunityId: opportunity.id,
 			version: 1,
-			createdAt: expect.any(Date) as Date,
+			createdAt: expectTimestamp,
 		});
 
 		const [firstProposal, secondProposal] = await getProposalsByExternalIds([

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -6,6 +6,7 @@ import {
 	loadBulkUpload,
 	loadProposalBundle,
 	loadApplicationFormFieldBundle,
+	loadApplicationFormBundle,
 } from '../../database';
 import { s3Client } from '../../s3Client';
 import { getMockJobHelpers } from '../../test/mockGraphileWorker';
@@ -13,7 +14,6 @@ import { processBulkUpload } from '../processBulkUpload';
 import { BulkUploadStatus, Proposal } from '../../types';
 import { expectTimestamp } from '../../test/utils';
 import type {
-	ApplicationForm,
 	ApplicationFormField,
 	BaseField,
 	BulkUpload,
@@ -391,8 +391,8 @@ describe('processBulkUpload', () => {
 		}
 
 		const {
-			rows: [applicationForm],
-		} = await db.sql<ApplicationForm>('applicationForms.selectAll');
+			entries: [applicationForm],
+		} = await loadApplicationFormBundle();
 		if (applicationForm === undefined) {
 			fail('The application form was not created');
 		}

--- a/src/types/ApplicationForm.ts
+++ b/src/types/ApplicationForm.ts
@@ -5,21 +5,23 @@ import type {
 	ApplicationFormField,
 	WritableApplicationFormFieldWithApplicationContext,
 } from './ApplicationFormField';
+import type { Writable } from './Writable';
 
-export interface ApplicationForm {
+interface ApplicationForm {
 	readonly id: number;
 	opportunityId: number;
-	version: number;
-	fields?: ApplicationFormField[];
+	readonly version: number;
+	readonly fields: ApplicationFormField[];
 	readonly createdAt: Date;
 }
 
-export type ApplicationFormWrite = Omit<
-	ApplicationForm,
-	'createdAt' | 'fields' | 'id' | 'version'
-> & { fields: WritableApplicationFormFieldWithApplicationContext[] };
+type WritableApplicationForm = Writable<ApplicationForm>;
 
-export const applicationFormWriteSchema: JSONSchemaType<ApplicationFormWrite> =
+type WritableApplicationFormWithFields = WritableApplicationForm & {
+	fields: WritableApplicationFormFieldWithApplicationContext[];
+};
+
+const writableApplicationFormWithFieldsSchema: JSONSchemaType<WritableApplicationFormWithFields> =
 	{
 		type: 'object',
 		properties: {
@@ -34,4 +36,13 @@ export const applicationFormWriteSchema: JSONSchemaType<ApplicationFormWrite> =
 		required: ['opportunityId', 'fields'],
 	};
 
-export const isApplicationFormWrite = ajv.compile(applicationFormWriteSchema);
+const isWritableApplicationFormWithFields = ajv.compile(
+	writableApplicationFormWithFieldsSchema,
+);
+
+export {
+	ApplicationForm,
+	isWritableApplicationFormWithFields,
+	writableApplicationFormWithFieldsSchema,
+	WritableApplicationForm,
+};


### PR DESCRIPTION
This PR continues the work of DB consolidation and moving to a standardized way of accessing data.

It makes the following changes:

1.  Adds utility methods for create / load.
2. Updates the existing queries into the modern age of returning json.
3. Removes the query parameter for optionally returning deep / shallow ApplicationForms; the API now always returns deep ApplicationForms.

Related to #228 