### PR TITLE
Add GET `/users` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `BulkUpload` entity now has a `createdBy` attribute.
 - The `Proposal` entity now has a `createdBy` attribute.
 - The `/proposals` endpoint now supports a `createdBy` filter.
+- The `User` type now exists.
+- The GET `/users` endpoint now exists.
 
 ### Changed
 

--- a/src/__tests__/users.int.test.ts
+++ b/src/__tests__/users.int.test.ts
@@ -1,0 +1,116 @@
+import request from 'supertest';
+import { app } from '../app';
+import { createUser, loadSystemUser, loadTableMetrics } from '../database';
+import { expectTimestamp, loadTestUser } from '../test/utils';
+import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
+} from '../test/mockJwt';
+
+const agent = request.agent(app);
+
+describe('/users', () => {
+	describe('GET /', () => {
+		it('requires authentication', async () => {
+			await agent.get('/users').expect(401);
+		});
+
+		it('returns the user associated with the requesting user', async () => {
+			const testUser = await loadTestUser();
+			await createUser({
+				authenticationId: 'totallyDifferentUser@example.com',
+			});
+			const { count: userCount } = await loadTableMetrics('users');
+
+			const response = await agent.get('/users').set(authHeader).expect(200);
+			expect(response.body).toEqual({
+				total: userCount,
+				entries: [testUser],
+			});
+		});
+
+		it('returns all users when the user is an administrator', async () => {
+			const systemUser = await loadSystemUser();
+			const testUser = await loadTestUser();
+			const anotherUser = await createUser({
+				authenticationId: 'totallyDifferentUser@example.com',
+			});
+			const { count: userCount } = await loadTableMetrics('users');
+
+			const response = await agent
+				.get('/users')
+				.set(authHeaderWithAdminRole)
+				.expect(200);
+			expect(response.body).toEqual({
+				total: userCount,
+				entries: [anotherUser, testUser, systemUser],
+			});
+		});
+
+		it('returns a specific user when an authenticationId is provided', async () => {
+			const anotherUser = await createUser({
+				authenticationId: 'totallyDifferentUser@example.com',
+			});
+			const { count: userCount } = await loadTableMetrics('users');
+
+			const response = await agent
+				.get('/users?authenticationId=totallyDifferentUser@example.com')
+				.set(authHeaderWithAdminRole)
+				.expect(200);
+			expect(response.body).toEqual({
+				total: userCount,
+				entries: [anotherUser],
+			});
+		});
+
+		it('returns according to pagination parameters', async () => {
+			const { count: baseUserCount } = await loadTableMetrics('users');
+			await Array.from(Array(20)).reduce(async (p, _, i) => {
+				await p;
+				await createUser({
+					authenticationId: `user-${i + 1}`,
+				});
+			}, Promise.resolve());
+			const { count: userCount } = await loadTableMetrics('users');
+
+			const response = await agent
+				.get('/users')
+				.query({
+					_page: 2,
+					_count: 5,
+				})
+				.set(authHeaderWithAdminRole)
+				.expect(200);
+			expect(response.body).toEqual({
+				total: userCount,
+				entries: [
+					{
+						id: 15 + baseUserCount,
+						authenticationId: 'user-15',
+						createdAt: expectTimestamp,
+					},
+					{
+						id: 14 + baseUserCount,
+						authenticationId: 'user-14',
+						createdAt: expectTimestamp,
+					},
+					{
+						id: 13 + baseUserCount,
+						authenticationId: 'user-13',
+						createdAt: expectTimestamp,
+					},
+					{
+						id: 12 + baseUserCount,
+						authenticationId: 'user-12',
+						createdAt: expectTimestamp,
+					},
+					{
+						id: 11 + baseUserCount,
+						authenticationId: 'user-11',
+						createdAt: expectTimestamp,
+					},
+				],
+			});
+		});
+	});
+});

--- a/src/database/operations/load/index.ts
+++ b/src/database/operations/load/index.ts
@@ -14,4 +14,5 @@ export * from './loadProposal';
 export * from './loadProposalBundle';
 export * from './loadSystemUser';
 export * from './loadTableMetrics';
+export * from './loadUserBundle';
 export * from './loadUserByAuthenticationId';

--- a/src/database/operations/load/loadUserBundle.ts
+++ b/src/database/operations/load/loadUserBundle.ts
@@ -1,0 +1,38 @@
+import { loadBundle } from './loadBundle';
+import type { JsonResultSet, Bundle, User, AuthContext } from '../../../types';
+
+export const loadUserBundle = async (
+	queryParameters: {
+		offset: number;
+		limit: number;
+		authenticationId?: string;
+	},
+	authContext?: AuthContext,
+): Promise<Bundle<User>> => {
+	const defaultQueryParameters = {
+		authenticationId: '',
+		userId: 0,
+		isAdministrator: false,
+	};
+	const { offset, limit, authenticationId } = queryParameters;
+	const userId = authContext?.user.id;
+	const isAdministrator = authContext?.role.isAdministrator;
+
+	const bundle = await loadBundle<JsonResultSet<User>>(
+		'users.selectWithPagination',
+		{
+			...defaultQueryParameters,
+			offset,
+			limit,
+			authenticationId,
+			userId,
+			isAdministrator,
+		},
+		'users',
+	);
+	const entries = bundle.entries.map((entry) => entry.object);
+	return {
+		...bundle,
+		entries,
+	};
+};

--- a/src/database/queries/users/selectWithPagination.sql
+++ b/src/database/queries/users/selectWithPagination.sql
@@ -1,0 +1,21 @@
+SELECT user_to_json(users.*) as "object"
+FROM users
+WHERE
+  CASE
+    WHEN :authenticationId != '' THEN
+      authentication_id = :authenticationId
+    ELSE
+      true
+    END
+  AND CASE
+    WHEN :userId != 0 THEN
+      (
+        id = :userId
+        OR :isAdministrator
+      )
+    ELSE
+      true
+    END
+GROUP BY id
+ORDER BY id DESC
+OFFSET :offset FETCH NEXT :limit ROWS ONLY;

--- a/src/handlers/usersHandlers.ts
+++ b/src/handlers/usersHandlers.ts
@@ -1,0 +1,52 @@
+import { getLimitValues, loadUserBundle } from '../database';
+import {
+	AuthenticatedRequest,
+	isAuthContext,
+	isTinyPgErrorWithQueryContext,
+} from '../types';
+import { DatabaseError, FailedMiddlewareError } from '../errors';
+import {
+	extractAuthenticationIdParameters,
+	extractPaginationParameters,
+	extractSearchParameters,
+} from '../queryParameters';
+import type { Response, NextFunction } from 'express';
+
+const getUsers = (
+	req: AuthenticatedRequest,
+	res: Response,
+	next: NextFunction,
+): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
+	const paginationParameters = extractPaginationParameters(req);
+	const searchParameters = extractSearchParameters(req);
+	const authenticationIdParameters = extractAuthenticationIdParameters(req);
+
+	(async () => {
+		const userBundle = await loadUserBundle(
+			{
+				...getLimitValues(paginationParameters),
+				...searchParameters,
+				...authenticationIdParameters,
+			},
+			req,
+		);
+
+		res.status(200).contentType('application/json').send(userBundle);
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error retrieving users.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const usersHandlers = {
+	getUsers,
+};
+
+export { usersHandlers };

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -7,6 +7,15 @@
 	},
 	"components": {
 		"parameters": {
+			"authenticationIdParam": {
+				"name": "authenticationId",
+				"description": "The authentication ID associated with the desired user.",
+				"in": "query",
+				"required": false,
+				"schema": {
+					"type": "string"
+				}
+			},
 			"pageParam": {
 				"schema": {
 					"type": "integer",
@@ -615,6 +624,45 @@
 								"type": "array",
 								"items": {
 									"$ref": "#/components/schemas/Proposal"
+								}
+							}
+						},
+						"required": ["entries"]
+					}
+				]
+			},
+			"User": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"readOnly": true,
+						"example": 3407
+					},
+					"authenticationId": {
+						"type": "string",
+						"example": "foo@example.com"
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"readOnly": true
+					}
+				},
+				"required": ["id", "authenticationId", "createdAt"]
+			},
+			"UserBundle": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Bundle"
+					},
+					{
+						"type": "object",
+						"properties": {
+							"entries": {
+								"type": "array",
+								"items": {
+									"$ref": "#/components/schemas/User"
 								}
 							}
 						},
@@ -1575,6 +1623,35 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/PdcError"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/users": {
+			"get": {
+				"operationId": "getUsers",
+				"summary": "Gets a list of users.",
+				"tags": ["Users"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{ "$ref": "#/components/parameters/pageParam" },
+					{ "$ref": "#/components/parameters/countParam" },
+					{ "$ref": "#/components/parameters/authenticationIdParam" }
+				],
+				"responses": {
+					"200": {
+						"description": "A list of users.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UserBundle"
 								}
 							}
 						}

--- a/src/queryParameters/extractAuthenticationIdParameters.ts
+++ b/src/queryParameters/extractAuthenticationIdParameters.ts
@@ -1,0 +1,41 @@
+import { ajv } from '../ajv';
+import { InputValidationError } from '../errors';
+import type { JSONSchemaType } from 'ajv';
+import type { Request } from 'express';
+
+interface AuthenticationIdParameters {
+	authenticationId: string | undefined;
+}
+
+const authenticationIdParametersSchema: JSONSchemaType<AuthenticationIdParameters> =
+	{
+		type: 'object',
+		properties: {
+			authenticationId: {
+				type: 'string',
+				nullable: true,
+			},
+		},
+		required: [],
+	};
+
+const isAuthenticationIdParameters = ajv.compile(
+	authenticationIdParametersSchema,
+);
+
+const extractAuthenticationIdParameters = (
+	request: Request,
+): AuthenticationIdParameters => {
+	const { query } = request;
+	if (!isAuthenticationIdParameters(query)) {
+		throw new InputValidationError(
+			'Invalid authenticationId parameter.',
+			isAuthenticationIdParameters.errors ?? [],
+		);
+	}
+	return {
+		authenticationId: query.authenticationId,
+	};
+};
+
+export { extractAuthenticationIdParameters };

--- a/src/queryParameters/index.ts
+++ b/src/queryParameters/index.ts
@@ -1,3 +1,4 @@
+export * from './extractAuthenticationIdParameters';
 export * from './extractCreatedByParameters';
 export * from './extractOrganizationParameters';
 export * from './extractPaginationParameters';

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -9,6 +9,7 @@ import { platformProviderResponsesRouter } from './platformProviderResponsesRout
 import { presignedPostRequestsRouter } from './presignedPostRequestsRouter';
 import { proposalsRouter } from './proposalsRouter';
 import { proposalVersionsRouter } from './proposalVersionsRouter';
+import { usersRouter } from './usersRouter';
 import { documentationRouter } from './documentationRouter';
 
 const rootRouter = express.Router();
@@ -23,6 +24,7 @@ rootRouter.use('/platformProviderResponses', platformProviderResponsesRouter);
 rootRouter.use('/presignedPostRequests', presignedPostRequestsRouter);
 rootRouter.use('/proposals', proposalsRouter);
 rootRouter.use('/proposalVersions', proposalVersionsRouter);
+rootRouter.use('/users', usersRouter);
 rootRouter.use('/', documentationRouter);
 
 export { rootRouter };

--- a/src/routers/usersRouter.ts
+++ b/src/routers/usersRouter.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { usersHandlers } from '../handlers/usersHandlers';
+import { requireAuthentication } from '../middleware';
+
+const usersRouter = express.Router();
+
+usersRouter.get('/', requireAuthentication, usersHandlers.getUsers);
+
+export { usersRouter };


### PR DESCRIPTION
This PR adds a new `/users` endpoint which will allow the front end to look up the id associated with their session.

I decided to implement this with auth context awareness off the bat, which means administrative users can actually view ALL users in the system if they want.

Resolves #942