### PR TITLE
Include field values in `/organizations`

### DIFF
--- a/src/__tests__/organizationProposals.int.test.ts
+++ b/src/__tests__/organizationProposals.int.test.ts
@@ -65,6 +65,7 @@ describe('/organizationProposals', () => {
 							name: 'Example Inc.',
 							taxId: '11-1111111',
 							createdAt: expectTimestamp,
+							fields: [],
 						},
 						proposalId: 2,
 						proposal: {
@@ -85,6 +86,7 @@ describe('/organizationProposals', () => {
 							name: 'Example Inc.',
 							taxId: '11-1111111',
 							createdAt: expectTimestamp,
+							fields: [],
 						},
 						proposalId: 1,
 						proposal: {
@@ -140,6 +142,7 @@ describe('/organizationProposals', () => {
 							name: 'Example Inc.',
 							taxId: '11-1111111',
 							createdAt: expectTimestamp,
+							fields: [],
 						},
 						proposalId: 1,
 						proposal: {
@@ -202,6 +205,7 @@ describe('/organizationProposals', () => {
 					name: 'Example Inc.',
 					taxId: '11-1111111',
 					createdAt: expectTimestamp,
+					fields: [],
 				},
 				proposalId: 1,
 				proposal: {

--- a/src/database/initialization/organization_to_json.sql
+++ b/src/database/initialization/organization_to_json.sql
@@ -1,11 +1,44 @@
-CREATE OR REPLACE FUNCTION organization_to_json(organization organizations)
+-- An explicit DROP is needed to remove the old function instead of overloading it.
+DROP FUNCTION IF EXISTS organization_to_json(organizations);
+CREATE OR REPLACE FUNCTION organization_to_json(organization organizations, authenticationId VARCHAR DEFAULT NULL)
 RETURNS JSONB AS $$
+DECLARE
+  proposal_field_values_json JSONB;
 BEGIN
+  SELECT jsonb_agg(
+    proposal_field_value_to_json(pfv_inner.*)
+  )
+  INTO proposal_field_values_json
+  FROM (
+    SELECT DISTINCT ON (bf.id) pfv.*
+    FROM proposal_field_values pfv
+    -- Remove field values for unauthenticated users while also (re)validating the user ID:
+    INNER JOIN users u
+      ON u.authentication_id = authenticationId
+    INNER JOIN application_form_fields aff
+      ON pfv.application_form_field_id = aff.id
+    INNER JOIN base_fields bf
+      ON aff.base_field_id = bf.id
+    INNER JOIN proposal_versions pv
+      ON pfv.proposal_version_id = pv.id
+    INNER JOIN organizations_proposals op
+      ON pv.proposal_id = op.proposal_id
+    WHERE op.organization_id = organization.id
+      AND bf.scope = 'organization'
+      AND pfv.is_valid
+      -- Guard against possible removal of NON NULL constraint on users table:
+      AND u.authentication_id IS NOT NULL
+      -- Guard against the valid-but-not-really-valid-here system user:
+      AND u.authentication_id != ''
+      ORDER BY bf.id,
+        pfv.created_at DESC
+  ) AS pfv_inner;
   RETURN jsonb_build_object(
     'id', organization.id,
     'taxId', organization.tax_id,
     'name', organization.name,
-    'createdAt', organization.created_at
+    'createdAt', organization.created_at,
+    'fields', COALESCE(proposal_field_values_json, '[]'::JSONB)
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/src/database/operations/load/loadOrganization.ts
+++ b/src/database/operations/load/loadOrganization.ts
@@ -1,12 +1,16 @@
 import { db } from '../../db';
 import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, Organization } from '../../../types';
+import type { Id, JsonResultSet, Organization } from '../../../types';
 
-export const loadOrganization = async (id: number): Promise<Organization> => {
+export const loadOrganization = async (
+	id: Id,
+	authenticationId?: string,
+): Promise<Organization> => {
 	const result = await db.sql<JsonResultSet<Organization>>(
 		'organizations.selectById',
 		{
 			id,
+			authenticationId,
 		},
 	);
 	const { object } = result.rows[0] ?? {};

--- a/src/database/operations/load/loadOrganizationBundle.ts
+++ b/src/database/operations/load/loadOrganizationBundle.ts
@@ -1,11 +1,14 @@
 import { loadBundle } from './loadBundle';
 import type { Bundle, JsonResultSet, Organization } from '../../../types';
 
-export const loadOrganizationBundle = async (queryParameters: {
-	offset: number;
-	limit: number;
-	proposalId?: number;
-}): Promise<Bundle<Organization>> => {
+export const loadOrganizationBundle = async (
+	queryParameters: {
+		offset: number;
+		limit: number;
+		proposalId?: number;
+	},
+	authenticationId?: string,
+): Promise<Bundle<Organization>> => {
 	const defaultQueryParameters = {
 		proposalId: 0,
 	};
@@ -14,6 +17,7 @@ export const loadOrganizationBundle = async (queryParameters: {
 		{
 			...defaultQueryParameters,
 			...queryParameters,
+			authenticationId,
 		},
 		'organizations',
 	);

--- a/src/database/queries/organizations/selectById.sql
+++ b/src/database/queries/organizations/selectById.sql
@@ -1,3 +1,3 @@
-SELECT organization_to_json(organizations.*) AS "object"
+SELECT organization_to_json(organizations.*, :authenticationId) AS "object"
 FROM organizations
 WHERE id = :id

--- a/src/database/queries/organizations/selectWithPagination.sql
+++ b/src/database/queries/organizations/selectWithPagination.sql
@@ -1,5 +1,5 @@
 SELECT DISTINCT o.id,
-  organization_to_json(o.*) AS "object"
+  organization_to_json(o.*, :authenticationId) AS "object"
 FROM organizations o
   LEFT JOIN organizations_proposals op on op.organization_id = o.id
 WHERE

--- a/src/handlers/organizationsHandlers.ts
+++ b/src/handlers/organizationsHandlers.ts
@@ -8,6 +8,7 @@ import {
 	isId,
 	isWritableOrganization,
 	isTinyPgErrorWithQueryContext,
+	AuthenticatedRequest,
 } from '../types';
 import { DatabaseError, InputValidationError } from '../errors';
 import {
@@ -44,16 +45,20 @@ const postOrganization = (
 };
 
 const getOrganizations = (
-	req: Request,
+	req: AuthenticatedRequest,
 	res: Response,
 	next: NextFunction,
 ): void => {
 	const paginationParameters = extractPaginationParameters(req);
 	const proposalParameters = extractProposalParameters(req);
-	loadOrganizationBundle({
-		...getLimitValues(paginationParameters),
-		...proposalParameters,
-	})
+	const authenticationId = req.user?.authenticationId;
+	loadOrganizationBundle(
+		{
+			...getLimitValues(paginationParameters),
+			...proposalParameters,
+		},
+		authenticationId,
+	)
 		.then((organizationBundle) => {
 			res.status(200).contentType('application/json').send(organizationBundle);
 		})
@@ -67,7 +72,7 @@ const getOrganizations = (
 };
 
 const getOrganization = (
-	req: Request,
+	req: AuthenticatedRequest,
 	res: Response,
 	next: NextFunction,
 ): void => {
@@ -76,7 +81,8 @@ const getOrganization = (
 		next(new InputValidationError('Invalid request body.', isId.errors ?? []));
 		return;
 	}
-	loadOrganization(organizationId)
+	const authenticationId = req.user?.authenticationId;
+	loadOrganization(organizationId, authenticationId)
 		.then((organization) => {
 			res.status(200).contentType('application/json').send(organization);
 		})

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -576,6 +576,7 @@ describe('processBulkUpload', () => {
 					taxId: '51-2144346',
 					id: 1,
 					name: 'Foo LLC.',
+					fields: [],
 				},
 			],
 			total: 1,

--- a/src/types/Organization.ts
+++ b/src/types/Organization.ts
@@ -1,11 +1,13 @@
 import { ajv } from '../ajv';
 import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
+import type { ProposalFieldValue } from './ProposalFieldValue';
 
 interface Organization {
 	readonly id: number;
 	taxId: string;
 	name: string;
+	readonly fields: ProposalFieldValue[];
 	readonly createdAt: string;
 }
 


### PR DESCRIPTION
Enhance the existing `/organizations` endpoint with by finding the best ("gold") values associated with that organization from proposal field values, and return the best values, one per base field.

Based on feedback, deeply integrate the gold data search into existing organization types and endpoints. Do much in the existing PG function.

Issue #1087