### PR TITLE
Add role middleware + an administrative role

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,12 @@ import express from 'express';
 import pinoHttp from 'pino-http';
 import cors from 'cors';
 import { rootRouter } from './routers';
-import { errorHandler, processJwt, addUserContext } from './middleware';
+import {
+	errorHandler,
+	processJwt,
+	addUserContext,
+	addRoleContext,
+} from './middleware';
 import { getLogger } from './logger';
 
 const logger = getLogger(__filename);
@@ -11,6 +16,7 @@ const app = express();
 app.use(cors());
 app.use(processJwt);
 app.use(addUserContext);
+app.use(addRoleContext);
 app.use(
 	pinoHttp({
 		logger,

--- a/src/middleware/__tests__/addRoleContext.int.test.ts
+++ b/src/middleware/__tests__/addRoleContext.int.test.ts
@@ -1,0 +1,44 @@
+import { addRoleContext } from '../addRoleContext';
+import { generateNextWithAssertions } from '../../test/utils';
+import type { Response } from 'express';
+import type { AuthenticatedRequest } from '../../types';
+
+describe('addRoleContext', () => {
+	it('Assigns the administrator role if pdc-admin is in the auth roles', (done) => {
+		const mockRequest = {
+			auth: {
+				realm_access: {
+					roles: ['pdc-admin'],
+				},
+			},
+		} as unknown as AuthenticatedRequest;
+		const mockResponse = {} as unknown as Response;
+
+		const runAssertions = async (err: unknown) => {
+			expect(err).toBe(undefined);
+			expect(mockRequest.role?.isAdministrator).toBe(true);
+		};
+
+		const nextMock = generateNextWithAssertions(runAssertions, done);
+		addRoleContext(mockRequest, mockResponse, nextMock);
+	});
+
+	it('Does NOT assign the administrator role if pdc-admin is not the auth roles', (done) => {
+		const mockRequest = {
+			auth: {
+				realm_access: {
+					roles: ['not-pdc-admin'],
+				},
+			},
+		} as unknown as AuthenticatedRequest;
+		const mockResponse = {} as unknown as Response;
+
+		const runAssertions = async (err: unknown) => {
+			expect(err).toBe(undefined);
+			expect(mockRequest.role?.isAdministrator).toBe(false);
+		};
+
+		const nextMock = generateNextWithAssertions(runAssertions, done);
+		addRoleContext(mockRequest, mockResponse, nextMock);
+	});
+});

--- a/src/middleware/__tests__/addUserContext.int.test.ts
+++ b/src/middleware/__tests__/addUserContext.int.test.ts
@@ -4,7 +4,7 @@ import { generateNextWithAssertions } from '../../test/utils';
 import type { Response } from 'express';
 import type { AuthenticatedRequest } from '../../types';
 
-describe('requireAuthentication', () => {
+describe('addUserContext', () => {
 	it('does not creates or assign a user when auth is not provided', (done) => {
 		const mockRequest = {} as unknown as AuthenticatedRequest;
 		const mockResponse = {} as unknown as Response;

--- a/src/middleware/addRoleContext.ts
+++ b/src/middleware/addRoleContext.ts
@@ -1,0 +1,41 @@
+import type { NextFunction, Response } from 'express';
+import type { AuthenticatedRequest } from '../types';
+import type { JwtPayload } from 'jsonwebtoken';
+
+const PDC_ADMIN_ROLE = 'pdc-admin';
+
+interface ObjectWithRolesArray {
+	roles: unknown[];
+}
+
+const isObjectWithRolesArray = (obj: unknown): obj is ObjectWithRolesArray =>
+	typeof obj === 'object' &&
+	obj !== null &&
+	'roles' in obj &&
+	Array.isArray(obj.roles);
+
+const isTokenWithRoles = (
+	token: JwtPayload,
+): token is JwtPayload & { realm_access: ObjectWithRolesArray } =>
+	isObjectWithRolesArray(token.realm_access);
+
+const getAuthRolesFromRequest = (req: AuthenticatedRequest): unknown[] => {
+	if (req.auth === undefined || !isTokenWithRoles(req.auth)) {
+		return [];
+	}
+	return req.auth.realm_access.roles;
+};
+
+const addRoleContext = (
+	req: AuthenticatedRequest,
+	res: Response,
+	next: NextFunction,
+): void => {
+	const authRoles = getAuthRolesFromRequest(req);
+	req.role = {
+		isAdministrator: authRoles.includes(PDC_ADMIN_ROLE),
+	};
+	next();
+};
+
+export { addRoleContext };

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,3 +1,4 @@
+export * from './addRoleContext';
 export * from './addUserContext';
 export * from './errorHandler';
 export * from './processJwt';

--- a/src/types/express/AuthenticatedRequest.ts
+++ b/src/types/express/AuthenticatedRequest.ts
@@ -3,6 +3,9 @@ import { User } from '../User';
 
 interface AuthenticatedRequest extends JwtRequest {
 	user?: User;
+	role?: {
+		isAdministrator: boolean;
+	};
 }
 
 export { AuthenticatedRequest };


### PR DESCRIPTION
This PR adds in middleware which will convert a jwt auth into a `role` object that gets added to the AuthenticatedRequest interface.

As of now being an administrator doesn't actually provide special access to anything, but providing that access will be as simple as checking `req.isAdministrator` once this is merged.