### PR TITLE
Make Maximum ID Value Explicit

### DIFF
--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -80,6 +80,17 @@ describe('/opportunities', () => {
 			});
 		});
 
+		it('returns 400 bad request when id is a number greater than 2^32-1', async () => {
+			const result = await agent
+				.get('/opportunities/555555555555555555555555555555')
+				.set(authHeader)
+				.expect(400);
+			expect(result.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expect.any(Array) as unknown[],
+			});
+		});
+
 		it('returns 404 when id is not found', async () => {
 			await createOpportunity({
 				title: 'This definitely should not be returned',

--- a/src/types/Id.ts
+++ b/src/types/Id.ts
@@ -6,6 +6,7 @@ export type Id = number;
 export const idSchema: JSONSchemaType<Id> = {
 	type: 'integer',
 	minimum: 1,
+	maximum: 4294967295,
 };
 
 export const isId = ajv.compile(idSchema);


### PR DESCRIPTION
This commit adds an explicit maximum value for IDs, as we do not support IDs greater than 2^32-1. Note that as per the example provided in #971:
Before:
```
GET' \
  'http://localhost:3001/opportunities/555555555555555555555555555555' \
```
Returns
```
{
  "name": "DatabaseError",
  "message": "Unexpected database error.",
  "details": [
    {
      "length": 168,
      "name": "error",
      "severity": "ERROR",
      "code": "22003",
      "where": "unnamed portal parameter $1 = '...'",
      "file": "numutils.c",
      "line": "314",
      "routine": "pg_strtoint32"
    }
  ]
}
```
After:
```
GET' \
  'http://localhost:3001/opportunities/555555555555555555555555555555' \
```
Returns:
```
{
  "name": "InputValidationError",
  "message": "Invalid id parameter.",
  "details": [
    {
      "instancePath": "",
      "schemaPath": "#/maximum",
      "keyword": "maximum",
      "params": {
        "comparison": "<=",
        "limit": 4294967295
      },
      "message": "must be <= 4294967295"
    }
  ]
}
```
Closes #971 