### PR TITLE
Add creator filter to proposal

### DIFF
--- a/src/database/operations/load/loadProposalBundle.ts
+++ b/src/database/operations/load/loadProposalBundle.ts
@@ -1,23 +1,42 @@
 import { loadBundle } from './loadBundle';
-import type { JsonResultSet, Bundle, Proposal } from '../../../types';
+import type {
+	JsonResultSet,
+	Bundle,
+	Proposal,
+	AuthContext,
+} from '../../../types';
 
-export const loadProposalBundle = async (queryParameters: {
-	offset: number;
-	limit: number;
-	search?: string;
-	organizationId?: number;
-	createdBy?: number;
-}): Promise<Bundle<Proposal>> => {
+export const loadProposalBundle = async (
+	queryParameters: {
+		offset: number;
+		limit: number;
+		search?: string;
+		organizationId?: number;
+		createdBy?: number;
+	},
+	authContext?: AuthContext,
+): Promise<Bundle<Proposal>> => {
 	const defaultQueryParameters = {
 		search: '',
 		organizationId: 0,
 		createdBy: 0,
+		userId: 0,
 	};
+	const { offset, limit, search, organizationId, createdBy } = queryParameters;
+	const userId = authContext?.user.id;
+	const isAdministrator = authContext?.role.isAdministrator;
+
 	const bundle = await loadBundle<JsonResultSet<Proposal>>(
 		'proposals.selectWithPagination',
 		{
 			...defaultQueryParameters,
-			...queryParameters,
+			offset,
+			limit,
+			search,
+			organizationId,
+			createdBy,
+			userId,
+			isAdministrator,
 		},
 		'proposals',
 	);

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -10,17 +10,24 @@ WHERE
     ELSE
       true
     END
-  AND
-  CASE
+  AND CASE
     WHEN :search::text != '' THEN
       pfv.value_search @@ websearch_to_tsquery('english', :search::text)
     ELSE
       true
     END
-  AND
-  CASE
+  AND CASE
     WHEN :organizationId != 0 THEN
       op.organization_id = :organizationId
+    ELSE
+      true
+    END
+  AND CASE
+    WHEN :userId != 0 THEN
+      (
+        p.created_by = :userId
+        OR :isAdministrator
+      )
     ELSE
       true
     END

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -6,6 +6,7 @@ import {
 } from '../database';
 import {
 	AuthenticatedRequest,
+	isAuthContext,
 	isTinyPgErrorWithQueryContext,
 	isWritableProposal,
 } from '../types';
@@ -26,8 +27,8 @@ const getProposals = (
 	res: Response,
 	next: NextFunction,
 ): void => {
-	if (req.user === undefined) {
-		next(new FailedMiddlewareError('Unexpected lack of user context.'));
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
 		return;
 	}
 	const { user } = req;

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -16,6 +16,7 @@ import {
 	InputValidationError,
 } from '../errors';
 import {
+	extractCreatedByParameters,
 	extractOrganizationParameters,
 	extractPaginationParameters,
 	extractSearchParameters,
@@ -31,17 +32,21 @@ const getProposals = (
 		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
 		return;
 	}
-	const { user } = req;
 	const paginationParameters = extractPaginationParameters(req);
 	const searchParameters = extractSearchParameters(req);
 	const organizationParameters = extractOrganizationParameters(req);
+	const createdByParameters = extractCreatedByParameters(req);
+
 	(async () => {
-		const proposalBundle = await loadProposalBundle({
-			...getLimitValues(paginationParameters),
-			...searchParameters,
-			...organizationParameters,
-			createdBy: user.id,
-		});
+		const proposalBundle = await loadProposalBundle(
+			{
+				...getLimitValues(paginationParameters),
+				...searchParameters,
+				...organizationParameters,
+				...createdByParameters,
+			},
+			req,
+		);
 
 		res.status(200).contentType('application/json').send(proposalBundle);
 	})().catch((error: unknown) => {

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -56,6 +56,15 @@
 				"name": "proposal",
 				"required": false,
 				"description": "A reference (ID) to an existing proposal entity."
+			},
+			"createdByParam": {
+				"schema": {
+					"type": "integer"
+				},
+				"in": "query",
+				"name": "createdBy",
+				"required": false,
+				"description": "A reference (ID) to a user entity."
 			}
 		},
 		"securitySchemes": {
@@ -1073,7 +1082,8 @@
 					{ "$ref": "#/components/parameters/pageParam" },
 					{ "$ref": "#/components/parameters/countParam" },
 					{ "$ref": "#/components/parameters/searchParam" },
-					{ "$ref": "#/components/parameters/organizationParam" }
+					{ "$ref": "#/components/parameters/organizationParam" },
+					{ "$ref": "#/components/parameters/createdByParam" }
 				],
 				"responses": {
 					"200": {

--- a/src/queryParameters/extractCreatedByParameters.ts
+++ b/src/queryParameters/extractCreatedByParameters.ts
@@ -1,0 +1,42 @@
+import { ajv } from '../ajv';
+import { InputValidationError } from '../errors';
+import type { JSONSchemaType } from 'ajv';
+import type { Request } from 'express';
+
+interface CreatedByParameters {
+	createdBy: number | undefined;
+}
+
+interface CreatedByParametersQuery {
+	createdBy: number | undefined;
+}
+
+const createdByParametersQuerySchema: JSONSchemaType<CreatedByParametersQuery> =
+	{
+		type: 'object',
+		properties: {
+			createdBy: {
+				type: 'integer',
+				minimum: 1,
+				nullable: true,
+			},
+		},
+		required: [],
+	};
+
+const isCreatedByParametersQuery = ajv.compile(createdByParametersQuerySchema);
+
+const extractCreatedByParameters = (request: Request): CreatedByParameters => {
+	const { query } = request;
+	if (!isCreatedByParametersQuery(query)) {
+		throw new InputValidationError(
+			'Invalid createdBy parameters.',
+			isCreatedByParametersQuery.errors ?? [],
+		);
+	}
+	return {
+		createdBy: query.createdBy,
+	};
+};
+
+export { extractCreatedByParameters };

--- a/src/queryParameters/index.ts
+++ b/src/queryParameters/index.ts
@@ -1,3 +1,4 @@
+export * from './extractCreatedByParameters';
 export * from './extractOrganizationParameters';
 export * from './extractPaginationParameters';
 export * from './extractProposalParameters';

--- a/src/types/AuthContext.ts
+++ b/src/types/AuthContext.ts
@@ -1,0 +1,32 @@
+import { ajv } from '../ajv';
+import { userSchema } from './User';
+import type { JSONSchemaType } from 'ajv';
+import type { User } from './User';
+
+interface AuthContext {
+	user: User;
+	role: {
+		isAdministrator: boolean;
+	};
+}
+
+const authContextSchema: JSONSchemaType<AuthContext> = {
+	type: 'object',
+	properties: {
+		user: userSchema,
+		role: {
+			type: 'object',
+			properties: {
+				isAdministrator: {
+					type: 'boolean',
+				},
+			},
+			required: ['isAdministrator'],
+		},
+	},
+	required: ['user', 'role'],
+};
+
+const isAuthContext = ajv.compile(authContextSchema);
+
+export { AuthContext, authContextSchema, isAuthContext };

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,3 +1,4 @@
+import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
 
 interface User {
@@ -6,6 +7,22 @@ interface User {
 	readonly createdAt: string;
 }
 
+const userSchema: JSONSchemaType<User> = {
+	type: 'object',
+	properties: {
+		id: {
+			type: 'number',
+		},
+		authenticationId: {
+			type: 'string',
+		},
+		createdAt: {
+			type: 'string',
+		},
+	},
+	required: ['id', 'authenticationId', 'createdAt'],
+};
+
 type WritableUser = Writable<User>;
 
-export { User, WritableUser };
+export { User, userSchema, WritableUser };

--- a/src/types/express/AuthenticatedRequest.ts
+++ b/src/types/express/AuthenticatedRequest.ts
@@ -1,11 +1,6 @@
 import { Request as JwtRequest } from 'express-jwt';
-import { User } from '../User';
+import type { AuthContext } from '../AuthContext';
 
-interface AuthenticatedRequest extends JwtRequest {
-	user?: User;
-	role?: {
-		isAdministrator: boolean;
-	};
-}
+type AuthenticatedRequest = JwtRequest & Partial<AuthContext>;
 
 export { AuthenticatedRequest };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './ApplicationForm';
 export * from './ApplicationFormField';
+export * from './AuthContext';
 export * from './BaseField';
 export * from './BulkUpload';
 export * from './Bundle';


### PR DESCRIPTION
This PR improves the `/proposals` endpoint in two ways:

1) It allows administrators to see all proposals.
2) It adds an optional `createdBy` filter which allows a user to filter in terms of author.

Related to #928 
Related to #927 