### PR TITLE
Correct `/bulkUploads` specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- The `BulkUploadBundle` entity now exists, and the `/bulkUploads` endpoint is properly documented to return that type.
+
 ### Fixed
 
 - Several read-only fields were improperly defined, resulting in improper SDK results.

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -161,6 +161,25 @@
 					"createdAt"
 				]
 			},
+			"BulkUploadBundle": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/Bundle"
+					},
+					{
+						"type": "object",
+						"properties": {
+							"entries": {
+								"type": "array",
+								"items": {
+									"$ref": "#/components/schemas/BulkUpload"
+								}
+							}
+						},
+						"required": ["entries"]
+					}
+				]
+			},
 			"Organization": {
 				"type": "object",
 				"properties": {
@@ -879,7 +898,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/BulkUpload"
+									"$ref": "#/components/schemas/BulkUploadBundle"
 								}
 							}
 						}


### PR DESCRIPTION
This PR adds the `BulkUploadBundle` entity type

This should be merged after:

- [x] #1020 

Resolves #1010