### PR TITLE
Update `createdAt` to string in most cases

### DIFF
--- a/src/types/ApplicationForm.ts
+++ b/src/types/ApplicationForm.ts
@@ -12,7 +12,7 @@ interface ApplicationForm {
 	opportunityId: number;
 	readonly version: number;
 	readonly fields: ApplicationFormField[];
-	readonly createdAt: Date;
+	readonly createdAt: string;
 }
 
 type WritableApplicationForm = Writable<ApplicationForm>;

--- a/src/types/ApplicationFormField.ts
+++ b/src/types/ApplicationFormField.ts
@@ -9,7 +9,7 @@ interface ApplicationFormField {
 	readonly baseField: BaseField;
 	position: number;
 	label: string;
-	readonly createdAt: Date;
+	readonly createdAt: string;
 }
 
 type WritableApplicationFormField = Writable<ApplicationFormField>;

--- a/src/types/Organization.ts
+++ b/src/types/Organization.ts
@@ -6,7 +6,7 @@ interface Organization {
 	readonly id: number;
 	employerIdentificationNumber: string;
 	name: string;
-	readonly createdAt: Date;
+	readonly createdAt: string;
 }
 
 type WritableOrganization = Writable<Organization>;

--- a/src/types/OrganizationProposal.ts
+++ b/src/types/OrganizationProposal.ts
@@ -6,7 +6,7 @@ interface OrganizationProposal {
 	readonly id: number;
 	organizationId: number;
 	proposalId: number;
-	readonly createdAt: Date;
+	readonly createdAt: string;
 }
 
 type WritableOrganizationProposal = Writable<OrganizationProposal>;

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -8,7 +8,7 @@ interface Proposal {
 	opportunityId: number;
 	externalId: string;
 	readonly versions?: ProposalVersion[];
-	readonly createdAt: Date;
+	readonly createdAt: string;
 }
 
 type WritableProposal = Writable<Proposal>;

--- a/src/types/ProposalFieldValue.ts
+++ b/src/types/ProposalFieldValue.ts
@@ -7,7 +7,7 @@ interface ProposalFieldValue {
 	applicationFormFieldId: number;
 	position: number;
 	value: string;
-	readonly createdAt: Date;
+	readonly createdAt: string;
 	readonly applicationFormField?: ApplicationFormField;
 	readonly isValid: boolean;
 }

--- a/src/types/ProposalVersion.ts
+++ b/src/types/ProposalVersion.ts
@@ -12,7 +12,7 @@ export interface ProposalVersion {
 	applicationFormId: number;
 	version: number;
 	fieldValues?: ProposalFieldValue[];
-	createdAt: Date;
+	createdAt: string;
 }
 
 export type ProposalVersionWrite = Omit<

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -3,7 +3,7 @@ import type { Writable } from './Writable';
 interface User {
 	readonly id: number;
 	authenticationId: string;
-	readonly createdAt: Date;
+	readonly createdAt: string;
 }
 
 type WritableUser = Writable<User>;


### PR DESCRIPTION
This PR corrects our type definitions so that `createdAt` is a string for any object that is retrieved from the database using the json object pattern.

Resolves #862