### PR TITLE
Add support for `Proposal` ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `BulkUpload` entity now has a `createdBy` attribute.
+- The `Proposal` entity now has a `createdBy` attribute.
 
 ## 0.7.0 2024-04-04
 

--- a/src/__tests__/organizationProposals.int.test.ts
+++ b/src/__tests__/organizationProposals.int.test.ts
@@ -7,7 +7,7 @@ import {
 	db,
 	loadTableMetrics,
 } from '../database';
-import { expectTimestamp } from '../test/utils';
+import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 
 const agent = request.agent(app);
@@ -33,14 +33,17 @@ describe('/organizationProposals', () => {
 			await db.sql('opportunities.insertOne', {
 				title: '🔥',
 			});
+			const testUser = await loadTestUser();
 			await insertTestOrganizations();
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
+				createdBy: testUser.id,
 			});
 			await createProposal({
 				opportunityId: 1,
 				externalId: '2',
+				createdBy: testUser.id,
 			});
 			await createOrganizationProposal({
 				organizationId: 1,
@@ -72,6 +75,7 @@ describe('/organizationProposals', () => {
 							externalId: '2',
 							versions: [],
 							createdAt: expectTimestamp,
+							createdBy: testUser.id,
 						},
 						createdAt: expectTimestamp,
 					},
@@ -91,6 +95,7 @@ describe('/organizationProposals', () => {
 							externalId: '1',
 							versions: [],
 							createdAt: expectTimestamp,
+							createdBy: testUser.id,
 						},
 						createdAt: expectTimestamp,
 					},
@@ -103,14 +108,17 @@ describe('/organizationProposals', () => {
 			await db.sql('opportunities.insertOne', {
 				title: '🔥',
 			});
+			const testUser = await loadTestUser();
 			await insertTestOrganizations();
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
+				createdBy: testUser.id,
 			});
 			await createProposal({
 				opportunityId: 1,
 				externalId: '2',
+				createdBy: testUser.id,
 			});
 			await createOrganizationProposal({
 				organizationId: 1,
@@ -142,6 +150,7 @@ describe('/organizationProposals', () => {
 							externalId: '1',
 							versions: [],
 							createdAt: expectTimestamp,
+							createdBy: testUser.id,
 						},
 						createdAt: expectTimestamp,
 					},
@@ -169,9 +178,11 @@ describe('/organizationProposals', () => {
 				title: '🔥',
 			});
 			await insertTestOrganizations();
+			const testUser = await loadTestUser();
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
+				createdBy: testUser.id,
 			});
 			const before = await loadTableMetrics('organizations_proposals');
 			const result = await agent
@@ -201,6 +212,7 @@ describe('/organizationProposals', () => {
 					externalId: '1',
 					versions: [],
 					createdAt: expectTimestamp,
+					createdBy: testUser.id,
 				},
 				createdAt: expectTimestamp,
 			});
@@ -211,10 +223,12 @@ describe('/organizationProposals', () => {
 			await db.sql('opportunities.insertOne', {
 				title: '🔥',
 			});
+			const testUser = await loadTestUser();
 			await insertTestOrganizations();
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
+				createdBy: testUser.id,
 			});
 			const result = await agent
 				.post('/organizationProposals')
@@ -234,10 +248,12 @@ describe('/organizationProposals', () => {
 			await db.sql('opportunities.insertOne', {
 				title: '🔥',
 			});
+			const testUser = await loadTestUser();
 			await insertTestOrganizations();
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
+				createdBy: testUser.id,
 			});
 			const result = await agent
 				.post('/organizationProposals')
@@ -276,9 +292,11 @@ describe('/organizationProposals', () => {
 			await db.sql('opportunities.insertOne', {
 				title: '🔥',
 			});
+			const testUser = await loadTestUser();
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
+				createdBy: testUser.id,
 			});
 			const result = await agent
 				.post('/organizationProposals')
@@ -298,10 +316,12 @@ describe('/organizationProposals', () => {
 			await db.sql('opportunities.insertOne', {
 				title: '🔥',
 			});
+			const testUser = await loadTestUser();
 			await insertTestOrganizations();
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
+				createdBy: testUser.id,
 			});
 			await createOrganizationProposal({
 				organizationId: 1,

--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -7,7 +7,7 @@ import {
 	db,
 	loadTableMetrics,
 } from '../database';
-import { expectTimestamp } from '../test/utils';
+import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import { PostgresErrorCode } from '../types';
 
@@ -123,9 +123,11 @@ describe('/organizations', () => {
 			await db.sql('opportunities.insertOne', {
 				title: '🔥',
 			});
+			const testUser = await loadTestUser();
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
+				createdBy: testUser.id,
 			});
 			await createOrganization({
 				employerIdentificationNumber: '123-123-123',

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -1,9 +1,9 @@
 import request from 'supertest';
 import { app } from '../app';
-import { db, loadTableMetrics } from '../database';
+import { createProposal, db, loadTableMetrics } from '../database';
 import { getLogger } from '../logger';
 import { BaseFieldDataType } from '../types';
-import { expectTimestamp } from '../test/utils';
+import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 
 const logger = getLogger(__filename);
@@ -39,15 +39,12 @@ describe('/proposalVersions', () => {
         VALUES
           ( '🔥', '2525-01-02T00:00:01Z' )
       `);
-			await db.query(`
-        INSERT INTO proposals (
-          external_id,
-          opportunity_id,
-          created_at
-        )
-        VALUES
-          ( 'proposal-1', 1, '2525-01-01T00:00:05Z' );
-      `);
+			const testUser = await loadTestUser();
+			await createProposal({
+				externalId: 'proposal-1',
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
 			await db.query(`
         INSERT INTO application_forms (
           opportunity_id,
@@ -89,15 +86,12 @@ describe('/proposalVersions', () => {
         VALUES
           ( '🔥', '2525-01-02T00:00:01Z' )
       `);
-			await db.query(`
-        INSERT INTO proposals (
-          external_id,
-          opportunity_id,
-          created_at
-        )
-        VALUES
-          ( 'proposal-1', 1, '2525-01-01T00:00:05Z' );
-      `);
+			const testUser = await loadTestUser();
+			await createProposal({
+				externalId: 'proposal-1',
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
 			await db.query(`
         INSERT INTO application_forms (
           opportunity_id,
@@ -218,15 +212,12 @@ describe('/proposalVersions', () => {
         VALUES
           ( '🔥', '2525-01-02T00:00:01Z' )
       `);
-			await db.query(`
-        INSERT INTO proposals (
-          external_id,
-          opportunity_id,
-          created_at
-        )
-        VALUES
-          ( 'proposal-1', 1, '2525-01-01T00:00:05Z' );
-      `);
+			const testUser = await loadTestUser();
+			await createProposal({
+				externalId: 'proposal-1',
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
 			await db.query(`
         INSERT INTO application_forms (
           opportunity_id,
@@ -267,15 +258,12 @@ describe('/proposalVersions', () => {
         VALUES
           ( '🔥', '2525-01-02T00:00:01Z' )
       `);
-			await db.query(`
-        INSERT INTO proposals (
-          external_id,
-          opportunity_id,
-          created_at
-        )
-        VALUES
-          ( 'proposal-1', 1, '2525-01-01T00:00:05Z' );
-      `);
+			const testUser = await loadTestUser();
+			await createProposal({
+				externalId: 'proposal-1',
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
 			await db.query(`
         INSERT INTO application_forms (
           opportunity_id,
@@ -322,15 +310,12 @@ describe('/proposalVersions', () => {
           ( '🔥', '2525-01-02T00:00:01Z' ),
           ( '💧', '2525-01-02T00:00:01Z' )
       `);
-			await db.query(`
-        INSERT INTO proposals (
-          external_id,
-          opportunity_id,
-          created_at
-        )
-        VALUES
-          ( 'proposal-1', 1, '2525-01-01T00:00:05Z' );
-      `);
+			const testUser = await loadTestUser();
+			await createProposal({
+				externalId: 'proposal-1',
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
 			await db.query(`
         INSERT INTO application_forms (
           opportunity_id,
@@ -379,15 +364,12 @@ describe('/proposalVersions', () => {
         VALUES
           ( '🔥', '2525-01-02T00:00:01Z' )
       `);
-			await db.query(`
-        INSERT INTO proposals (
-          external_id,
-          opportunity_id,
-          created_at
-        )
-        VALUES
-          ( 'proposal-1', 1, '2525-01-01T00:00:05Z' );
-      `);
+			const testUser = await loadTestUser();
+			await createProposal({
+				externalId: 'proposal-1',
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
 			await db.query(`
         INSERT INTO application_forms (
           opportunity_id,
@@ -440,15 +422,13 @@ describe('/proposalVersions', () => {
         VALUES
           ( '🔥', '2525-01-02T00:00:01Z' )
       `);
-			await db.query(`
-        INSERT INTO proposals (
-          external_id,
-          opportunity_id,
-          created_at
-        )
-        VALUES
-          ( 'proposal-1', 1, '2525-01-01T00:00:05Z' );
-      `);
+
+			const testUser = await loadTestUser();
+			await createProposal({
+				externalId: 'proposal-1',
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
 			await db.query(`
         INSERT INTO application_forms (
           opportunity_id,

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -8,14 +8,15 @@ import {
 	db,
 	loadTableMetrics,
 } from '../database';
-import { getLogger } from '../logger';
-import { expectTimestamp } from '../test/utils';
-import { mockJwt as authHeader } from '../test/mockJwt';
+import { expectTimestamp, loadTestUser } from '../test/utils';
+import {
+	mockJwt as authHeader,
+	mockJwtWithoutSub as authHeaderWithNoSubj,
+} from '../test/mockJwt';
 import { PostgresErrorCode } from '../types/PostgresErrorCode';
 import { createApplicationForm } from '../database/operations/create/createApplicationForm';
 import { BaseFieldDataType } from '../types';
 
-const logger = getLogger(__filename);
 const agent = request.agent(app);
 
 const createTestBaseFields = async () => {
@@ -54,14 +55,17 @@ describe('/proposals', () => {
 			await db.sql('opportunities.insertOne', {
 				title: '🔥',
 			});
+			const testUser = await loadTestUser();
 			await createTestBaseFields();
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
+				createdBy: testUser.id,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
+				createdBy: testUser.id,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -96,6 +100,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-2',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 						versions: [],
 					},
 					{
@@ -103,6 +108,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-1',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 						versions: [
 							{
 								id: 1,
@@ -149,14 +155,17 @@ describe('/proposals', () => {
 				title: '🔥',
 			});
 
+			const testUser = await loadTestUser();
 			await createTestBaseFields();
 			const proposal = await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
+				createdBy: testUser.id,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
+				createdBy: testUser.id,
 			});
 			const organization = await createOrganization({
 				employerIdentificationNumber: '123-123-123',
@@ -178,6 +187,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-1',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 						versions: [],
 					},
 				],
@@ -200,14 +210,17 @@ describe('/proposals', () => {
 				title: '🔥',
 			});
 
+			const testUser = await loadTestUser();
 			await createTestBaseFields();
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
+				createdBy: testUser.id,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
+				createdBy: testUser.id,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -252,6 +265,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-1',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 						versions: [
 							{
 								id: 1,
@@ -300,14 +314,17 @@ describe('/proposals', () => {
 			await db.sql('opportunities.insertOne', {
 				title: 'Grand opportunity',
 			});
+			const testUser = await loadTestUser();
 			await createTestBaseFields();
 			await createProposal({
 				externalId: 'proposal-4999',
 				opportunityId: 1,
+				createdBy: testUser.id,
 			});
 			await createProposal({
 				externalId: 'proposal-5003',
 				opportunityId: 1,
+				createdBy: testUser.id,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -352,6 +369,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-4999',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 						versions: [
 							{
 								id: 1,
@@ -397,11 +415,14 @@ describe('/proposals', () => {
 			await db.sql('opportunities.insertOne', {
 				title: '🔥',
 			});
+
+			const testUser = await loadTestUser();
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
 				await createProposal({
 					externalId: `proposal-${i + 1}`,
 					opportunityId: 1,
+					createdBy: testUser.id,
 				});
 			}, Promise.resolve());
 			const response = await agent
@@ -421,6 +442,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 					},
 					{
 						id: 14,
@@ -428,6 +450,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 					},
 					{
 						id: 13,
@@ -435,6 +458,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 					},
 					{
 						id: 12,
@@ -442,6 +466,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 					},
 					{
 						id: 11,
@@ -449,6 +474,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 					},
 				],
 			});
@@ -497,16 +523,19 @@ describe('/proposals', () => {
         VALUES
           ( '⛰️', '2525-01-03T00:00:01Z' )
       `);
-			await db.query(`
-        INSERT INTO proposals (
-          external_id,
-          opportunity_id,
-          created_at
-        )
-        VALUES
-          ( 'proposal-1', 1, '2525-01-03T00:00:04Z' ),
-          ( 'proposal-2', 1, '2525-01-03T00:00:05Z' );
-      `);
+
+			const testUser = await loadTestUser();
+			await createProposal({
+				externalId: `proposal-1`,
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
+			await createProposal({
+				externalId: `proposal-2`,
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
+
 			const response = await agent
 				.get('/proposals/2')
 				.set(authHeader)
@@ -517,6 +546,7 @@ describe('/proposals', () => {
 				versions: [],
 				opportunityId: 1,
 				createdAt: expectTimestamp,
+				createdBy: testUser.id,
 			});
 		});
 
@@ -551,15 +581,12 @@ describe('/proposals', () => {
           ( 1, 2, 1, 'Short summary or title', '2525-01-04T00:00:05Z' ),
           ( 1, 1, 2, 'Long summary or abstract', '2525-01-04T00:00:06Z' );
       `);
-			await db.query(`
-        INSERT INTO proposals (
-          external_id,
-          opportunity_id,
-          created_at
-        )
-        VALUES
-          ( 'proposal-2525-01-04T00Z', 1, '2525-01-04T00:00:07Z' );
-      `);
+			const testUser = await loadTestUser();
+			await createProposal({
+				externalId: `proposal-2525-01-04T00Z`,
+				opportunityId: 1,
+				createdBy: testUser.id,
+			});
 			await db.query(`
         INSERT INTO proposal_versions (
           proposal_id,
@@ -595,6 +622,7 @@ describe('/proposals', () => {
 				opportunityId: 1,
 				externalId: 'proposal-2525-01-04T00Z',
 				createdAt: expectTimestamp,
+				createdBy: testUser.id,
 				versions: [
 					{
 						id: 2,
@@ -724,6 +752,10 @@ describe('/proposals', () => {
 			await agent.post('/proposals').expect(401);
 		});
 
+		it('requires a user', async () => {
+			await agent.post('/proposals').set(authHeaderWithNoSubj).expect(401);
+		});
+
 		it('creates exactly one proposal', async () => {
 			await db.query(`
         INSERT INTO opportunities (
@@ -734,7 +766,7 @@ describe('/proposals', () => {
           ( '🔥', '2525-01-02T00:00:01Z' )
       `);
 			const before = await loadTableMetrics('proposals');
-			logger.debug('before: %o', before);
+			const testUser = await loadTestUser();
 			const result = await agent
 				.post('/proposals')
 				.type('application/json')
@@ -745,13 +777,13 @@ describe('/proposals', () => {
 				})
 				.expect(201);
 			const after = await loadTableMetrics('proposals');
-			logger.debug('after: %o', after);
 			expect(before.count).toEqual(0);
 			expect(result.body).toMatchObject({
 				id: 1,
 				externalId: 'proposal123',
 				opportunityId: 1,
 				createdAt: expectTimestamp,
+				createdBy: testUser.id,
 			});
 			expect(after.count).toEqual(1);
 		});

--- a/src/database/initialization/proposal_to_json.sql
+++ b/src/database/initialization/proposal_to_json.sql
@@ -16,7 +16,8 @@ BEGIN
     'opportunityId', proposal.opportunity_id,
     'externalId', proposal.external_id,
     'versions', COALESCE(proposal_versions_json, '[]'::JSONB),
-    'createdAt', proposal.created_at
+    'createdAt', proposal.created_at,
+    'createdBy', proposal.created_by
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/src/database/migrations/0025-alter-proposals.sql
+++ b/src/database/migrations/0025-alter-proposals.sql
@@ -1,0 +1,6 @@
+ALTER TABLE proposals
+  ADD COLUMN created_by INTEGER NOT NULL DEFAULT select_system_user_id(),
+  ADD CONSTRAINT fk_createdBy FOREIGN KEY (created_by) REFERENCES users(id);
+
+ALTER TABLE proposals
+  ALTER COLUMN created_by DROP DEFAULT;

--- a/src/database/operations/create/createProposal.ts
+++ b/src/database/operations/create/createProposal.ts
@@ -1,13 +1,18 @@
 import { db } from '../../db';
-import type { Proposal, JsonResultSet, WritableProposal } from '../../../types';
+import type {
+	Proposal,
+	JsonResultSet,
+	InternallyWritableProposal,
+} from '../../../types';
 
 export const createProposal = async (
-	createValues: WritableProposal,
+	createValues: InternallyWritableProposal,
 ): Promise<Proposal> => {
-	const { opportunityId, externalId } = createValues;
+	const { opportunityId, externalId, createdBy } = createValues;
 	const result = await db.sql<JsonResultSet<Proposal>>('proposals.insertOne', {
 		opportunityId,
 		externalId,
+		createdBy,
 	});
 	const proposal = result.rows[0]?.object;
 	if (proposal === undefined) {

--- a/src/database/queries/proposals/insertOne.sql
+++ b/src/database/queries/proposals/insertOne.sql
@@ -1,8 +1,10 @@
 INSERT INTO proposals (
   external_id,
-  opportunity_id
+  opportunity_id,
+  created_by
 ) VALUES (
   :externalId,
-  :opportunityId
+  :opportunityId,
+  :createdBy
 )
 RETURNING proposal_to_json(proposals) AS "object";

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -255,6 +255,11 @@
 						"type": "string",
 						"format": "date-time",
 						"readOnly": true
+					},
+					"createdBy": {
+						"description": "The id of the PDC user that created this proposal",
+						"type": "integer",
+						"readOnly": true
 					}
 				},
 				"required": ["id", "opportunityId", "externalId", "createdAt"]

--- a/src/tasks/processBulkUpload.ts
+++ b/src/tasks/processBulkUpload.ts
@@ -28,7 +28,6 @@ import type {
 	ApplicationFormField,
 	BulkUpload,
 	Opportunity,
-	Proposal,
 	ProposalFieldValue,
 	ProposalVersion,
 } from '../types';
@@ -186,17 +185,6 @@ const createApplicationFormFieldsForBulkUpload = async (
 	return applicationFormFields;
 };
 
-const createProposalForBulkUploadCsvRecord = async (
-	opportunityId: number,
-	externalId: string,
-): Promise<Proposal> => {
-	const proposal = await createProposal({
-		opportunityId,
-		externalId,
-	});
-	return proposal;
-};
-
 const createProposalVersionForBulkUploadCsvRecord = async (
 	proposalId: number,
 	applicationFormId: number,
@@ -304,10 +292,11 @@ export const processBulkUpload = async (
 		let recordNumber = 0;
 		await parser.forEach(async (record: string[]) => {
 			recordNumber += 1;
-			const proposal = await createProposalForBulkUploadCsvRecord(
-				opportunity.id,
-				`${recordNumber}`,
-			);
+			const proposal = await createProposal({
+				opportunityId: opportunity.id,
+				externalId: `${recordNumber}`,
+				createdBy: bulkUpload.createdBy,
+			});
 			const proposalVersion = await createProposalVersionForBulkUploadCsvRecord(
 				proposal.id,
 				applicationForm.id,

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -9,9 +9,13 @@ interface Proposal {
 	externalId: string;
 	readonly versions?: ProposalVersion[];
 	readonly createdAt: string;
+	readonly createdBy: number;
 }
 
 type WritableProposal = Writable<Proposal>;
+
+type InternallyWritableProposal = WritableProposal &
+	Pick<Proposal, 'createdBy'>;
 
 const writableProposalSchema: JSONSchemaType<WritableProposal> = {
 	type: 'object',
@@ -31,6 +35,7 @@ const isWritableProposal = ajv.compile(writableProposalSchema);
 
 export {
 	isWritableProposal,
+	InternallyWritableProposal,
 	Proposal,
 	WritableProposal,
 	writableProposalSchema,


### PR DESCRIPTION
This PR adds`createdBy` to the `proposals` table and populates the `createdBy` field based on the user that initiated the creation of a given proposal.

This PR should not be merged until after #892 has been merged.

Resolves #485