### PR TITLE
Add BaseField enum validation

### DIFF
--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -175,6 +175,25 @@ describe('/baseFields', () => {
 			});
 		});
 
+		it('returns 400 bad request when an invalid dataType is sent', async () => {
+			const result = await agent
+				.post('/baseFields')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					label: '🏷️',
+					description: '😍',
+					shortCode: '🩳',
+					dataType: '🤡',
+					scope: BaseFieldScope.PROPOSAL,
+				})
+				.expect(400);
+			expect(result.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expect.any(Array) as unknown[],
+			});
+		});
+
 		it('returns 400 bad request when no scope is sent', async () => {
 			const result = await agent
 				.post('/baseFields')
@@ -185,6 +204,25 @@ describe('/baseFields', () => {
 					description: '😍',
 					shortCode: '🩳',
 					dataType: BaseFieldDataType.STRING,
+				})
+				.expect(400);
+			expect(result.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expect.any(Array) as unknown[],
+			});
+		});
+
+		it('returns 400 bad request when an invalid scope is sent', async () => {
+			const result = await agent
+				.post('/baseFields')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					label: '🏷️',
+					description: '😍',
+					shortCode: '🩳',
+					dataType: BaseFieldDataType.STRING,
+					scope: '🤡',
 				})
 				.expect(400);
 			expect(result.body).toMatchObject({

--- a/src/types/BaseField.ts
+++ b/src/types/BaseField.ts
@@ -42,9 +42,11 @@ const writableBaseFieldSchema: JSONSchemaType<WritableBaseField> = {
 		},
 		dataType: {
 			type: 'string',
+			enum: Object.values(BaseFieldDataType),
 		},
 		scope: {
 			type: 'string',
+			enum: Object.values(BaseFieldScope),
 		},
 	},
 	required: ['label', 'description', 'shortCode', 'dataType', 'scope'],


### PR DESCRIPTION
This PR fixes an omission from our BaseField type definition (and resulting validation).

The API should now properly return an error code if the base field has an unexpected value.

Resolves #1099