### PR TITLE
Restrict POST / PUT for /baseFields

### DIFF
--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -4,7 +4,10 @@ import { db, loadBaseFields, loadTableMetrics } from '../database';
 import { getLogger } from '../logger';
 import { BaseFieldDataType, PostgresErrorCode } from '../types';
 import { expectTimestamp } from '../test/utils';
-import { mockJwt as authHeader } from '../test/mockJwt';
+import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as adminUserAuthHeader,
+} from '../test/mockJwt';
 
 const logger = getLogger(__filename);
 const agent = request.agent(app);
@@ -67,13 +70,17 @@ describe('/baseFields', () => {
 			await agent.post('/baseFields').expect(401);
 		});
 
+		it('requires administrator role', async () => {
+			await agent.post('/baseFields').set(authHeader).expect(401);
+		});
+
 		it('creates exactly one base field', async () => {
 			const before = await loadTableMetrics('base_fields');
 			logger.debug('before: %o', before);
 			const result = await agent
 				.post('/baseFields')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',
@@ -98,7 +105,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.post('/baseFields')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					shortCode: '🩳',
 					description: '😍',
@@ -114,7 +121,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.post('/baseFields')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					shortCode: '🩳',
@@ -130,7 +137,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.post('/baseFields')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',
@@ -146,7 +153,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.post('/baseFields')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',
@@ -168,7 +175,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.post('/baseFields')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',
@@ -192,6 +199,10 @@ describe('/baseFields', () => {
 			await agent.put('/baseFields/1').expect(401);
 		});
 
+		it('requires administrator role', async () => {
+			await agent.put('/baseFields/1').set(authHeader).expect(401);
+		});
+
 		it('updates the specified base field', async () => {
 			// Not using the helper here because observing a change in values is explicitly
 			// the point of the test, so having full explicit control of the original value
@@ -205,7 +216,7 @@ describe('/baseFields', () => {
 			await agent
 				.put('/baseFields/1')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',
@@ -229,7 +240,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.put('/baseFields/1')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',
@@ -253,7 +264,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.put('/baseFields/1')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					shortCode: '🩳',
 					description: '😍',
@@ -271,7 +282,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.put('/baseFields/1')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					shortCode: '🩳',
@@ -289,7 +300,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.put('/baseFields/1')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',
@@ -307,7 +318,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.put('/baseFields/1')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',
@@ -324,7 +335,7 @@ describe('/baseFields', () => {
 			const result = await agent
 				.put('/baseFields/notanumber')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',
@@ -342,7 +353,7 @@ describe('/baseFields', () => {
 			await agent
 				.put('/baseFields/1')
 				.type('application/json')
-				.set(authHeader)
+				.set(adminUserAuthHeader)
 				.send({
 					label: '🏷️',
 					description: '😍',

--- a/src/middleware/__tests__/requireAdministratorRole.int.test.ts
+++ b/src/middleware/__tests__/requireAdministratorRole.int.test.ts
@@ -1,0 +1,50 @@
+import { requireAdministratorRole } from '../requireAdministratorRole';
+import { UnauthorizedError } from '../../errors';
+import type { Response } from 'express';
+import type { Request as JWTRequest } from 'express-jwt';
+
+describe('requireAuthentication', () => {
+	it('calls next with an UnauthorizedError when no roles value is provided', (done) => {
+		const mockRequest = {} as unknown as JWTRequest;
+		const mockResponse = {} as unknown as Response;
+		const nextMock = jest.fn((error) => {
+			expect(error).toBeInstanceOf(UnauthorizedError);
+			expect((error as UnauthorizedError).message).toEqual(
+				'Your account must have the administrator role.',
+			);
+			done();
+		});
+		requireAdministratorRole(mockRequest, mockResponse, nextMock);
+	});
+
+	it('calls next with an UnauthorizedError when the user has an administrator role set to false', (done) => {
+		const mockRequest = {
+			role: {
+				isAdministrator: false,
+			},
+		} as unknown as JWTRequest;
+		const mockResponse = {} as unknown as Response;
+		const nextMock = jest.fn((error) => {
+			expect(error).toBeInstanceOf(UnauthorizedError);
+			expect((error as UnauthorizedError).message).toEqual(
+				'Your account must have the administrator role.',
+			);
+			done();
+		});
+		requireAdministratorRole(mockRequest, mockResponse, nextMock);
+	});
+
+	it('calls next when the user has an administrator role set to true', (done) => {
+		const mockRequest = {
+			role: {
+				isAdministrator: true,
+			},
+		} as unknown as JWTRequest;
+		const mockResponse = {} as unknown as Response;
+		const nextMock = jest.fn((error) => {
+			expect(error).toBe(undefined);
+			done();
+		});
+		requireAdministratorRole(mockRequest, mockResponse, nextMock);
+	});
+});

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -2,4 +2,5 @@ export * from './addRoleContext';
 export * from './addUserContext';
 export * from './errorHandler';
 export * from './processJwt';
+export * from './requireAdministratorRole';
 export * from './requireAuthentication';

--- a/src/middleware/requireAdministratorRole.ts
+++ b/src/middleware/requireAdministratorRole.ts
@@ -1,0 +1,19 @@
+import { Response, NextFunction } from 'express';
+import { UnauthorizedError } from '../errors';
+import type { AuthenticatedRequest } from '../types';
+
+const requireAdministratorRole = (
+	req: AuthenticatedRequest,
+	res: Response,
+	next: NextFunction,
+) => {
+	if (req.role?.isAdministrator !== true) {
+		next(
+			new UnauthorizedError('Your account must have the administrator role.'),
+		);
+		return;
+	}
+	next();
+};
+
+export { requireAdministratorRole };

--- a/src/routers/baseFieldsRouter.ts
+++ b/src/routers/baseFieldsRouter.ts
@@ -1,18 +1,18 @@
 import express from 'express';
 import { baseFieldsHandlers } from '../handlers/baseFieldsHandlers';
-import { requireAuthentication } from '../middleware';
+import { requireAdministratorRole } from '../middleware';
 
 const baseFieldsRouter = express.Router();
 
 baseFieldsRouter.get('/', baseFieldsHandlers.getBaseFields);
 baseFieldsRouter.post(
 	'/',
-	requireAuthentication,
+	requireAdministratorRole,
 	baseFieldsHandlers.postBaseField,
 );
 baseFieldsRouter.put(
 	'/:id',
-	requireAuthentication,
+	requireAdministratorRole,
 	baseFieldsHandlers.putBaseField,
 );
 

--- a/src/test/mockJwt.ts
+++ b/src/test/mockJwt.ts
@@ -8,26 +8,44 @@ const getMockJwks = (): JWKSMock =>
 
 const mockJwks = getMockJwks();
 
-const getMockJwt = (sub?: string): { Authorization: string } => {
+const getMockJwt = (
+	settings: {
+		sub?: string;
+		roles?: string[];
+	} = {},
+): { Authorization: string } => {
 	const aMomentAgo = Math.round(new Date().getTime() / 1000);
 
 	const token = mockJwks.token({
 		exp: aMomentAgo + 1000000,
 		iat: aMomentAgo,
 		iss: issuer,
-		sub,
+		sub: settings.sub,
 		aud: 'account',
 		typ: 'Bearer',
 		azp: 'pdc-service',
 		realm_access: {
-			roles: ['default-roles-pdc'],
+			roles: settings.roles ?? ['default-roles-pdc'],
 		},
 	});
 	return { Authorization: `Bearer ${token}` };
 };
 
-const mockJwt = getMockJwt(getTestUserAuthenticationId());
+const mockJwt = getMockJwt({
+	sub: getTestUserAuthenticationId(),
+});
 
 const mockJwtWithoutSub = getMockJwt();
 
-export { mockJwks, mockJwt, mockJwtWithoutSub, getMockJwt };
+const mockJwtWithAdminRole = getMockJwt({
+	sub: getTestUserAuthenticationId(),
+	roles: ['pdc-admin'],
+});
+
+export {
+	mockJwks,
+	mockJwt,
+	mockJwtWithoutSub,
+	mockJwtWithAdminRole,
+	getMockJwt,
+};


### PR DESCRIPTION
This PR updates our `/baseFields` endpoints that change or create data so that only administrative users are able to access the endpoints.

Resolves #929 