### PR TITLE
Recognize admin authority when selecting individual proposals

### DIFF
--- a/src/database/operations/assert/assertProposalAuthorization.ts
+++ b/src/database/operations/assert/assertProposalAuthorization.ts
@@ -1,14 +1,22 @@
 import { db } from '../../db';
 import { NotFoundError } from '../../../errors';
-import type { CheckResult } from '../../../types';
+import type { AuthContext, CheckResult } from '../../../types';
 
 export const assertProposalAuthorization = async (
 	id: number,
-	userId: number,
+	authContext: AuthContext,
 ): Promise<void> => {
+	const {
+		user: { id: userId },
+	} = authContext;
+	const {
+		role: { isAdministrator },
+	} = authContext;
+
 	const result = await db.sql<CheckResult>('proposals.checkAuthorization', {
 		id,
 		userId,
+		isAdministrator,
 	});
 
 	if (result.rows[0]?.result !== true) {

--- a/src/database/queries/proposals/checkAuthorization.sql
+++ b/src/database/queries/proposals/checkAuthorization.sql
@@ -5,7 +5,10 @@ SELECT EXISTS (
       AND
         CASE
           WHEN :userId != 0 THEN
+          (
             created_by = :userId
+            OR :isAdministrator
+          )
           ELSE
             true
           END

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -65,18 +65,17 @@ const getProposal = (
 	res: Response,
 	next: NextFunction,
 ): void => {
-	const { user } = req;
-	const { proposalId } = req.params;
-	if (user === undefined) {
-		next(new FailedMiddlewareError('Unexpected lack of user context.'));
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
 		return;
 	}
+	const { proposalId } = req.params;
 	if (!isId(proposalId)) {
 		next(new InputValidationError('Invalid id parameter.', isId.errors ?? []));
 		return;
 	}
 	(async () => {
-		await assertProposalAuthorization(proposalId, user.id);
+		await assertProposalAuthorization(proposalId, req);
 		const proposal = await loadProposal(proposalId);
 		res.status(200).contentType('application/json').send(proposal);
 	})().catch((error: unknown) => {


### PR DESCRIPTION
This PR fixes a bug where an admin couldn't access proposal data they didn't own when loading individual proposals

Resolves #951