### PR TITLE
Fail eslint on warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"cleanup": "rimraf dist",
 		"format": "prettier . --write",
 		"lint": "npm run lint:ts && npm run lint:prettier && npm run lint:swagger",
-		"lint:ts": "eslint ./src --ext .ts",
+		"lint:ts": "eslint ./src --ext .ts --max-warnings=0",
 		"lint:swagger": "swagger-spec-validator src/openapi.json",
 		"lint:prettier": "prettier . --check",
 		"migrate": "ts-node src/scripts/migrate.ts | pino-pretty",


### PR DESCRIPTION
This PR updates our lint command to fail if there are warnings.  This will apply both to local invocations of lint as well as the CI invocation.