### PR TITLE
Fix test to use createOrganization

### DIFF
--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -5,7 +5,6 @@ import {
 	createOrganization,
 	createOrganizationProposal,
 	createProposal,
-	db,
 	loadTableMetrics,
 } from '../database';
 import { expectTimestamp, loadTestUser } from '../test/utils';
@@ -68,7 +67,7 @@ describe('/organizations', () => {
 		it('returns according to pagination parameters', async () => {
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
-				await db.sql('organizations.insertOne', {
+				await createOrganization({
 					taxId: '11-1111111',
 					name: `Organization ${i + 1}`,
 				});


### PR DESCRIPTION
This PR removes a direct DB call in a test and replaces it with our DB utilities.

This was simply missed in a previous PR.

Related to #228 