### PR TITLE
Update test timestamp pattern

### DIFF
--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,7 +1,7 @@
 import { createUser, loadUserByAuthenticationId } from '../database';
 
 export const isoTimestampPattern =
-	/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3,6})?(Z|(\+|-)\d{2}:\d{2})$/;
+	/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?(Z|(\+|-)\d{2}:\d{2})$/;
 
 export const expectTimestamp = expect.stringMatching(
 	isoTimestampPattern,


### PR DESCRIPTION
This PR updates our timestamp to account for situations where the DB returns lower precision timestamps, which has now happened at least once in CI!

Resolves #906 