### PR TITLE
Rename `employer_identification_number` to `tax_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.9.0 2024-05-02
+
 ### Added
 
 - `BaseField` now has a `scope` attribute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The GET `/opportunities` endpoint now returns an `OpportunityBundle` and accepts pagination parameters.
+- Added a new `Organization` attribute `taxId` which contains the same value as `employerIdentificationNumber`.
+- Deprecated the `Organizations` attribute `employerIdentificationNumber`. Please update your clients to use `taxId` instead.
 
 ## 0.8.0 2024-04-23
 

--- a/src/__tests__/organizationProposals.int.test.ts
+++ b/src/__tests__/organizationProposals.int.test.ts
@@ -14,11 +14,11 @@ const agent = request.agent(app);
 
 const insertTestOrganizations = async () => {
 	await createOrganization({
-		employerIdentificationNumber: '11-1111111',
+		taxId: '11-1111111',
 		name: 'Example Inc.',
 	});
 	await createOrganization({
-		employerIdentificationNumber: '22-2222222',
+		taxId: '22-2222222',
 		name: 'Another Inc.',
 	});
 };
@@ -65,6 +65,7 @@ describe('/organizationProposals', () => {
 						organization: {
 							id: 1,
 							name: 'Example Inc.',
+							taxId: '11-1111111',
 							employerIdentificationNumber: '11-1111111',
 							createdAt: expectTimestamp,
 						},
@@ -85,6 +86,7 @@ describe('/organizationProposals', () => {
 						organization: {
 							id: 1,
 							name: 'Example Inc.',
+							taxId: '11-1111111',
 							employerIdentificationNumber: '11-1111111',
 							createdAt: expectTimestamp,
 						},
@@ -140,6 +142,7 @@ describe('/organizationProposals', () => {
 						organization: {
 							id: 1,
 							name: 'Example Inc.',
+							taxId: '11-1111111',
 							employerIdentificationNumber: '11-1111111',
 							createdAt: expectTimestamp,
 						},
@@ -202,6 +205,7 @@ describe('/organizationProposals', () => {
 				organization: {
 					id: 1,
 					name: 'Example Inc.',
+					taxId: '11-1111111',
 					employerIdentificationNumber: '11-1111111',
 					createdAt: expectTimestamp,
 				},

--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -16,11 +16,11 @@ const agent = request.agent(app);
 
 const insertTestOrganizations = async () => {
 	await createOrganization({
-		employerIdentificationNumber: '11-1111111',
+		taxId: '11-1111111',
 		name: 'Example Inc.',
 	});
 	await createOrganization({
-		employerIdentificationNumber: '22-2222222',
+		taxId: '22-2222222',
 		name: 'Another Inc.',
 	});
 };
@@ -50,12 +50,14 @@ describe('/organizations', () => {
 						entries: [
 							{
 								id: 2,
+								taxId: '22-2222222',
 								employerIdentificationNumber: '22-2222222',
 								name: 'Another Inc.',
 								createdAt: expectTimestamp,
 							},
 							{
 								id: 1,
+								taxId: '11-1111111',
 								employerIdentificationNumber: '11-1111111',
 								name: 'Example Inc.',
 								createdAt: expectTimestamp,
@@ -69,7 +71,7 @@ describe('/organizations', () => {
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
 				await db.sql('organizations.insertOne', {
-					employerIdentificationNumber: '11-1111111',
+					taxId: '11-1111111',
 					name: `Organization ${i + 1}`,
 				});
 			}, Promise.resolve());
@@ -87,30 +89,35 @@ describe('/organizations', () => {
 						entries: [
 							{
 								id: 15,
+								taxId: '11-1111111',
 								employerIdentificationNumber: '11-1111111',
 								name: 'Organization 15',
 								createdAt: expectTimestamp,
 							},
 							{
 								id: 14,
+								taxId: '11-1111111',
 								employerIdentificationNumber: '11-1111111',
 								name: 'Organization 14',
 								createdAt: expectTimestamp,
 							},
 							{
 								id: 13,
+								taxId: '11-1111111',
 								employerIdentificationNumber: '11-1111111',
 								name: 'Organization 13',
 								createdAt: expectTimestamp,
 							},
 							{
 								id: 12,
+								taxId: '11-1111111',
 								employerIdentificationNumber: '11-1111111',
 								name: 'Organization 12',
 								createdAt: expectTimestamp,
 							},
 							{
 								id: 11,
+								taxId: '11-1111111',
 								employerIdentificationNumber: '11-1111111',
 								name: 'Organization 11',
 								createdAt: expectTimestamp,
@@ -131,11 +138,11 @@ describe('/organizations', () => {
 				createdBy: testUser.id,
 			});
 			await createOrganization({
-				employerIdentificationNumber: '123-123-123',
+				taxId: '123-123-123',
 				name: 'Canadian Company',
 			});
 			await createOrganization({
-				employerIdentificationNumber: '123-123-123',
+				taxId: '123-123-123',
 				name: 'Another Canadian Company',
 			});
 			await createOrganizationProposal({
@@ -151,6 +158,7 @@ describe('/organizations', () => {
 				entries: [
 					{
 						id: 1,
+						taxId: '123-123-123',
 						employerIdentificationNumber: '123-123-123',
 						name: 'Canadian Company',
 						createdAt: expectTimestamp,
@@ -175,7 +183,7 @@ describe('/organizations', () => {
 				createdBy: testUser.id,
 			});
 			await createOrganization({
-				employerIdentificationNumber: '123-123-123',
+				taxId: '123-123-123',
 				name: 'Canadian Company',
 			});
 			await createOrganizationProposal({
@@ -195,6 +203,7 @@ describe('/organizations', () => {
 				entries: [
 					{
 						id: 1,
+						taxId: '123-123-123',
 						employerIdentificationNumber: '123-123-123',
 						name: 'Canadian Company',
 						createdAt: expectTimestamp,
@@ -234,6 +243,7 @@ describe('/organizations', () => {
 				.expect((res) =>
 					expect(res.body).toEqual({
 						id: 2,
+						taxId: '22-2222222',
 						employerIdentificationNumber: '22-2222222',
 						name: 'Another Inc.',
 						createdAt: expectTimestamp,
@@ -258,7 +268,7 @@ describe('/organizations', () => {
 				.type('application/json')
 				.set(authHeader)
 				.send({
-					employerIdentificationNumber: '11-1111111',
+					taxId: '11-1111111',
 					name: 'Example Inc.',
 				})
 				.expect(201);
@@ -266,6 +276,7 @@ describe('/organizations', () => {
 			expect(before.count).toEqual(0);
 			expect(result.body).toMatchObject({
 				id: 1,
+				taxId: '11-1111111',
 				employerIdentificationNumber: '11-1111111',
 				name: 'Example Inc.',
 				createdAt: expectTimestamp,
@@ -273,7 +284,7 @@ describe('/organizations', () => {
 			expect(after.count).toEqual(1);
 		});
 
-		it('returns 400 bad request when no employerIdentificationNumber is sent', async () => {
+		it('returns 400 bad request when no taxId is sent', async () => {
 			const result = await agent
 				.post('/organizations')
 				.type('application/json')
@@ -294,7 +305,7 @@ describe('/organizations', () => {
 				.type('application/json')
 				.set(authHeader)
 				.send({
-					employerIdentificationNumber: '11-1111111',
+					taxId: '11-1111111',
 				})
 				.expect(400);
 			expect(result.body).toMatchObject({
@@ -305,7 +316,7 @@ describe('/organizations', () => {
 
 		it('returns 409 conflict when an existing EIN + name combination is submitted', async () => {
 			await createOrganization({
-				employerIdentificationNumber: '11-1111111',
+				taxId: '11-1111111',
 				name: 'Example Inc.',
 			});
 			const result = await agent
@@ -313,7 +324,7 @@ describe('/organizations', () => {
 				.type('application/json')
 				.set(authHeader)
 				.send({
-					employerIdentificationNumber: '11-1111111',
+					taxId: '11-1111111',
 					name: 'Example Inc.',
 				})
 				.expect(409);

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -183,7 +183,7 @@ describe('/proposals', () => {
 				createdBy: testUser.id,
 			});
 			const organization = await createOrganization({
-				employerIdentificationNumber: '123-123-123',
+				taxId: '123-123-123',
 				name: 'Canadian Company',
 			});
 			await createOrganizationProposal({

--- a/src/database/initialization/organization_to_json.sql
+++ b/src/database/initialization/organization_to_json.sql
@@ -3,7 +3,8 @@ RETURNS JSONB AS $$
 BEGIN
   RETURN jsonb_build_object(
     'id', organization.id,
-    'employerIdentificationNumber', organization.employer_identification_number,
+    'taxId', organization.tax_id,
+    'employerIdentificationNumber', organization.tax_id,
     'name', organization.name,
     'createdAt', organization.created_at
   );

--- a/src/database/migrations/0027-alter-organizations-rename-ein.sql
+++ b/src/database/migrations/0027-alter-organizations-rename-ein.sql
@@ -1,0 +1,2 @@
+ALTER TABLE organizations
+  RENAME COLUMN employer_identification_number TO tax_id;

--- a/src/database/operations/create/createOrganization.ts
+++ b/src/database/operations/create/createOrganization.ts
@@ -8,11 +8,11 @@ import type {
 export const createOrganization = async (
 	createValues: WritableOrganization,
 ): Promise<Organization> => {
-	const { employerIdentificationNumber, name } = createValues;
+	const { taxId, name } = createValues;
 	const result = await db.sql<JsonResultSet<Organization>>(
 		'organizations.insertOne',
 		{
-			employerIdentificationNumber,
+			taxId,
 			name,
 		},
 	);

--- a/src/database/operations/load/index.ts
+++ b/src/database/operations/load/index.ts
@@ -10,7 +10,7 @@ export * from './loadOpportunity';
 export * from './loadOpportunityBundle';
 export * from './loadOrganization';
 export * from './loadOrganizationBundle';
-export * from './loadOrganizationByEmployerIdentificationNumber';
+export * from './loadOrganizationByTaxId';
 export * from './loadOrganizationProposalBundle';
 export * from './loadProposal';
 export * from './loadProposalBundle';

--- a/src/database/operations/load/loadOrganizationByTaxId.ts
+++ b/src/database/operations/load/loadOrganizationByTaxId.ts
@@ -2,19 +2,19 @@ import { db } from '../../db';
 import { NotFoundError } from '../../../errors';
 import type { JsonResultSet, Organization } from '../../../types';
 
-export const loadOrganizationByEmployerIdentificationNumber = async (
-	employerIdentificationNumber: string,
+export const loadOrganizationByTaxId = async (
+	taxId: string,
 ): Promise<Organization> => {
 	const result = await db.sql<JsonResultSet<Organization>>(
-		'organizations.selectByEmployerIdentificationNumber',
+		'organizations.selectByTaxId',
 		{
-			employerIdentificationNumber,
+			taxId,
 		},
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
 		throw new NotFoundError(
-			`The organization was not found (EIN: ${employerIdentificationNumber})`,
+			`The organization was not found (Tax ID: ${taxId})`,
 		);
 	}
 	return object;

--- a/src/database/queries/organizations/insertOne.sql
+++ b/src/database/queries/organizations/insertOne.sql
@@ -1,8 +1,8 @@
 INSERT INTO organizations (
-  employer_identification_number,
+  tax_id,
   name
 ) VALUES (
-  :employerIdentificationNumber,
+  :taxId,
   :name
 )
 RETURNING organization_to_json(organizations) AS "object";

--- a/src/database/queries/organizations/selectByTaxId.sql
+++ b/src/database/queries/organizations/selectByTaxId.sql
@@ -1,3 +1,3 @@
 SELECT organization_to_json(organizations) AS "object"
 FROM organizations
-WHERE employer_identification_number = :employerIdentificationNumber
+WHERE tax_id = :taxId

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for organizations seeking grants.",
-		"version": "0.8.0"
+		"version": "0.9.0"
 	},
 	"components": {
 		"parameters": {

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -162,9 +162,14 @@
 						"readOnly": true,
 						"example": 3407
 					},
-					"employerIdentificationNumber": {
+					"taxId": {
 						"type": "string",
 						"example": "11-1111111"
+					},
+					"employerIdentificationNumber": {
+						"type": "string",
+						"example": "11-1111111",
+						"deprecated": true
 					},
 					"name": {
 						"type": "string",
@@ -176,7 +181,7 @@
 						"readOnly": true
 					}
 				},
-				"required": ["id", "employerIdentificationNumber", "name", "createdAt"]
+				"required": ["id", "taxId", "name", "createdAt"]
 			},
 			"OrganizationProposal": {
 				"type": "object",

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -579,6 +579,7 @@ describe('processBulkUpload', () => {
 			entries: [
 				{
 					createdAt: expectTimestamp,
+					taxId: '51-2144346',
 					employerIdentificationNumber: '51-2144346',
 					id: 1,
 					name: 'Foo LLC.',

--- a/src/tasks/processBulkUpload.ts
+++ b/src/tasks/processBulkUpload.ts
@@ -18,7 +18,7 @@ import {
 	createProposal,
 	loadBaseFields,
 	loadBulkUpload,
-	loadOrganizationByEmployerIdentificationNumber,
+	loadOrganizationByTaxId,
 	updateBulkUpload,
 } from '../database/operations';
 import { BulkUploadStatus, isProcessBulkUploadJobPayload } from '../types';
@@ -239,9 +239,7 @@ const createOrLoadOrganization = async (
 	writeValues: Omit<WritableOrganization, 'name'> & { name?: string },
 ): Promise<Organization | undefined> => {
 	try {
-		return await loadOrganizationByEmployerIdentificationNumber(
-			writeValues.employerIdentificationNumber,
-		);
+		return await loadOrganizationByTaxId(writeValues.taxId);
 	} catch {
 		if (writeValues.name !== undefined) {
 			return createOrganization({
@@ -337,7 +335,7 @@ export const processBulkUpload = async (
 			if (organizationTaxId !== undefined) {
 				const organization = await createOrLoadOrganization({
 					name: organizationName,
-					employerIdentificationNumber: organizationTaxId,
+					taxId: organizationTaxId,
 				});
 
 				if (organization !== undefined) {

--- a/src/types/Organization.ts
+++ b/src/types/Organization.ts
@@ -4,7 +4,8 @@ import type { Writable } from './Writable';
 
 interface Organization {
 	readonly id: number;
-	employerIdentificationNumber: string;
+	taxId: string;
+	readonly employerIdentificationNumber: string;
 	name: string;
 	readonly createdAt: string;
 }
@@ -14,14 +15,14 @@ type WritableOrganization = Writable<Organization>;
 const writableOrganizationSchema: JSONSchemaType<WritableOrganization> = {
 	type: 'object',
 	properties: {
-		employerIdentificationNumber: {
+		taxId: {
 			type: 'string',
 		},
 		name: {
 			type: 'string',
 		},
 	},
-	required: ['employerIdentificationNumber', 'name'],
+	required: ['taxId', 'name'],
 };
 
 const isWritableOrganization = ajv.compile(writableOrganizationSchema);


### PR DESCRIPTION
This PR updates the `Organization` entity to have a `taxId` rather than the US-centric `EmployerIdentificationNumber`. The old value is still there, but is marked as deprecated and will be removed once we've updated our front-end to use the new attribute.

Related to #931 