### PR TITLE
Ignore eslint major dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
This PR disables dependabot for eslint 9 for now (we'll re-enable once our other dependencies support it)

Related to #978