### PR TITLE
Use Java 17 and cache Gradle artifacts

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -24,6 +24,11 @@ jobs:
           path: 'sdk'
       - name: Copy API definition
         run: cp service/src/openapi.json sdk/openapi.json
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
       - name: Invoke the TypeScript generator
         working-directory: sdk
         run: ./gradlew generateSwaggerCode

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Invoke the TypeScript generator
         working-directory: sdk
         run: ./gradlew generateSwaggerCode


### PR DESCRIPTION
The SDK build [failed recently](https://github.com/PhilanthropyDataCommons/service/actions/runs/10200019587/job/28218495676) due to a network timeout downloading the Gradle binary.

Use the [`setup-gradle` action](https://github.com/gradle/actions/blob/main/setup-gradle/README.md) to cache Gradle artifacts between runs, including both the Gradle binary and the dependencies it downloads. Caching should improve performance, protect against transitory network failures, and help us be a better neighbor by downloading less.

The `setup-gradle` action recommends the [`setup-java` action](https://github.com/actions/setup-java). Previously, we were defaulting to Java 11, the version [provided by the runner](https://github.com/actions/runner-images/blob/ubuntu22/20240721.1/images/ubuntu/Ubuntu2204-Readme.md). Specify Java 17, which is the most recent LTS supported by the version of Gradle used by the SDK.