### PR TITLE
Use json for proposal versions

### DIFF
--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -8,6 +8,7 @@ import {
 	createOrganizationProposal,
 	createProposal,
 	createProposalFieldValue,
+	createProposalVersion,
 	createUser,
 	db,
 	loadTableMetrics,
@@ -85,7 +86,7 @@ describe('/proposals', () => {
 			await createApplicationForm({
 				opportunityId: 1,
 			});
-			await db.sql('proposalVersions.insertOne', {
+			await createProposalVersion({
 				proposalId: 1,
 				applicationFormId: 1,
 			});
@@ -252,11 +253,11 @@ describe('/proposals', () => {
 			await createApplicationForm({
 				opportunityId: 1,
 			});
-			await db.sql('proposalVersions.insertOne', {
+			await createProposalVersion({
 				proposalId: 1,
 				applicationFormId: 1,
 			});
-			await db.sql('proposalVersions.insertOne', {
+			await createProposalVersion({
 				proposalId: 2,
 				applicationFormId: 1,
 			});
@@ -482,11 +483,11 @@ describe('/proposals', () => {
 			await createApplicationForm({
 				opportunityId: 1,
 			});
-			await db.sql('proposalVersions.insertOne', {
+			await createProposalVersion({
 				proposalId: 1,
 				applicationFormId: 1,
 			});
-			await db.sql('proposalVersions.insertOne', {
+			await createProposalVersion({
 				proposalId: 2,
 				applicationFormId: 1,
 			});

--- a/src/database/operations/create/createProposalVersion.ts
+++ b/src/database/operations/create/createProposalVersion.ts
@@ -1,0 +1,22 @@
+import { db as defaultDb } from '../../db';
+import type { ProposalVersion, WritableProposalVersion } from '../../../types';
+
+const createProposalVersion = async (
+	createValues: WritableProposalVersion,
+	db = defaultDb,
+): Promise<ProposalVersion> => {
+	const { proposalId, applicationFormId } = createValues;
+	const result = await db.sql<ProposalVersion>('proposalVersions.insertOne', {
+		proposalId,
+		applicationFormId,
+	});
+	const object = result.rows[0];
+	if (object === undefined) {
+		throw new Error(
+			'The entity creation did not appear to fail, but no data was returned by the operation.',
+		);
+	}
+	return object;
+};
+
+export { createProposalVersion };

--- a/src/database/operations/create/createProposalVersion.ts
+++ b/src/database/operations/create/createProposalVersion.ts
@@ -1,16 +1,23 @@
 import { db as defaultDb } from '../../db';
-import type { ProposalVersion, WritableProposalVersion } from '../../../types';
+import type {
+	JsonResultSet,
+	ProposalVersion,
+	WritableProposalVersion,
+} from '../../../types';
 
 const createProposalVersion = async (
 	createValues: WritableProposalVersion,
 	db = defaultDb,
 ): Promise<ProposalVersion> => {
 	const { proposalId, applicationFormId } = createValues;
-	const result = await db.sql<ProposalVersion>('proposalVersions.insertOne', {
-		proposalId,
-		applicationFormId,
-	});
-	const object = result.rows[0];
+	const result = await db.sql<JsonResultSet<ProposalVersion>>(
+		'proposalVersions.insertOne',
+		{
+			proposalId,
+			applicationFormId,
+		},
+	);
+	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
 		throw new Error(
 			'The entity creation did not appear to fail, but no data was returned by the operation.',

--- a/src/database/operations/create/index.ts
+++ b/src/database/operations/create/index.ts
@@ -7,4 +7,5 @@ export * from './createOrganization';
 export * from './createOrganizationProposal';
 export * from './createProposal';
 export * from './createProposalFieldValue';
+export * from './createProposalVersion';
 export * from './createUser';

--- a/src/database/queries/proposalVersions/insertOne.sql
+++ b/src/database/queries/proposalVersions/insertOne.sql
@@ -14,9 +14,4 @@ INSERT INTO proposal_versions (
     1
   )
 )
-RETURNING
-  id as "id",
-  proposal_id as "proposalId",
-  application_form_id as "applicationFormId",
-  version as "version",
-  created_at AS "createdAt"
+RETURNING proposal_version_to_json(proposal_versions) AS "object";

--- a/src/types/ProposalVersion.ts
+++ b/src/types/ProposalVersion.ts
@@ -5,22 +5,24 @@ import type {
 	ProposalFieldValue,
 	WritableProposalFieldValueWithProposalVersionContext,
 } from './ProposalFieldValue';
+import type { Writable } from './Writable';
 
-export interface ProposalVersion {
-	id: number;
+interface ProposalVersion {
+	readonly id: number;
 	proposalId: number;
+	readonly version: number;
 	applicationFormId: number;
-	version: number;
-	fieldValues: ProposalFieldValue[];
-	createdAt: string;
+	readonly fieldValues: ProposalFieldValue[];
+	readonly createdAt: string;
 }
 
-export type ProposalVersionWrite = Omit<
-	ProposalVersion,
-	'createdAt' | 'fieldValues' | 'id' | 'version'
-> & { fieldValues: WritableProposalFieldValueWithProposalVersionContext[] };
+type WritableProposalVersion = Writable<ProposalVersion>;
 
-export const proposalVersionWriteSchema: JSONSchemaType<ProposalVersionWrite> =
+type WritableProposalVersionWithFieldValues = WritableProposalVersion & {
+	fieldValues: WritableProposalFieldValueWithProposalVersionContext[];
+};
+
+const writableProposalVersionWithFieldValuesSchema: JSONSchemaType<WritableProposalVersionWithFieldValues> =
 	{
 		type: 'object',
 		properties: {
@@ -38,4 +40,13 @@ export const proposalVersionWriteSchema: JSONSchemaType<ProposalVersionWrite> =
 		required: ['proposalId', 'applicationFormId', 'fieldValues'],
 	};
 
-export const isProposalVersionWrite = ajv.compile(proposalVersionWriteSchema);
+const isWritableProposalVersionWithFieldValues = ajv.compile(
+	writableProposalVersionWithFieldValuesSchema,
+);
+
+export {
+	ProposalVersion,
+	WritableProposalVersion,
+	WritableProposalVersionWithFieldValues,
+	isWritableProposalVersionWithFieldValues,
+};


### PR DESCRIPTION
This PR updates our proposal version queries to use db utilities as well as the json return pattern.

Related to #821 
Related to #228 
