### PR TITLE
Fix codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,4 +68,6 @@ jobs:
           S3_REGION: fake-s3-region
 
       - name: Upload test coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
A long time ago dependabot tried to update our codecov to v4 -- that required a token.

We closed the PR since codecov had removed the release, but in doing so accidentally stopped dependabot from monitoring codecov!

Anyway, this updates codecov and passes the token as needed now by their API.

Resolves #936 