### PR TITLE
Validate Primitives using Ajv

### DIFF
--- a/src/__tests__/fieldValidation.unit.test.ts
+++ b/src/__tests__/fieldValidation.unit.test.ts
@@ -9,9 +9,13 @@ describe('field value validation against BaseFieldDataType', () => {
 	});
 	test('validate a valid numeric string as NUMBER', () => {
 		expect(fieldValueIsValid('123456', BaseFieldDataType.NUMBER)).toBe(true);
+		expect(fieldValueIsValid(' 123456 ', BaseFieldDataType.NUMBER)).toBe(true);
 	});
 	test('validate an invalid numeric string as NUMBER', () => {
 		expect(fieldValueIsValid('abc123', BaseFieldDataType.NUMBER)).toBe(false);
+		expect(fieldValueIsValid('abc123    4', BaseFieldDataType.NUMBER)).toBe(
+			false,
+		);
 	});
 	test('validate a valid email string as EMAIL', () => {
 		expect(fieldValueIsValid('abc@def.com', BaseFieldDataType.EMAIL)).toBe(
@@ -27,6 +31,9 @@ describe('field value validation against BaseFieldDataType', () => {
 		).toBe(true);
 		expect(
 			fieldValueIsValid('+1(800)-555-5555', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(true);
+		expect(
+			fieldValueIsValid('800-555-5555', BaseFieldDataType.PHONE_NUMBER),
 		).toBe(true);
 		expect(
 			fieldValueIsValid('800-555-5555', BaseFieldDataType.PHONE_NUMBER),
@@ -49,14 +56,14 @@ describe('field value validation against BaseFieldDataType', () => {
 	test('validate a valid boolean as BOOLEAN', () => {
 		expect(fieldValueIsValid('true', BaseFieldDataType.BOOLEAN)).toBe(true);
 		expect(fieldValueIsValid('false', BaseFieldDataType.BOOLEAN)).toBe(true);
-		expect(fieldValueIsValid('True', BaseFieldDataType.BOOLEAN)).toBe(true);
-		expect(fieldValueIsValid('False', BaseFieldDataType.BOOLEAN)).toBe(true);
 	});
 	test('validate an invalid boolean as BOOLEAN', () => {
 		expect(fieldValueIsValid('true123', BaseFieldDataType.BOOLEAN)).toBe(false);
 		expect(fieldValueIsValid('123false', BaseFieldDataType.BOOLEAN)).toBe(
 			false,
 		);
+		expect(fieldValueIsValid('TrUE', BaseFieldDataType.BOOLEAN)).toBe(false);
+		expect(fieldValueIsValid('FaLSE', BaseFieldDataType.BOOLEAN)).toBe(false);
 	});
 	test('validate a valid URL as URL', () => {
 		expect(

--- a/src/ajv.ts
+++ b/src/ajv.ts
@@ -1,7 +1,10 @@
 import Ajv from 'ajv';
 import ajvKeywords from 'ajv-keywords';
+import addFormats from 'ajv-formats';
 
 export const ajv = new Ajv({
 	coerceTypes: true,
 });
+
 ajvKeywords(ajv, 'instanceof');
+addFormats(ajv, ['email', 'uri']);

--- a/src/fieldValidation.ts
+++ b/src/fieldValidation.ts
@@ -1,31 +1,30 @@
-import Ajv from 'ajv';
-import addFormats from 'ajv-formats';
 import { phone } from 'phone';
 import { BaseFieldDataType } from './types';
+import { ajv } from './ajv';
 
-const ajv = new Ajv();
-addFormats(ajv, ['email', 'uri']);
+const isEmailString = ajv.compile({
+	type: 'string',
+	format: 'email',
+});
 
-function isValidEmail(email: string): boolean {
-	const emailSchema = {
-		type: 'string',
-		format: 'email',
-	};
+const isUrlString = ajv.compile({
+	type: 'string',
+	format: 'uri',
+});
 
-	return ajv.validate(emailSchema, email);
-}
+const isNumericString = ajv.compile({
+	type: 'number',
+});
 
-function isValidUrl(url: string): boolean {
-	const uriSchema = {
-		type: 'string',
-		format: 'uri',
-	};
-	return ajv.validate(uriSchema, url);
-}
+const isBooleanString = ajv.compile({
+	type: 'boolean',
+});
 
-function isValidPhoneNumber(phoneNumber: string): boolean {
-	return phone(phoneNumber).isValid;
-}
+const isString = ajv.compile({
+	type: 'string',
+});
+
+const isPhoneNumberString = (value: string) => phone(value).isValid;
 
 export const fieldValueIsValid = (
 	fieldValue: string,
@@ -33,16 +32,16 @@ export const fieldValueIsValid = (
 ): boolean => {
 	switch (dataType) {
 		case BaseFieldDataType.NUMBER:
-			return /^[0-9]*$/.test(fieldValue);
+			return isNumericString(fieldValue);
 		case BaseFieldDataType.PHONE_NUMBER:
-			return isValidPhoneNumber(fieldValue);
+			return isPhoneNumberString(fieldValue);
 		case BaseFieldDataType.EMAIL:
-			return isValidEmail(fieldValue);
+			return isEmailString(fieldValue);
 		case BaseFieldDataType.URL:
-			return isValidUrl(fieldValue);
+			return isUrlString(fieldValue);
 		case BaseFieldDataType.BOOLEAN:
-			return /^(true|false)$/i.test(fieldValue);
+			return isBooleanString(fieldValue);
 		default:
-			return true;
+			return isString(fieldValue);
 	}
 };


### PR DESCRIPTION
This PR rids us of the last of the hard-coded regex's used in type validation of proposal field values. It utilizes the primitive type validation in ajv to validate numbers and booleans. It follows the pattern in PR #914 of refactoring the ```fieldValueIsValid``` function to use a series of validation functions, instead of performing the validation itself.

Closes #899 