### PR TITLE
Add createdBy parameter to /bulkUploads

### DIFF
--- a/src/__tests__/bulkUploads.int.test.ts
+++ b/src/__tests__/bulkUploads.int.test.ts
@@ -10,6 +10,7 @@ import { expectTimestamp, loadTestUser } from '../test/utils';
 import {
 	mockJwt as authHeader,
 	mockJwtWithoutSub as authHeaderWithNoSub,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
 } from '../test/mockJwt';
 import { BulkUploadStatus } from '../types';
 
@@ -88,6 +89,95 @@ describe('/bulkUploads', () => {
 								status: BulkUploadStatus.PENDING,
 								createdAt: expectTimestamp,
 								createdBy: testUser.id,
+							},
+						],
+					}),
+				);
+		});
+
+		it('returns all bulk uploads for administrative users', async () => {
+			const testUser = await loadTestUser();
+			const anotherUser = await createUser({
+				authenticationId: 'totallyDifferentUser@example.com',
+			});
+			await createBulkUpload({
+				fileName: 'foo.csv',
+				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
+				status: BulkUploadStatus.PENDING,
+				createdBy: testUser.id,
+			});
+			await createBulkUpload({
+				fileName: 'bar.csv',
+				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+				status: BulkUploadStatus.COMPLETED,
+				createdBy: anotherUser.id,
+			});
+
+			await agent
+				.get('/bulkUploads')
+				.set(authHeaderWithAdminRole)
+				.expect(200)
+				.expect((res) =>
+					expect(res.body).toEqual({
+						total: 2,
+						entries: [
+							{
+								id: 2,
+								fileName: 'bar.csv',
+								fileSize: null,
+								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+								status: BulkUploadStatus.COMPLETED,
+								createdAt: expectTimestamp,
+								createdBy: anotherUser.id,
+							},
+							{
+								id: 1,
+								fileName: 'foo.csv',
+								fileSize: null,
+								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
+								status: BulkUploadStatus.PENDING,
+								createdAt: expectTimestamp,
+								createdBy: testUser.id,
+							},
+						],
+					}),
+				);
+		});
+
+		it('returns uploads for specified createdBy user', async () => {
+			const testUser = await loadTestUser();
+			const anotherUser = await createUser({
+				authenticationId: 'totallyDifferentUser@example.com',
+			});
+			await createBulkUpload({
+				fileName: 'foo.csv',
+				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
+				status: BulkUploadStatus.PENDING,
+				createdBy: testUser.id,
+			});
+			await createBulkUpload({
+				fileName: 'bar.csv',
+				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+				status: BulkUploadStatus.COMPLETED,
+				createdBy: anotherUser.id,
+			});
+
+			await agent
+				.get(`/bulkUploads?createdBy=${anotherUser.id}`)
+				.set(authHeaderWithAdminRole)
+				.expect(200)
+				.expect((res) =>
+					expect(res.body).toEqual({
+						total: 2,
+						entries: [
+							{
+								id: 2,
+								fileName: 'bar.csv',
+								fileSize: null,
+								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+								status: BulkUploadStatus.COMPLETED,
+								createdAt: expectTimestamp,
+								createdBy: anotherUser.id,
 							},
 						],
 					}),

--- a/src/database/operations/load/loadBulkUploadBundle.ts
+++ b/src/database/operations/load/loadBulkUploadBundle.ts
@@ -1,15 +1,27 @@
 import { loadBundle } from './loadBundle';
-import type { JsonResultSet, Bundle, BulkUpload } from '../../../types';
+import type {
+	JsonResultSet,
+	Bundle,
+	BulkUpload,
+	AuthContext,
+} from '../../../types';
 
-export const loadBulkUploadBundle = async (queryParameters: {
-	offset: number;
-	limit: number;
-	createdBy?: number;
-}): Promise<Bundle<BulkUpload>> => {
+export const loadBulkUploadBundle = async (
+	queryParameters: {
+		offset: number;
+		limit: number;
+		createdBy?: number;
+	},
+	authContext?: AuthContext,
+): Promise<Bundle<BulkUpload>> => {
 	const defaultQueryParameters = {
 		createdBy: 0,
+		userId: 0,
+		isAdministrator: false,
 	};
 	const { offset, limit, createdBy } = queryParameters;
+	const userId = authContext?.user.id;
+	const isAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<BulkUpload>>(
 		'bulkUploads.selectWithPagination',
@@ -18,6 +30,8 @@ export const loadBulkUploadBundle = async (queryParameters: {
 			offset,
 			limit,
 			createdBy,
+			userId,
+			isAdministrator,
 		},
 		'bulk_uploads',
 	);

--- a/src/database/queries/bulkUploads/selectWithPagination.sql
+++ b/src/database/queries/bulkUploads/selectWithPagination.sql
@@ -7,6 +7,15 @@ WHERE
     ELSE
       true
     END
+  AND CASE
+    WHEN :userId != 0 THEN
+      (
+        bulk_uploads.created_by = :userId
+        OR :isAdministrator
+      )
+    ELSE
+      true
+    END
 ORDER BY id DESC
 LIMIT
   CASE WHEN :limit != 0 THEN

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -748,7 +748,8 @@
 				],
 				"parameters": [
 					{ "$ref": "#/components/parameters/pageParam" },
-					{ "$ref": "#/components/parameters/countParam" }
+					{ "$ref": "#/components/parameters/countParam" },
+					{ "$ref": "#/components/parameters/createdByParam" }
 				],
 				"responses": {
 					"200": {


### PR DESCRIPTION
This PR adds the `createdBy` filter to `/bulkUploads` in addition to expanding the default return set for administrators.


Resolves #928
Resolves #927