### PR TITLE
Allow public organizations access

### DIFF
--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -26,8 +26,8 @@ const insertTestOrganizations = async () => {
 
 describe('/organizations', () => {
 	describe('GET /', () => {
-		it('requires authentication', async () => {
-			await agent.get('/organizations').expect(401);
+		it('does not require authentication', async () => {
+			await agent.get('/organizations').expect(200);
 		});
 
 		it('returns an empty Bundle when no data is present', async () => {
@@ -215,8 +215,9 @@ describe('/organizations', () => {
 	});
 
 	describe('GET /:id', () => {
-		it('requires authentication', async () => {
-			await agent.get('/organizations/1').expect(401);
+		it('does not require authentication', async () => {
+			await insertTestOrganizations();
+			await agent.get('/organizations/1').expect(200);
 		});
 
 		it('returns 404 when given id is not present', async () => {

--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -240,7 +240,6 @@ describe('/organizations', () => {
 		});
 
 		it('returns a 400 bad request when a non-integer ID is sent', async () => {
-			await insertTestOrganizations();
 			await agent.get('/organizations/foo').set(authHeader).expect(400);
 		});
 	});

--- a/src/routers/organizationsRouter.ts
+++ b/src/routers/organizationsRouter.ts
@@ -4,15 +4,10 @@ import { requireAuthentication } from '../middleware';
 
 const organizationsRouter = express.Router();
 
-organizationsRouter.get(
-	'/',
-	requireAuthentication,
-	organizationsHandlers.getOrganizations,
-);
+organizationsRouter.get('/', organizationsHandlers.getOrganizations);
 
 organizationsRouter.get(
 	'/:organizationId',
-	requireAuthentication,
 	organizationsHandlers.getOrganization,
 );
 


### PR DESCRIPTION
This PR updates our `/organizations` endpoints so the GET varieties are public.  Eventually we may add private data to the returned objects, but that data would only be available for authorized users.

Resolves #912 