### PR TITLE
Add license information to swagger spec

### DIFF
--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3,7 +3,11 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for organizations seeking grants.",
-		"version": "0.11.0"
+		"version": "0.11.0",
+		"license": {
+			"name": "GNU Affero General Public License v3.0 only",
+			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"
+		}
 	},
 	"components": {
 		"parameters": {


### PR DESCRIPTION
This PR adds some license information to our swagger specification.

This means the license gets rendered on our api page: 

<img width="314" alt="image" src="https://github.com/user-attachments/assets/1bccd277-ac5f-46a3-807a-adae6118cfd5">

I wasn't able to add an `identifier` attribute even though [it is listed as a valid attribute in the specification](https://swagger.io/specification/).  Our validator complained about it.  Rather than debug, I think this is good enough and meets 99% of the value of including this information at all.

Resolves #853