### PR TITLE
Fix readonly object references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Several read-only fields were improperly defined, resulting in improper SDK results.
+
 ## 0.10.0 2024-05-03
 
 ### Removed

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -196,12 +196,10 @@
 						"type": "integer"
 					},
 					"organization": {
+						"readOnly": true,
 						"allOf": [
 							{
 								"$ref": "#/components/schemas/Organization"
-							},
-							{
-								"readOnly": true
 							}
 						]
 					},
@@ -209,12 +207,10 @@
 						"type": "integer"
 					},
 					"proposal": {
+						"readOnly": true,
 						"allOf": [
 							{
 								"$ref": "#/components/schemas/Proposal"
-							},
-							{
-								"readOnly": true
 							}
 						]
 					},
@@ -371,12 +367,10 @@
 						"example": 3613
 					},
 					"applicationFormField": {
+						"readOnly": true,
 						"allOf": [
 							{
 								"$ref": "#/components/schemas/ApplicationFormField"
-							},
-							{
-								"readOnly": true
 							}
 						]
 					},
@@ -459,12 +453,10 @@
 						"example": 3011
 					},
 					"baseField": {
+						"readOnly": true,
 						"allOf": [
 							{
 								"$ref": "#/components/schemas/BaseField"
-							},
-							{
-								"readOnly": true
 							}
 						]
 					},


### PR DESCRIPTION
This PR fixes the way some of our object attributes are marked as `readOnly` so that swagger codegen will properly generate types that don't combine with `any`.

To test this you will need to follow the instructions in https://github.com/PhilanthropyDataCommons/sdk to use this branch's `openapi.json` to generate the sdk.  You can search the resulting code to ensure `& any` is not included anywhere.

Resolves #1004