### PR TITLE
Fix `PresignedPostRequest` definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Several read-only fields were improperly defined, resulting in improper SDK results.
+- `WritablePresignedPostRequest` will no longer require a populated `presignedPost`.
+
+### Changed
+
+- Created a new `PresignedPost` entity type instead of directly embedding the definition in `PresignedPostRequest`.
 
 ## 0.10.0 2024-05-03
 

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -261,27 +261,34 @@
 						"example": 512
 					},
 					"presignedPost": {
-						"type": "object",
 						"readOnly": true,
-						"properties": {
-							"url": {
-								"type": "string"
-							},
-							"fields": {
-								"type": "object",
-								"properties": {
-									"key": {
-										"type": "string",
-										"example": "96ddab90-1931-478d-8c02-a1dc80ae01e5"
-									}
-								},
-								"required": ["key"]
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/PresignedPost"
 							}
-						},
-						"required": ["url", "fields"]
+						]
 					}
 				},
 				"required": ["fileType", "fileSize", "presignedPost"]
+			},
+			"PresignedPost": {
+				"type": "object",
+				"properties": {
+					"url": {
+						"type": "string"
+					},
+					"fields": {
+						"type": "object",
+						"properties": {
+							"key": {
+								"type": "string",
+								"example": "96ddab90-1931-478d-8c02-a1dc80ae01e5"
+							}
+						},
+						"required": ["key"]
+					}
+				},
+				"required": ["url", "fields"]
 			},
 			"Proposal": {
 				"type": "object",


### PR DESCRIPTION
This PR fixes the definition of `PresignedPostRequest` so that swagger codegen will honor the readonly nature of the `presignedPost` attribute.

This will be a breaking change to the SDK since it changes the name of the `PresignedPost` type (which was previously `PresignedPostRequestPresignedPost`.

Resolves #1012 

This should be merged after:

- [x] #1021 