### PR TITLE
Use Error Code 422 When Referenced Resources Don't Exist

### DIFF
--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -351,7 +351,7 @@ describe('/applicationForms', () => {
 			});
 		});
 
-		it('returns 409 conflict when a non-existent opportunity id is provided', async () => {
+		it('returns 422 conflict when a non-existent opportunity id is provided', async () => {
 			const result = await agent
 				.post('/applicationForms')
 				.type('application/json')
@@ -360,7 +360,7 @@ describe('/applicationForms', () => {
 					opportunityId: 1,
 					fields: [],
 				})
-				.expect(409);
+				.expect(422);
 			expect(result.body).toMatchObject({
 				name: 'DatabaseError',
 				details: [

--- a/src/__tests__/organizationProposals.int.test.ts
+++ b/src/__tests__/organizationProposals.int.test.ts
@@ -269,7 +269,7 @@ describe('/organizationProposals', () => {
 			});
 		});
 
-		it('returns 409 Conflict when a non-existent proposal is sent', async () => {
+		it('returns 422 Conflict when a non-existent proposal is sent', async () => {
 			await createOpportunity({
 				title: '🔥',
 			});
@@ -282,13 +282,13 @@ describe('/organizationProposals', () => {
 					organizationId: 1,
 					proposalId: 42,
 				})
-				.expect(409);
+				.expect(422);
 			expect(result.body).toMatchObject({
 				name: 'DatabaseError',
 			});
 		});
 
-		it('returns 409 Conflict when a non-existent organization is sent', async () => {
+		it('returns 422 Conflict when a non-existent organization is sent', async () => {
 			await createOpportunity({
 				title: '🔥',
 			});
@@ -306,7 +306,7 @@ describe('/organizationProposals', () => {
 					organizationId: 42,
 					proposalId: 1,
 				})
-				.expect(409);
+				.expect(422);
 			expect(result.body).toMatchObject({
 				name: 'DatabaseError',
 			});

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -1193,7 +1193,7 @@ describe('/proposals', () => {
 			});
 		});
 
-		it('returns 409 conflict when a non-existent opportunity id is provided', async () => {
+		it('returns 422 conflict when a non-existent opportunity id is provided', async () => {
 			const result = await agent
 				.post('/proposals')
 				.type('application/json')
@@ -1202,7 +1202,7 @@ describe('/proposals', () => {
 					externalId: 'proposal123',
 					opportunityId: 1,
 				})
-				.expect(409);
+				.expect(422);
 			expect(result.body).toMatchObject({
 				name: 'DatabaseError',
 				details: [

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -15,7 +15,7 @@ const logger = getLogger(__filename);
 const getHttpStatusCodeForDatabaseErrorCode = (errorCode: string): number => {
 	switch (errorCode) {
 		case PostgresErrorCode.FOREIGN_KEY_VIOLATION.valueOf():
-			return 409;
+			return 422;
 		case PostgresErrorCode.UNIQUE_VIOLATION.valueOf():
 			return 409;
 		case PostgresErrorCode.INSUFFICIENT_RESOURCES.valueOf():

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -837,7 +837,17 @@
 						}
 					},
 					"409": {
-						"description": "There was a unique key or foreign key conflict.",
+						"description": "There was a unique key conflict.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PdcError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "The application references entities that do not exist in the database.",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -1298,7 +1308,17 @@
 						}
 					},
 					"409": {
-						"description": "There was a unique key or foreign key conflict.",
+						"description": "There was a unique key conflict.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PdcError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "The proposal references entities that do not exist in the database.",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -1386,8 +1406,8 @@
 							}
 						}
 					},
-					"409": {
-						"description": "There was a foreign key conflict.",
+					"422": {
+						"description": "The proposal version references entities that do not exist in the database.",
 						"content": {
 							"application/json": {
 								"schema": {


### PR DESCRIPTION
This commit distinguishes creation errors when referenced resources don't exist by using the error code 422, whereas before both unique id AND foreign key errors were covered by the error code 409.  It also updates the openapi spec to match these changes.

Closes Issue #827 