### PR TITLE
Only return bulk uploads for the current user

### DIFF
--- a/src/database/operations/load/loadBulkUploadBundle.ts
+++ b/src/database/operations/load/loadBulkUploadBundle.ts
@@ -1,13 +1,24 @@
 import { loadBundle } from './loadBundle';
-import type { TinyPgParams } from 'tinypg';
 import type { JsonResultSet, Bundle, BulkUpload } from '../../../types';
 
-export const loadBulkUploadBundle = async (
-	queryParameters: TinyPgParams,
-): Promise<Bundle<BulkUpload>> => {
+export const loadBulkUploadBundle = async (queryParameters: {
+	offset: number;
+	limit: number;
+	createdBy?: number;
+}): Promise<Bundle<BulkUpload>> => {
+	const defaultQueryParameters = {
+		createdBy: 0,
+	};
+	const { offset, limit, createdBy } = queryParameters;
+
 	const bundle = await loadBundle<JsonResultSet<BulkUpload>>(
 		'bulkUploads.selectWithPagination',
-		queryParameters,
+		{
+			...defaultQueryParameters,
+			offset,
+			limit,
+			createdBy,
+		},
 		'bulk_uploads',
 	);
 	const entries = bundle.entries.map((entry) => entry.object);

--- a/src/database/queries/bulkUploads/selectWithPagination.sql
+++ b/src/database/queries/bulkUploads/selectWithPagination.sql
@@ -1,5 +1,12 @@
 SELECT bulk_upload_to_json(bulk_uploads.*) as "object"
 FROM bulk_uploads
+WHERE
+  CASE
+    WHEN :createdBy != 0 THEN
+      bulk_uploads.created_by = :createdBy
+    ELSE
+      true
+    END
 ORDER BY id DESC
 LIMIT
   CASE WHEN :limit != 0 THEN

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -743,7 +743,7 @@
 				],
 				"responses": {
 					"200": {
-						"description": "All bulk uploads currently registered in the PDC.",
+						"description": "Requested bulk uploads registered in the PDC.",
 						"content": {
 							"application/json": {
 								"schema": {


### PR DESCRIPTION
This PR changes the way GET `/bulkUploads` works so that it only returns the bulk uploads associated with the current user.

This PR should not be reviewed until after #894

Resolves #759 