### PR TITLE
Add `sourceId` to `Users`

### DIFF
--- a/src/database/initialization/user_to_json.sql
+++ b/src/database/initialization/user_to_json.sql
@@ -1,10 +1,19 @@
 CREATE OR REPLACE FUNCTION user_to_json("user" users)
 RETURNS JSONB AS $$
+DECLARE
+  source_json JSONB := NULL::JSONB;
 BEGIN
-  RETURN jsonb_build_object(
+  SELECT source_to_json(sources.*)
+  INTO source_json
+  FROM sources
+  WHERE sources.id = "user".source_id;
+
+  RETURN jsonb_strip_nulls(jsonb_build_object(
     'id', "user".id,
     'authenticationId', "user".authentication_id,
+    'sourceId', "user".source_id,
+    'source', source_json,
     'createdAt', "user".created_at
-  );
+  ));
 END;
 $$ LANGUAGE plpgsql;

--- a/src/database/migrations/0034-alter-users-add-source_id.sql
+++ b/src/database/migrations/0034-alter-users-add-source_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users
+  ADD COLUMN source_id INTEGER,
+  ADD CONSTRAINT fk_source_id
+    FOREIGN KEY(source_id)
+      REFERENCES sources(id);

--- a/src/database/operations/create/createUser.ts
+++ b/src/database/operations/create/createUser.ts
@@ -2,9 +2,10 @@ import { db } from '../../db';
 import type { User, JsonResultSet, WritableUser } from '../../../types';
 
 export const createUser = async (createValues: WritableUser): Promise<User> => {
-	const { authenticationId } = createValues;
+	const { authenticationId, sourceId } = createValues;
 	const result = await db.sql<JsonResultSet<User>>('users.insertOne', {
 		authenticationId,
+		sourceId,
 	});
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {

--- a/src/database/queries/users/insertOne.sql
+++ b/src/database/queries/users/insertOne.sql
@@ -1,7 +1,9 @@
 INSERT INTO users (
-  authentication_id
+  authentication_id,
+  source_id
 )
 VALUES (
-  :authenticationId
+  :authenticationId,
+  :sourceId
 )
 RETURNING user_to_json(users) AS "object";

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -4,6 +4,7 @@ import type { Writable } from './Writable';
 interface User {
 	readonly id: number;
 	authenticationId: string;
+	sourceId?: number;
 	readonly createdAt: string;
 }
 
@@ -15,6 +16,10 @@ const userSchema: JSONSchemaType<User> = {
 		},
 		authenticationId: {
 			type: 'string',
+		},
+		sourceId: {
+			type: 'number',
+			nullable: true,
 		},
 		createdAt: {
 			type: 'string',


### PR DESCRIPTION
This PR updates the `users` table and type to support an optional association with a `source`.

Currently there is no way to actually set this value for a given user but this provides the necessary type definitions to support those endpoints.

This PR also includes an improvement to our `Writable` utility type in order to support optional values in a write (this is our first optional value in a type, fun fact!)

Related to #1154 