### PR TITLE
Fix organization duplicate result bug

### DIFF
--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -133,6 +133,10 @@ describe('/organizations', () => {
 				employerIdentificationNumber: '123-123-123',
 				name: 'Canadian Company',
 			});
+			await createOrganization({
+				employerIdentificationNumber: '123-123-123',
+				name: 'Another Canadian Company',
+			});
 			await createOrganizationProposal({
 				organizationId: 1,
 				proposalId: 1,
@@ -142,7 +146,7 @@ describe('/organizations', () => {
 				.set(authHeader)
 				.expect(200);
 			expect(response.body).toEqual({
-				total: 1,
+				total: 2,
 				entries: [
 					{
 						id: 1,

--- a/src/database/queries/organizations/selectWithPagination.sql
+++ b/src/database/queries/organizations/selectWithPagination.sql
@@ -1,4 +1,4 @@
-SELECT o.id AS "id",
+SELECT DISTINCT o.id AS "id",
   o.employer_identification_number AS "employerIdentificationNumber",
   o.name AS "name",
   o.created_at AS "createdAt"


### PR DESCRIPTION
This PR fixes a bug where the `/organizations` endpoint would return multiple organizations if that organization had more than one associated proposal.

Resolves #905 