### PR TITLE
Add authorization to GET `/proposals/:proposalId`

### DIFF
--- a/src/database/operations/assert/assertProposalAuthorization.ts
+++ b/src/database/operations/assert/assertProposalAuthorization.ts
@@ -1,0 +1,17 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import type { CheckResult } from '../../../types';
+
+export const assertProposalAuthorization = async (
+	id: number,
+	userId: number,
+): Promise<void> => {
+	const result = await db.sql<CheckResult>('proposals.checkAuthorization', {
+		id,
+		userId,
+	});
+
+	if (result.rows[0]?.result !== true) {
+		throw new NotFoundError(`The proposal was not found (id: ${id})`);
+	}
+};

--- a/src/database/operations/assert/index.ts
+++ b/src/database/operations/assert/index.ts
@@ -1,0 +1,1 @@
+export * from './assertProposalAuthorization';

--- a/src/database/operations/index.ts
+++ b/src/database/operations/index.ts
@@ -1,3 +1,4 @@
+export * from './assert';
 export * from './create';
 export * from './load';
 export * from './update';

--- a/src/database/queries/proposals/checkAuthorization.sql
+++ b/src/database/queries/proposals/checkAuthorization.sql
@@ -1,0 +1,12 @@
+SELECT EXISTS (
+  SELECT 1
+    FROM proposals
+    WHERE id = :id
+      AND
+        CASE
+          WHEN :userId != 0 THEN
+            created_by = :userId
+          ELSE
+            true
+          END
+) AS result

--- a/src/database/queries/proposals/checkExistsById.sql
+++ b/src/database/queries/proposals/checkExistsById.sql
@@ -1,3 +1,0 @@
-SELECT EXISTS (
-  SELECT 1 FROM proposals where id = :id
-) AS result

--- a/src/database/queries/proposals/selectById.sql
+++ b/src/database/queries/proposals/selectById.sql
@@ -1,3 +1,3 @@
 SELECT proposal_to_json(proposals.*) as "object"
-FROM proposals
-WHERE id = :id;
+  FROM proposals
+  WHERE id = :id

--- a/src/routers/proposalsRouter.ts
+++ b/src/routers/proposalsRouter.ts
@@ -5,7 +5,7 @@ import { requireAuthentication } from '../middleware';
 const proposalsRouter = express.Router();
 
 proposalsRouter.get(
-	'/:id',
+	'/:proposalId',
 	requireAuthentication,
 	proposalsHandlers.getProposal,
 );

--- a/src/types/CheckResult.ts
+++ b/src/types/CheckResult.ts
@@ -1,0 +1,5 @@
+interface CheckResult {
+	result: boolean;
+}
+
+export { CheckResult };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ export * from './ApplicationFormField';
 export * from './BaseField';
 export * from './BulkUpload';
 export * from './Bundle';
+export * from './CheckResult';
 export * from './express/AuthenticatedRequest';
 export * from './Id';
 export * from './JsonObject';


### PR DESCRIPTION
This PR updates the GET `/proposals/:proposalId` endpoint so that it will return a 404 if a user is attempting to load a proposal they don't have access to.

Resolves #932 