### PR TITLE
Lower default count for pagination

### DIFF
--- a/src/openapi.json
+++ b/src/openapi.json
@@ -31,7 +31,7 @@
 				"schema": {
 					"type": "integer",
 					"minimum": 1,
-					"default": 100
+					"default": 10
 				},
 				"in": "query",
 				"name": "_count",


### PR DESCRIPTION
This PR updates the default count for paginated resources to 10.

Resolves #330