### PR TITLE
Use supertest agents sparingly

### DIFF
--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -14,7 +14,6 @@ import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 
 const logger = getLogger(__filename);
-const agent = request.agent(app);
 
 const createTestBaseFields = async () => {
 	await createBaseField({
@@ -36,11 +35,11 @@ const createTestBaseFields = async () => {
 describe('/applicationForms', () => {
 	describe('GET /', () => {
 		it('requires authentication', async () => {
-			await agent.get('/applicationForms').expect(401);
+			await request(app).get('/applicationForms').expect(401);
 		});
 
 		it('returns an empty array when no data is present', async () => {
-			const response = await agent
+			const response = await request(app)
 				.get('/applicationForms')
 				.set(authHeader)
 				.expect(200);
@@ -66,7 +65,7 @@ describe('/applicationForms', () => {
 			await createApplicationForm({
 				opportunityId: 2,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get('/applicationForms')
 				.set(authHeader)
 				.expect(200);
@@ -136,7 +135,7 @@ describe('/applicationForms', () => {
 				position: 1,
 				label: 'Duration of work in years',
 			});
-			const result = await agent
+			const result = await request(app)
 				.get('/applicationForms/2')
 				.set(authHeader)
 				.expect(200);
@@ -185,7 +184,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('should return 404 when the applicationForm is not found (shallow)', async () => {
-			const result = await agent
+			const result = await request(app)
 				.get('/applicationForms/6')
 				.set(authHeader)
 				.expect(404);
@@ -196,7 +195,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('should return 404 when the applicationForm is not found (with fields)', async () => {
-			const result = await agent
+			const result = await request(app)
 				.get('/applicationForms/7')
 				.query({ includeFields: 'true' })
 				.set(authHeader)
@@ -210,7 +209,7 @@ describe('/applicationForms', () => {
 
 	describe('POST /', () => {
 		it('requires authentication', async () => {
-			await agent.post('/applicationForms').expect(401);
+			await request(app).post('/applicationForms').expect(401);
 		});
 
 		it('creates exactly one application form', async () => {
@@ -218,7 +217,7 @@ describe('/applicationForms', () => {
 				title: 'Tremendous opportunity 👌',
 			});
 			const before = await loadTableMetrics('application_forms');
-			const result = await agent
+			const result = await request(app)
 				.post('/applicationForms')
 				.type('application/json')
 				.set(authHeader)
@@ -245,7 +244,7 @@ describe('/applicationForms', () => {
 			});
 			await createTestBaseFields();
 			const before = await loadTableMetrics('application_form_fields');
-			const result = await agent
+			const result = await request(app)
 				.post('/applicationForms')
 				.type('application/json')
 				.set(authHeader)
@@ -292,7 +291,7 @@ describe('/applicationForms', () => {
 			await createApplicationForm({
 				opportunityId: 1,
 			});
-			const result = await agent
+			const result = await request(app)
 				.post('/applicationForms')
 				.type('application/json')
 				.set(authHeader)
@@ -310,7 +309,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns 400 bad request when no opportunity id is provided', async () => {
-			await agent
+			await request(app)
 				.post('/applicationForms')
 				.type('application/json')
 				.set(authHeader)
@@ -321,7 +320,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns 400 bad request when no fields value is provided', async () => {
-			await agent
+			await request(app)
 				.post('/applicationForms')
 				.type('application/json')
 				.set(authHeader)
@@ -332,7 +331,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns 400 bad request when an invalid field is provided', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/applicationForms')
 				.type('application/json')
 				.set(authHeader)
@@ -352,7 +351,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns 422 conflict when a non-existent opportunity id is provided', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/applicationForms')
 				.type('application/json')
 				.set(authHeader)
@@ -393,7 +392,7 @@ describe('/applicationForms', () => {
 				.mockImplementationOnce(async () => {
 					throw new Error('This is unexpected');
 				});
-			const result = await agent
+			const result = await request(app)
 				.post('/applicationForms')
 				.type('application/json')
 				.set(authHeader)

--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -14,8 +14,6 @@ import {
 	mockJwtWithAdminRole as adminUserAuthHeader,
 } from '../test/mockJwt';
 
-const agent = request.agent(app);
-
 const createTestBaseField = async () =>
 	createBaseField({
 		label: 'Summary',
@@ -44,11 +42,11 @@ const createTestBaseFieldWithLocalization = async () => {
 describe('/baseFields', () => {
 	describe('GET /', () => {
 		it('does not require authentication', async () => {
-			await agent.get('/baseFields').expect(200);
+			await request(app).get('/baseFields').expect(200);
 		});
 
 		it('returns an empty array when no data is present', async () => {
-			await agent.get('/baseFields').expect(200, []);
+			await request(app).get('/baseFields').expect(200, []);
 		});
 
 		it('returns all base fields present in the database', async () => {
@@ -81,7 +79,7 @@ describe('/baseFields', () => {
 				description: 'le postnom',
 			});
 
-			const result = await agent.get('/baseFields').expect(200);
+			const result = await request(app).get('/baseFields').expect(200);
 			expect(result.body).toMatchObject([
 				{
 					id: 1,
@@ -125,16 +123,16 @@ describe('/baseFields', () => {
 
 	describe('POST /', () => {
 		it('requires authentication', async () => {
-			await agent.post('/baseFields').expect(401);
+			await request(app).post('/baseFields').expect(401);
 		});
 
 		it('requires administrator role', async () => {
-			await agent.post('/baseFields').set(authHeader).expect(401);
+			await request(app).post('/baseFields').set(authHeader).expect(401);
 		});
 
 		it('creates exactly one base field', async () => {
 			const before = await loadTableMetrics('base_fields');
-			const result = await agent
+			const result = await request(app)
 				.post('/baseFields')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -162,7 +160,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 400 bad request when no label is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/baseFields')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -180,7 +178,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 400 bad request when no description is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/baseFields')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -198,7 +196,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 400 bad request when no shortCode is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/baseFields')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -216,7 +214,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 400 bad request when no dataType is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/baseFields')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -234,7 +232,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 400 bad request when an invalid dataType is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/baseFields')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -253,7 +251,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 400 bad request when no scope is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/baseFields')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -271,7 +269,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 400 bad request when an invalid scope is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/baseFields')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -297,7 +295,7 @@ describe('/baseFields', () => {
 				dataType: BaseFieldDataType.STRING,
 				scope: BaseFieldScope.PROPOSAL,
 			});
-			const result = await agent
+			const result = await request(app)
 				.post('/baseFields')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -322,11 +320,11 @@ describe('/baseFields', () => {
 
 	describe('PUT /:baseFieldId', () => {
 		it('requires authentication', async () => {
-			await agent.put('/baseFields/1').expect(401);
+			await request(app).put('/baseFields/1').expect(401);
 		});
 
 		it('requires administrator role', async () => {
-			await agent.put('/baseFields/1').set(authHeader).expect(401);
+			await request(app).put('/baseFields/1').set(authHeader).expect(401);
 		});
 
 		it('updates the specified base field', async () => {
@@ -340,7 +338,7 @@ describe('/baseFields', () => {
 				dataType: BaseFieldDataType.STRING,
 				scope: BaseFieldScope.PROPOSAL,
 			});
-			await agent
+			await request(app)
 				.put('/baseFields/1')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -367,7 +365,7 @@ describe('/baseFields', () => {
 
 		it('returns the updated base field', async () => {
 			await createTestBaseField();
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/1')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -394,7 +392,7 @@ describe('/baseFields', () => {
 		it('returns 400 bad request when no label is sent', async () => {
 			await createTestBaseField();
 
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/1')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -412,7 +410,7 @@ describe('/baseFields', () => {
 
 		it('returns 400 bad request when no description is sent', async () => {
 			await createTestBaseField();
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/1')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -430,7 +428,7 @@ describe('/baseFields', () => {
 
 		it('returns 400 bad request when no shortCode is sent', async () => {
 			await createTestBaseField();
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/1')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -448,7 +446,7 @@ describe('/baseFields', () => {
 
 		it('returns 400 bad request when no dataType is sent', async () => {
 			await createTestBaseField();
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/1')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -465,7 +463,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 400 when a non-numeric ID is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/notanumber')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -483,7 +481,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 404 when attempting to update a non-existent record', async () => {
-			await agent
+			await request(app)
 				.put('/baseFields/1')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -500,7 +498,7 @@ describe('/baseFields', () => {
 	describe('GET /:baseFieldId/localizations', () => {
 		it('does not require authentication', async () => {
 			await createTestBaseFieldWithLocalization();
-			await agent.get('/baseFields/1/localizations').expect(200);
+			await request(app).get('/baseFields/1/localizations').expect(200);
 		});
 
 		it('returns all base field localizations related to the given baseFieldId', async () => {
@@ -526,7 +524,9 @@ describe('/baseFields', () => {
 				description: 'The First Name of the applicant',
 			});
 
-			const result = await agent.get('/baseFields/1/localizations').expect(200);
+			const result = await request(app)
+				.get('/baseFields/1/localizations')
+				.expect(200);
 			expect(result.body).toMatchObject({
 				total: 2,
 				entries: [
@@ -548,7 +548,9 @@ describe('/baseFields', () => {
 			});
 		});
 		it('returns 404 when a base field is referenced that does not exist', async () => {
-			const result = await agent.get('/baseFields/1/localizations').expect(404);
+			const result = await request(app)
+				.get('/baseFields/1/localizations')
+				.expect(404);
 			expect(result.body).toMatchObject({
 				name: 'NotFoundError',
 				details: [
@@ -562,11 +564,11 @@ describe('/baseFields', () => {
 
 	describe('PUT /:baseFieldId/localizations/:language', () => {
 		it('requires authentication', async () => {
-			await agent.put('/baseFields/1/localizations/fr').expect(401);
+			await request(app).put('/baseFields/1/localizations/fr').expect(401);
 		});
 
 		it('requires administrator role', async () => {
-			await agent
+			await request(app)
 				.put('/baseFields/1/localizations/fr')
 				.set(authHeader)
 				.expect(401);
@@ -575,7 +577,7 @@ describe('/baseFields', () => {
 		it('creates the specified base field localization if it does not exist', async () => {
 			await createTestBaseField();
 			const before = await loadTableMetrics('base_field_localizations');
-			await agent
+			await request(app)
 				.put('/baseFields/1/localizations/fr')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -613,7 +615,7 @@ describe('/baseFields', () => {
 				description: 'The Summary of a proposal',
 			});
 			const before = await loadTableMetrics('base_field_localizations');
-			await agent
+			await request(app)
 				.put('/baseFields/1/localizations/fr')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -645,7 +647,7 @@ describe('/baseFields', () => {
 		it('returns 400 bad request when no label is sent', async () => {
 			await createTestBaseField();
 
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/1/localizations/fr')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -661,7 +663,7 @@ describe('/baseFields', () => {
 
 		it('returns 400 bad request when no description is sent', async () => {
 			await createTestBaseField();
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/1/localizations/fr')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -676,7 +678,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 400 when a non-numeric ID is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/notanumber/localizations/fr')
 				.type('application/json')
 				.set(adminUserAuthHeader)
@@ -693,7 +695,7 @@ describe('/baseFields', () => {
 
 		it('returns 400 when an invalid IETF language tag is sent', async () => {
 			await createTestBaseField();
-			const result = await agent
+			const result = await request(app)
 				.put(
 					'/baseFields/1/localizations/theLanguageKlingonWhichIsNotARealLanguage',
 				)
@@ -711,7 +713,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 404 when a base field is referenced that does not exist', async () => {
-			const result = await agent
+			const result = await request(app)
 				.put('/baseFields/1/localizations/fr')
 				.type('application/json')
 				.set(adminUserAuthHeader)

--- a/src/__tests__/bulkUploads.int.test.ts
+++ b/src/__tests__/bulkUploads.int.test.ts
@@ -14,20 +14,21 @@ import {
 } from '../test/mockJwt';
 import { BulkUploadStatus } from '../types';
 
-const agent = request.agent(app);
-
 describe('/bulkUploads', () => {
 	describe('GET /', () => {
 		it('requires authentication', async () => {
-			await agent.get('/bulkUploads').expect(401);
+			await request(app).get('/bulkUploads').expect(401);
 		});
 
 		it('requires a user', async () => {
-			await agent.get('/bulkUploads').set(authHeaderWithNoSub).expect(401);
+			await request(app)
+				.get('/bulkUploads')
+				.set(authHeaderWithNoSub)
+				.expect(401);
 		});
 
 		it('returns an empty Bundle when no data is present', async () => {
-			await agent.get('/bulkUploads').set(authHeader).expect(200, {
+			await request(app).get('/bulkUploads').set(authHeader).expect(200, {
 				total: 0,
 				entries: [],
 			});
@@ -64,7 +65,7 @@ describe('/bulkUploads', () => {
 				createdBy: thirdUser.id,
 			});
 
-			await agent
+			await request(app)
 				.get('/bulkUploads')
 				.set(authHeader)
 				.expect(200)
@@ -113,7 +114,7 @@ describe('/bulkUploads', () => {
 				createdBy: anotherUser.id,
 			});
 
-			await agent
+			await request(app)
 				.get('/bulkUploads')
 				.set(authHeaderWithAdminRole)
 				.expect(200)
@@ -162,7 +163,7 @@ describe('/bulkUploads', () => {
 				createdBy: anotherUser.id,
 			});
 
-			await agent
+			await request(app)
 				.get(`/bulkUploads?createdBy=${anotherUser.id}`)
 				.set(authHeaderWithAdminRole)
 				.expect(200)
@@ -202,7 +203,7 @@ describe('/bulkUploads', () => {
 				createdBy: anotherUser.id,
 			});
 
-			await agent
+			await request(app)
 				.get(`/bulkUploads?createdBy=me`)
 				.set(authHeaderWithAdminRole)
 				.expect(200)
@@ -236,7 +237,7 @@ describe('/bulkUploads', () => {
 				});
 			}, Promise.resolve());
 
-			await agent
+			await request(app)
 				.get('/bulkUploads')
 				.query({
 					_page: 2,
@@ -306,16 +307,19 @@ describe('/bulkUploads', () => {
 
 	describe('POST /', () => {
 		it('requires authentication', async () => {
-			await agent.post('/bulkUploads').expect(401);
+			await request(app).post('/bulkUploads').expect(401);
 		});
 
 		it('requires a user', async () => {
-			await agent.post('/bulkUploads').set(authHeaderWithNoSub).expect(401);
+			await request(app)
+				.post('/bulkUploads')
+				.set(authHeaderWithNoSub)
+				.expect(401);
 		});
 
 		it('creates exactly one bulk upload', async () => {
 			const before = await loadTableMetrics('bulk_uploads');
-			const result = await agent
+			const result = await request(app)
 				.post('/bulkUploads')
 				.type('application/json')
 				.set(authHeader)
@@ -341,7 +345,7 @@ describe('/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when no file name is provided', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/bulkUploads')
 				.type('application/json')
 				.set(authHeader)
@@ -356,7 +360,7 @@ describe('/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when an invalid file name is provided', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/bulkUploads')
 				.type('application/json')
 				.set(authHeader)
@@ -372,7 +376,7 @@ describe('/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when an invalid source key is provided', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/bulkUploads')
 				.type('application/json')
 				.set(authHeader)
@@ -388,7 +392,7 @@ describe('/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when no source key is provided', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/bulkUploads')
 				.type('application/json')
 				.set(authHeader)

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -4,16 +4,14 @@ import { createOpportunity, loadTableMetrics } from '../database';
 import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 
-const agent = request.agent(app);
-
 describe('/opportunities', () => {
 	describe('GET /', () => {
 		it('requires authentication', async () => {
-			await agent.get('/opportunities').expect(401);
+			await request(app).get('/opportunities').expect(401);
 		});
 
 		it('returns an empty bundle when no data is present', async () => {
-			await agent.get('/opportunities').set(authHeader).expect(200, {
+			await request(app).get('/opportunities').set(authHeader).expect(200, {
 				entries: [],
 				total: 0,
 			});
@@ -26,7 +24,7 @@ describe('/opportunities', () => {
 			await createOpportunity({
 				title: 'Terrific opportunity 👐',
 			});
-			const response = await agent
+			const response = await request(app)
 				.get('/opportunities')
 				.set(authHeader)
 				.expect(200);
@@ -50,7 +48,7 @@ describe('/opportunities', () => {
 
 	describe('GET /:id', () => {
 		it('requires authentication', async () => {
-			await agent.get('/opportunities/1').expect(401);
+			await request(app).get('/opportunities/1').expect(401);
 		});
 
 		it('returns exactly one opportunity selected by id', async () => {
@@ -58,7 +56,7 @@ describe('/opportunities', () => {
 			await createOpportunity({ title: '✨' });
 			await createOpportunity({ title: '🚀' });
 
-			const response = await agent
+			const response = await request(app)
 				.get(`/opportunities/2`)
 				.set(authHeader)
 				.expect(200);
@@ -70,7 +68,7 @@ describe('/opportunities', () => {
 		});
 
 		it('returns 400 bad request when id is a letter', async () => {
-			const result = await agent
+			const result = await request(app)
 				.get('/opportunities/a')
 				.set(authHeader)
 				.expect(400);
@@ -81,7 +79,7 @@ describe('/opportunities', () => {
 		});
 
 		it('returns 400 bad request when id is a number greater than 2^32-1', async () => {
-			const result = await agent
+			const result = await request(app)
 				.get('/opportunities/555555555555555555555555555555')
 				.set(authHeader)
 				.expect(400);
@@ -95,18 +93,18 @@ describe('/opportunities', () => {
 			await createOpportunity({
 				title: 'This definitely should not be returned',
 			});
-			await agent.get('/opportunities/9001').set(authHeader).expect(404);
+			await request(app).get('/opportunities/9001').set(authHeader).expect(404);
 		});
 	});
 
 	describe('POST /', () => {
 		it('requires authentication', async () => {
-			await agent.post('/opportunities').expect(401);
+			await request(app).post('/opportunities').expect(401);
 		});
 
 		it('creates and returns exactly one opportunity', async () => {
 			const before = await loadTableMetrics('opportunities');
-			const result = await agent
+			const result = await request(app)
 				.post('/opportunities')
 				.type('application/json')
 				.set(authHeader)
@@ -123,7 +121,7 @@ describe('/opportunities', () => {
 		});
 
 		it('returns 400 bad request when no title sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/opportunities')
 				.type('application/json')
 				.set(authHeader)

--- a/src/__tests__/organizationProposals.int.test.ts
+++ b/src/__tests__/organizationProposals.int.test.ts
@@ -10,8 +10,6 @@ import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import { createOpportunity } from '../database/operations/create/createOpportunity';
 
-const agent = request.agent(app);
-
 const insertTestOrganizations = async () => {
 	await createOrganization({
 		taxId: '11-1111111',
@@ -26,7 +24,7 @@ const insertTestOrganizations = async () => {
 describe('/organizationProposals', () => {
 	describe('GET /', () => {
 		it('requires authentication', async () => {
-			await agent.get('/organizationProposals').expect(401);
+			await request(app).get('/organizationProposals').expect(401);
 		});
 
 		it('returns the OrganizationProposals for the specified organization', async () => {
@@ -53,7 +51,7 @@ describe('/organizationProposals', () => {
 				organizationId: 1,
 				proposalId: 2,
 			});
-			const result = await agent
+			const result = await request(app)
 				.get(`/organizationProposals?organization=1`)
 				.set(authHeader)
 				.expect(200);
@@ -128,7 +126,7 @@ describe('/organizationProposals', () => {
 				organizationId: 2,
 				proposalId: 2,
 			});
-			const result = await agent
+			const result = await request(app)
 				.get(`/organizationProposals?proposal=1`)
 				.set(authHeader)
 				.expect(200);
@@ -161,7 +159,7 @@ describe('/organizationProposals', () => {
 
 		it('returns a 400 bad request when a non-integer ID is sent', async () => {
 			await insertTestOrganizations();
-			await agent
+			await request(app)
 				.get('/organizationProposals?organization=foo')
 				.set(authHeader)
 				.expect(400);
@@ -170,7 +168,7 @@ describe('/organizationProposals', () => {
 
 	describe('POST /', () => {
 		it('requires authentication', async () => {
-			await agent.post('/organizationProposals').expect(401);
+			await request(app).post('/organizationProposals').expect(401);
 		});
 
 		it('creates exactly one OrganizationProposal', async () => {
@@ -185,7 +183,7 @@ describe('/organizationProposals', () => {
 				createdBy: testUser.id,
 			});
 			const before = await loadTableMetrics('organizations_proposals');
-			const result = await agent
+			const result = await request(app)
 				.post('/organizationProposals')
 				.type('application/json')
 				.set(authHeader)
@@ -230,7 +228,7 @@ describe('/organizationProposals', () => {
 				externalId: '1',
 				createdBy: testUser.id,
 			});
-			const result = await agent
+			const result = await request(app)
 				.post('/organizationProposals')
 				.type('application/json')
 				.set(authHeader)
@@ -255,7 +253,7 @@ describe('/organizationProposals', () => {
 				externalId: '1',
 				createdBy: testUser.id,
 			});
-			const result = await agent
+			const result = await request(app)
 				.post('/organizationProposals')
 				.type('application/json')
 				.set(authHeader)
@@ -274,7 +272,7 @@ describe('/organizationProposals', () => {
 				title: '🔥',
 			});
 			await insertTestOrganizations();
-			const result = await agent
+			const result = await request(app)
 				.post('/organizationProposals')
 				.type('application/json')
 				.set(authHeader)
@@ -298,7 +296,7 @@ describe('/organizationProposals', () => {
 				externalId: '1',
 				createdBy: testUser.id,
 			});
-			const result = await agent
+			const result = await request(app)
 				.post('/organizationProposals')
 				.type('application/json')
 				.set(authHeader)
@@ -327,7 +325,7 @@ describe('/organizationProposals', () => {
 				organizationId: 1,
 				proposalId: 1,
 			});
-			const result = await agent
+			const result = await request(app)
 				.post('/organizationProposals')
 				.type('application/json')
 				.set(authHeader)

--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -11,8 +11,6 @@ import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 import { PostgresErrorCode } from '../types';
 
-const agent = request.agent(app);
-
 const insertTestOrganizations = async () => {
 	await createOrganization({
 		taxId: '11-1111111',
@@ -27,11 +25,11 @@ const insertTestOrganizations = async () => {
 describe('/organizations', () => {
 	describe('GET /', () => {
 		it('does not require authentication', async () => {
-			await agent.get('/organizations').expect(200);
+			await request(app).get('/organizations').expect(200);
 		});
 
 		it('returns an empty Bundle when no data is present', async () => {
-			await agent.get('/organizations').set(authHeader).expect(200, {
+			await request(app).get('/organizations').set(authHeader).expect(200, {
 				total: 0,
 				entries: [],
 			});
@@ -39,7 +37,7 @@ describe('/organizations', () => {
 
 		it('returns organizations present in the database', async () => {
 			await insertTestOrganizations();
-			await agent
+			await request(app)
 				.get('/organizations')
 				.set(authHeader)
 				.expect(200)
@@ -72,7 +70,7 @@ describe('/organizations', () => {
 					name: `Organization ${i + 1}`,
 				});
 			}, Promise.resolve());
-			await agent
+			await request(app)
 				.get('/organizations')
 				.query({
 					_page: 2,
@@ -141,7 +139,7 @@ describe('/organizations', () => {
 				organizationId: 1,
 				proposalId: 1,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get(`/organizations?proposal=1`)
 				.set(authHeader)
 				.expect(200);
@@ -185,7 +183,7 @@ describe('/organizations', () => {
 				organizationId: 1,
 				proposalId: 2,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get(`/organizations`)
 				.set(authHeader)
 				.expect(200);
@@ -203,7 +201,7 @@ describe('/organizations', () => {
 		});
 
 		it('returns a 400 error if an invalid organization filter is provided', async () => {
-			const response = await agent
+			const response = await request(app)
 				.get(`/proposals?organization=foo`)
 				.set(authHeader)
 				.expect(400);
@@ -217,16 +215,16 @@ describe('/organizations', () => {
 	describe('GET /:id', () => {
 		it('does not require authentication', async () => {
 			await insertTestOrganizations();
-			await agent.get('/organizations/1').expect(200);
+			await request(app).get('/organizations/1').expect(200);
 		});
 
 		it('returns 404 when given id is not present', async () => {
-			await agent.get('/organizations/9001').set(authHeader).expect(404);
+			await request(app).get('/organizations/9001').set(authHeader).expect(404);
 		});
 
 		it('returns the specified organization', async () => {
 			await insertTestOrganizations();
-			await agent
+			await request(app)
 				.get('/organizations/2')
 				.set(authHeader)
 				.expect(200)
@@ -241,18 +239,18 @@ describe('/organizations', () => {
 		});
 
 		it('returns a 400 bad request when a non-integer ID is sent', async () => {
-			await agent.get('/organizations/foo').set(authHeader).expect(400);
+			await request(app).get('/organizations/foo').set(authHeader).expect(400);
 		});
 	});
 
 	describe('POST /', () => {
 		it('requires authentication', async () => {
-			await agent.post('/organizations').expect(401);
+			await request(app).post('/organizations').expect(401);
 		});
 
 		it('creates exactly one organization', async () => {
 			const before = await loadTableMetrics('organizations');
-			const result = await agent
+			const result = await request(app)
 				.post('/organizations')
 				.type('application/json')
 				.set(authHeader)
@@ -273,7 +271,7 @@ describe('/organizations', () => {
 		});
 
 		it('returns 400 bad request when no taxId is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/organizations')
 				.type('application/json')
 				.set(authHeader)
@@ -288,7 +286,7 @@ describe('/organizations', () => {
 		});
 
 		it('returns 400 bad request when no name is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/organizations')
 				.type('application/json')
 				.set(authHeader)
@@ -307,7 +305,7 @@ describe('/organizations', () => {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 			});
-			const result = await agent
+			const result = await request(app)
 				.post('/organizations')
 				.type('application/json')
 				.set(authHeader)

--- a/src/__tests__/platformProviderResponses.int.test.ts
+++ b/src/__tests__/platformProviderResponses.int.test.ts
@@ -4,16 +4,14 @@ import { db, loadTableMetrics } from '../database';
 import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 
-const agent = request.agent(app);
-
 describe('/platformProviderResponses', () => {
 	describe('GET /', () => {
 		it('requires authentication', async () => {
-			await agent.get('/platformProviderResponses').expect(401);
+			await request(app).get('/platformProviderResponses').expect(401);
 		});
 
 		it('returns no platform provider responses if none exist', async () => {
-			const result = await agent
+			const result = await request(app)
 				.get('/platformProviderResponses?externalId=000000000')
 				.set(authHeader)
 				.expect(200);
@@ -31,7 +29,7 @@ describe('/platformProviderResponses', () => {
 				platformProvider: 'anotherExample',
 				data: JSON.stringify({ goodbyeGalaxy: '17' }),
 			});
-			const result = await agent
+			const result = await request(app)
 				.get('/platformProviderResponses?externalId=000000000')
 				.set(authHeader)
 				.expect(200);
@@ -56,7 +54,7 @@ describe('/platformProviderResponses', () => {
 		});
 
 		it('returns a 400 error if no external ID is provided', async () => {
-			const result = await agent
+			const result = await request(app)
 				.get('/platformProviderResponses')
 				.set(authHeader)
 				.expect(400);
@@ -70,7 +68,7 @@ describe('/platformProviderResponses', () => {
 	describe('POST /', () => {
 		it('creates exactly one platform provider response', async () => {
 			const before = await loadTableMetrics('platform_provider_responses');
-			const result = await agent
+			const result = await request(app)
 				.post('/platformProviderResponses')
 				.type('application/json')
 				.set(authHeader)
@@ -102,7 +100,7 @@ describe('/platformProviderResponses', () => {
 				data: JSON.stringify({ helloWorld: 42 }),
 			});
 			const before = await loadTableMetrics('platform_provider_responses');
-			const result = await agent
+			const result = await request(app)
 				.post('/platformProviderResponses')
 				.type('application/json')
 				.set(authHeader)
@@ -129,7 +127,7 @@ describe('/platformProviderResponses', () => {
 
 		it('returns a 400 error if no external ID is provided', async () => {
 			const before = await loadTableMetrics('platform_provider_responses');
-			const result = await agent
+			const result = await request(app)
 				.post('/platformProviderResponses')
 				.type('application/json')
 				.set(authHeader)

--- a/src/__tests__/presignedPostRequests.int.test.ts
+++ b/src/__tests__/presignedPostRequests.int.test.ts
@@ -14,12 +14,10 @@ jest.mock('@aws-sdk/s3-presigned-post', () => ({
 	createPresignedPost: mockedCreatePresignedPost,
 }));
 
-const agent = request.agent(app);
-
 describe('/presignedPostRequests', () => {
 	describe('POST /', () => {
 		it('requires authentication', async () => {
-			await agent.post('/presignedPostRequests').expect(401);
+			await request(app).post('/presignedPostRequests').expect(401);
 		});
 
 		it('invokes the S3 API to generate a presigned post', async () => {
@@ -34,7 +32,7 @@ describe('/presignedPostRequests', () => {
 				() => mockedPresignedPost,
 			);
 
-			const result = await agent
+			const result = await request(app)
 				.post('/presignedPostRequests')
 				.type('application/json')
 				.set(authHeader)
@@ -64,7 +62,7 @@ describe('/presignedPostRequests', () => {
 		});
 
 		it('Returns 400 when an invalid file size is provided', async () => {
-			await agent
+			await request(app)
 				.post('/presignedPostRequests')
 				.type('application/json')
 				.set(authHeader)
@@ -76,7 +74,7 @@ describe('/presignedPostRequests', () => {
 		});
 
 		it('Returns 400 when file type is missing', async () => {
-			await agent
+			await request(app)
 				.post('/presignedPostRequests')
 				.type('application/json')
 				.set(authHeader)
@@ -87,7 +85,7 @@ describe('/presignedPostRequests', () => {
 		});
 
 		it('Returns 400 when file size is missing', async () => {
-			await agent
+			await request(app)
 				.post('/presignedPostRequests')
 				.type('application/json')
 				.set(authHeader)
@@ -102,7 +100,7 @@ describe('/presignedPostRequests', () => {
 				throw new Error('Failed to create the presigned post!');
 			});
 
-			await agent
+			await request(app)
 				.post('/presignedPostRequests')
 				.type('application/json')
 				.set(authHeader)

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -14,7 +14,6 @@ import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 
 const logger = getLogger(__filename);
-const agent = request.agent(app);
 
 const createTestBaseFields = async () => {
 	await createBaseField({
@@ -36,7 +35,7 @@ const createTestBaseFields = async () => {
 describe('/proposalVersions', () => {
 	describe('POST /', () => {
 		it('requires authentication', async () => {
-			await agent.post('/proposalVersions').expect(401);
+			await request(app).post('/proposalVersions').expect(401);
 		});
 
 		it('creates exactly one proposal version', async () => {
@@ -52,7 +51,7 @@ describe('/proposalVersions', () => {
 			});
 			const before = await loadTableMetrics('proposal_versions');
 			logger.debug('before: %o', before);
-			const result = await agent
+			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)
@@ -98,7 +97,7 @@ describe('/proposalVersions', () => {
 				label: 'Last Name',
 			});
 			const before = await loadTableMetrics('proposal_field_values');
-			const result = await agent
+			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)
@@ -150,7 +149,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('returns 400 bad request when no proposal id is provided', async () => {
-			await agent
+			await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)
@@ -162,7 +161,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('returns 400 bad request when no application id is provided', async () => {
-			await agent
+			await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)
@@ -174,7 +173,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('returns 400 bad request when no field values array is provided', async () => {
-			await agent
+			await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)
@@ -196,7 +195,7 @@ describe('/proposalVersions', () => {
 			await createApplicationForm({
 				opportunityId: 1,
 			});
-			const result = await agent
+			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)
@@ -231,7 +230,7 @@ describe('/proposalVersions', () => {
 			});
 			const before = await loadTableMetrics('proposal_field_values');
 			logger.debug('before: %o', before);
-			const result = await agent
+			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)
@@ -273,7 +272,7 @@ describe('/proposalVersions', () => {
 			});
 			const before = await loadTableMetrics('proposal_field_values');
 			logger.debug('before: %o', before);
-			const result = await agent
+			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)
@@ -313,7 +312,7 @@ describe('/proposalVersions', () => {
 			});
 			const before = await loadTableMetrics('proposal_field_values');
 			logger.debug('before: %o', before);
-			const result = await agent
+			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)
@@ -374,7 +373,7 @@ describe('/proposalVersions', () => {
 			});
 			const before = await loadTableMetrics('proposal_field_values');
 			logger.debug('before: %o', before);
-			const result = await agent
+			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
 				.set(authHeader)

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -23,8 +23,6 @@ import { PostgresErrorCode } from '../types/PostgresErrorCode';
 import { createApplicationForm } from '../database/operations/create/createApplicationForm';
 import { BaseFieldDataType, BaseFieldScope } from '../types';
 
-const agent = request.agent(app);
-
 const createTestBaseFields = async () => {
 	await createBaseField({
 		label: 'Summary',
@@ -45,11 +43,11 @@ const createTestBaseFields = async () => {
 describe('/proposals', () => {
 	describe('GET /', () => {
 		it('requires authentication', async () => {
-			await agent.get('/proposals').expect(401);
+			await request(app).get('/proposals').expect(401);
 		});
 
 		it('returns an empty Bundle when no data is present', async () => {
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals')
 				.set(authHeader)
 				.expect(200);
@@ -104,7 +102,7 @@ describe('/proposals', () => {
 				isValid: true,
 			});
 
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals')
 				.set(authHeader)
 				.expect(200);
@@ -193,7 +191,7 @@ describe('/proposals', () => {
 				organizationId: organization.id,
 				proposalId: proposal.id,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get(`/proposals?organization=${organization.id}`)
 				.set(authHeader)
 				.expect(200);
@@ -213,7 +211,7 @@ describe('/proposals', () => {
 		});
 
 		it('returns a 400 error if an invalid organization filter is provided', async () => {
-			const response = await agent
+			const response = await request(app)
 				.get(`/proposals?organization=foo`)
 				.set(authHeader)
 				.expect(400);
@@ -224,7 +222,7 @@ describe('/proposals', () => {
 		});
 
 		it('returns a 400 error if an invalid createdBy filter is provided', async () => {
-			const response = await agent
+			const response = await request(app)
 				.get(`/proposals?createdBy=foo`)
 				.set(authHeader)
 				.expect(400);
@@ -282,7 +280,7 @@ describe('/proposals', () => {
 				value: 'This is a pair of pants',
 				isValid: true,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals?_content=summary')
 				.set(authHeader)
 				.expect(200);
@@ -358,7 +356,7 @@ describe('/proposals', () => {
 				opportunityId: 1,
 				createdBy: anotherUser.id,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals')
 				.set(authHeaderWithAdminRole)
 				.expect(200);
@@ -405,7 +403,7 @@ describe('/proposals', () => {
 				opportunityId: 1,
 				createdBy: anotherUser.id,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get(`/proposals?createdBy=${testUser.id}`)
 				.set(authHeaderWithAdminRole)
 				.expect(200);
@@ -444,7 +442,7 @@ describe('/proposals', () => {
 				opportunityId: 1,
 				createdBy: anotherUser.id,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get(`/proposals?createdBy=me`)
 				.set(authHeaderWithAdminRole)
 				.expect(200);
@@ -513,7 +511,7 @@ describe('/proposals', () => {
 				value: 'This is a pair of pants',
 				isValid: true,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals?_content=summary')
 				.set(authHeader)
 				.expect(200);
@@ -583,7 +581,7 @@ describe('/proposals', () => {
 					createdBy: testUser.id,
 				});
 			}, Promise.resolve());
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals')
 				.query({
 					_page: 2,
@@ -641,11 +639,11 @@ describe('/proposals', () => {
 
 	describe('GET /:id', () => {
 		it('requires authentication', async () => {
-			await agent.get('/proposals/9001').expect(401);
+			await request(app).get('/proposals/9001').expect(401);
 		});
 
 		it('returns 404 when given id is not present', async () => {
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals/9001')
 				.set(authHeader)
 				.expect(404);
@@ -673,7 +671,7 @@ describe('/proposals', () => {
 				createdBy: anotherUser.id,
 			});
 
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals/1')
 				.set(authHeader)
 				.expect(404);
@@ -689,7 +687,7 @@ describe('/proposals', () => {
 		});
 
 		it('returns 400 when given id is a string', async () => {
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals/foobar')
 				.set(authHeader)
 				.expect(400);
@@ -717,7 +715,7 @@ describe('/proposals', () => {
 				createdBy: testUser.id,
 			});
 
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals/2')
 				.set(authHeader)
 				.expect(200);
@@ -793,7 +791,7 @@ describe('/proposals', () => {
 				value: 'Abstract for version 2 from 2525-01-04',
 				isValid: true,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals/1')
 				.set(authHeader)
 				.expect(200);
@@ -996,7 +994,7 @@ describe('/proposals', () => {
 				value: 'Abstract for version 2 from 2525-01-04',
 				isValid: true,
 			});
-			const response = await agent
+			const response = await request(app)
 				.get('/proposals/1')
 				.set(authHeaderWithAdminRole)
 				.expect(200);
@@ -1140,11 +1138,14 @@ describe('/proposals', () => {
 
 	describe('POST /', () => {
 		it('requires authentication', async () => {
-			await agent.post('/proposals').expect(401);
+			await request(app).post('/proposals').expect(401);
 		});
 
 		it('requires a user', async () => {
-			await agent.post('/proposals').set(authHeaderWithNoSubj).expect(401);
+			await request(app)
+				.post('/proposals')
+				.set(authHeaderWithNoSubj)
+				.expect(401);
 		});
 
 		it('creates exactly one proposal', async () => {
@@ -1153,7 +1154,7 @@ describe('/proposals', () => {
 			});
 			const before = await loadTableMetrics('proposals');
 			const testUser = await loadTestUser();
-			const result = await agent
+			const result = await request(app)
 				.post('/proposals')
 				.type('application/json')
 				.set(authHeader)
@@ -1175,7 +1176,7 @@ describe('/proposals', () => {
 		});
 
 		it('returns 400 bad request when no external ID is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/proposals')
 				.type('application/json')
 				.set(authHeader)
@@ -1190,7 +1191,7 @@ describe('/proposals', () => {
 		});
 
 		it('returns 400 bad request when no opportunity ID is sent', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/proposals')
 				.type('application/json')
 				.set(authHeader)
@@ -1205,7 +1206,7 @@ describe('/proposals', () => {
 		});
 
 		it('returns 422 conflict when a non-existent opportunity id is provided', async () => {
-			const result = await agent
+			const result = await request(app)
 				.post('/proposals')
 				.type('application/json')
 				.set(authHeader)

--- a/src/__tests__/users.int.test.ts
+++ b/src/__tests__/users.int.test.ts
@@ -7,12 +7,10 @@ import {
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
 } from '../test/mockJwt';
 
-const agent = request.agent(app);
-
 describe('/users', () => {
 	describe('GET /', () => {
 		it('requires authentication', async () => {
-			await agent.get('/users').expect(401);
+			await request(app).get('/users').expect(401);
 		});
 
 		it('returns the user associated with the requesting user', async () => {
@@ -22,7 +20,10 @@ describe('/users', () => {
 			});
 			const { count: userCount } = await loadTableMetrics('users');
 
-			const response = await agent.get('/users').set(authHeader).expect(200);
+			const response = await request(app)
+				.get('/users')
+				.set(authHeader)
+				.expect(200);
 			expect(response.body).toEqual({
 				total: userCount,
 				entries: [testUser],
@@ -37,7 +38,7 @@ describe('/users', () => {
 			});
 			const { count: userCount } = await loadTableMetrics('users');
 
-			const response = await agent
+			const response = await request(app)
 				.get('/users')
 				.set(authHeaderWithAdminRole)
 				.expect(200);
@@ -53,7 +54,7 @@ describe('/users', () => {
 			});
 			const { count: userCount } = await loadTableMetrics('users');
 
-			const response = await agent
+			const response = await request(app)
 				.get('/users?authenticationId=totallyDifferentUser@example.com')
 				.set(authHeaderWithAdminRole)
 				.expect(200);
@@ -73,7 +74,7 @@ describe('/users', () => {
 			}, Promise.resolve());
 			const { count: userCount } = await loadTableMetrics('users');
 
-			const response = await agent
+			const response = await request(app)
 				.get('/users')
 				.query({
 					_page: 2,


### PR DESCRIPTION
There is potential (mis)use of shared state across tests when using supertest agents. Without this change, it can be easy to set, for example, auth headers on the agent rather than the request and those headers unintentionally affect tests later in the same file. This change avoids re-use of state by simply avoiding the use of agent.

In future, there may be some situations that need to use shared state across tests. In that case, a supertest agent is a fine tool for the job. See the example at https://www.npmjs.com/package/supertest where `const agent` is used.

Fixes #1171