### PR TITLE
Fix migration hang

### DIFF
--- a/src/scripts/migrate.ts
+++ b/src/scripts/migrate.ts
@@ -1,17 +1,19 @@
 import { getLogger } from '../logger';
-import { migrate } from '../database';
+import { db, migrate } from '../database';
 
 const logger = getLogger(__filename);
 
 logger.info('Starting migrations...');
 migrate()
-	.then(() => {
+	.then(async () => {
 		logger.info('Migrations complete.');
+		await db.close();
 	})
-	.catch((reason: unknown) => {
+	.catch(async (reason: unknown) => {
 		logger.error('Migrations failed!');
 		if (reason instanceof Error) {
 			logger.error(`${reason.message}`);
 		}
+		await db.close();
 		process.exit(1);
 	});


### PR DESCRIPTION
This PR closes the migration process in the event that they are successful.

You should now be able to run `npm run migrate` and it will exit right after migrations complete without requiring you to close the process manually.

Resolves #947