### PR TITLE
Add source id parameter to `POST /proposalVersions`

### DIFF
--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -668,6 +668,10 @@ describe('/proposals', () => {
 				details: [
 					{
 						name: 'NotFoundError',
+						details: {
+							entityId: '9001',
+							entityType: 'Proposal',
+						},
 					},
 				],
 			});
@@ -696,6 +700,10 @@ describe('/proposals', () => {
 				details: [
 					{
 						name: 'NotFoundError',
+						details: {
+							entityId: '1',
+							entityType: 'Proposal',
+						},
 					},
 				],
 			});

--- a/src/database/operations/assert/assertProposalAuthorization.ts
+++ b/src/database/operations/assert/assertProposalAuthorization.ts
@@ -20,6 +20,9 @@ export const assertProposalAuthorization = async (
 	});
 
 	if (result.rows[0]?.result !== true) {
-		throw new NotFoundError(`The proposal was not found (id: ${id})`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'Proposal',
+			entityId: id,
+		});
 	}
 };

--- a/src/database/operations/assert/assertSourceExists.ts
+++ b/src/database/operations/assert/assertSourceExists.ts
@@ -1,5 +1,5 @@
 import { db } from '../../db';
-import { InputConflictError } from '../../../errors';
+import { NotFoundError } from '../../../errors';
 import type { CheckResult } from '../../../types';
 
 export const assertSourceExists = async (sourceId: number): Promise<void> => {
@@ -8,7 +8,7 @@ export const assertSourceExists = async (sourceId: number): Promise<void> => {
 	});
 
 	if (result.rows[0]?.result !== true) {
-		throw new InputConflictError('The source was not found', {
+		throw new NotFoundError(`Entity not found`, {
 			entityType: 'Source',
 			entityId: sourceId,
 		});

--- a/src/database/operations/assert/assertSourceExists.ts
+++ b/src/database/operations/assert/assertSourceExists.ts
@@ -1,0 +1,16 @@
+import { db } from '../../db';
+import { InputConflictError } from '../../../errors';
+import type { CheckResult } from '../../../types';
+
+export const assertSourceExists = async (sourceId: number): Promise<void> => {
+	const result = await db.sql<CheckResult>('sources.checkExistsById', {
+		sourceId,
+	});
+
+	if (result.rows[0]?.result !== true) {
+		throw new InputConflictError('The source was not found', {
+			entityType: 'Source',
+			entityId: sourceId,
+		});
+	}
+};

--- a/src/database/operations/assert/index.ts
+++ b/src/database/operations/assert/index.ts
@@ -1,1 +1,2 @@
 export * from './assertProposalAuthorization';
+export * from './assertSourceExists';

--- a/src/database/operations/createOrUpdate/createOrUpdateBaseFieldLocalizations.ts
+++ b/src/database/operations/createOrUpdate/createOrUpdateBaseFieldLocalizations.ts
@@ -21,7 +21,13 @@ export const createOrUpdateBaseFieldLocalization = async (
 	);
 	const baseFieldLocalization = result.rows[0]?.object;
 	if (baseFieldLocalization === undefined) {
-		throw new NotFoundError('This base field localization does not exist.');
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'BaseFieldLocalization',
+			entityPrimaryKey: {
+				baseFieldId,
+				language,
+			},
+		});
 	}
 	return baseFieldLocalization;
 };

--- a/src/database/operations/load/loadApplicationForm.ts
+++ b/src/database/operations/load/loadApplicationForm.ts
@@ -13,7 +13,10 @@ export const loadApplicationForm = async (
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(`Application Form not found (id: ${id})`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'ApplicationForm',
+			entityId: id,
+		});
 	}
 	return object;
 };

--- a/src/database/operations/load/loadApplicationFormField.ts
+++ b/src/database/operations/load/loadApplicationFormField.ts
@@ -13,9 +13,10 @@ export const loadApplicationFormField = async (
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(
-			`The Application Form Field was not found (id: ${id})`,
-		);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'ApplicationFormField',
+			entityId: id,
+		});
 	}
 	return object;
 };

--- a/src/database/operations/load/loadBaseField.ts
+++ b/src/database/operations/load/loadBaseField.ts
@@ -11,7 +11,10 @@ export const loadBaseField = async (id: number): Promise<BaseField> => {
 	);
 	const baseField = result.rows[0]?.object;
 	if (baseField === undefined) {
-		throw new NotFoundError(`The base field was not found (id: ${id})`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'BaseField',
+			entityId: id,
+		});
 	}
 	return baseField;
 };

--- a/src/database/operations/load/loadBulkUpload.ts
+++ b/src/database/operations/load/loadBulkUpload.ts
@@ -11,7 +11,10 @@ export const loadBulkUpload = async (id: number): Promise<BulkUpload> => {
 	);
 	const { object } = bulkUploadsQueryResult.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(`The bulk upload was not found (id: ${id})`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'BulkUpload',
+			entityId: id,
+		});
 	}
 	return object;
 };

--- a/src/database/operations/load/loadDataProvider.ts
+++ b/src/database/operations/load/loadDataProvider.ts
@@ -13,7 +13,10 @@ const loadDataProvider = async (
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(`The item was not found (short cod: ${shortCode})`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'DataProvider',
+			entityShortCode: shortCode,
+		});
 	}
 	return object;
 };

--- a/src/database/operations/load/loadFunder.ts
+++ b/src/database/operations/load/loadFunder.ts
@@ -11,9 +11,10 @@ export const loadFunder = async (shortCode: ShortCode): Promise<Funder> => {
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(
-			`The funder was not found (short code: ${shortCode})`,
-		);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'Funder',
+			entityShortCode: shortCode,
+		});
 	}
 	return object;
 };

--- a/src/database/operations/load/loadOpportunity.ts
+++ b/src/database/operations/load/loadOpportunity.ts
@@ -11,7 +11,10 @@ const loadOpportunity = async (id: number): Promise<Opportunity> => {
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(`The opportunity was not found (id: ${id})`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'Opportunity',
+			entityId: id,
+		});
 	}
 	return object;
 };

--- a/src/database/operations/load/loadOrganization.ts
+++ b/src/database/operations/load/loadOrganization.ts
@@ -15,7 +15,10 @@ export const loadOrganization = async (
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(`The organization was not found (id: ${id})`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'Organization',
+			entityId: id,
+		});
 	}
 	return object;
 };

--- a/src/database/operations/load/loadOrganizationByTaxId.ts
+++ b/src/database/operations/load/loadOrganizationByTaxId.ts
@@ -13,9 +13,12 @@ export const loadOrganizationByTaxId = async (
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(
-			`The organization was not found (Tax ID: ${taxId})`,
-		);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'Organization',
+			lookupValues: {
+				taxId,
+			},
+		});
 	}
 	return object;
 };

--- a/src/database/operations/load/loadProposal.ts
+++ b/src/database/operations/load/loadProposal.ts
@@ -8,7 +8,10 @@ export const loadProposal = async (id: number): Promise<Proposal> => {
 	});
 	const proposal = result.rows[0]?.object;
 	if (proposal === undefined) {
-		throw new NotFoundError(`The proposal was not found (id: ${id})`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'Proposal',
+			entityId: id,
+		});
 	}
 	return proposal;
 };

--- a/src/database/operations/load/loadSource.ts
+++ b/src/database/operations/load/loadSource.ts
@@ -8,7 +8,10 @@ export const loadSource = async (id: number): Promise<Source> => {
 	});
 	const item = result.rows[0]?.object;
 	if (item === undefined) {
-		throw new NotFoundError(`The item was not found (id: ${id})`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'Source',
+			entityId: id,
+		});
 	}
 	return item;
 };

--- a/src/database/operations/load/loadSystemDataProvider.ts
+++ b/src/database/operations/load/loadSystemDataProvider.ts
@@ -9,7 +9,10 @@ const loadSystemDataProvider = async (): Promise<DataProvider> => {
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(`The system data provider was not found`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'DataProvider',
+			lookupValues: { specialQuery: 'selectSystemDataProvider' },
+		});
 	}
 	return object;
 };

--- a/src/database/operations/load/loadSystemSource.ts
+++ b/src/database/operations/load/loadSystemSource.ts
@@ -9,7 +9,12 @@ const loadSystemSource = async (): Promise<Source> => {
 	);
 	const item = result.rows[0]?.object;
 	if (item === undefined) {
-		throw new NotFoundError(`The system source was not found.`);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'Source',
+			lookupValues: {
+				specialQuery: 'selectSystemSource',
+			},
+		});
 	}
 	return item;
 };

--- a/src/database/operations/load/loadUserByAuthenticationId.ts
+++ b/src/database/operations/load/loadUserByAuthenticationId.ts
@@ -13,9 +13,10 @@ export const loadUserByAuthenticationId = async (
 	);
 	const { object } = userQueryResult.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError(
-			`The entity was not found (authenticationId: ${authenticationId})`,
-		);
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'User',
+			lookupValues: { authenticationId },
+		});
 	}
 	return object;
 };

--- a/src/database/operations/update/updateBaseField.ts
+++ b/src/database/operations/update/updateBaseField.ts
@@ -24,7 +24,10 @@ export const updateBaseField = async (
 	);
 	const baseField = result.rows[0]?.object;
 	if (baseField === undefined) {
-		throw new NotFoundError('This base field does not exist.');
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'BaseField',
+			entityId: id,
+		});
 	}
 	return baseField;
 };

--- a/src/database/operations/update/updateBulkUpload.ts
+++ b/src/database/operations/update/updateBulkUpload.ts
@@ -28,7 +28,10 @@ export const updateBulkUpload = async (
 	);
 	const { object } = result.rows[0] ?? {};
 	if (object === undefined) {
-		throw new NotFoundError('This bulk upload does not exist.');
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'BulkUpload',
+			entityId: id,
+		});
 	}
 	return object;
 };

--- a/src/database/queries/sources/checkExistsById.sql
+++ b/src/database/queries/sources/checkExistsById.sql
@@ -1,0 +1,5 @@
+SELECT EXISTS (
+  SELECT 1
+    FROM sources
+    WHERE id = :sourceId
+) AS result

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,6 +1,35 @@
+interface NotFoundErrorDetailsWithShortCode {
+	entityType: string;
+	entityShortCode: string;
+}
+
+interface NotFoundErrorDetailsWithId {
+	entityType: string;
+	entityId: number;
+}
+
+interface NotFoundErrorDetailsWithComplexPrimaryKey {
+	entityType: string;
+	entityPrimaryKey: Record<string, number | string>;
+}
+
+interface NotFoundErrorDetailsWithLookupValues {
+	entityType: string;
+	lookupValues: Record<string, number | string>;
+}
+
+type NotFoundErrorDetails =
+	| NotFoundErrorDetailsWithShortCode
+	| NotFoundErrorDetailsWithId
+	| NotFoundErrorDetailsWithComplexPrimaryKey
+	| NotFoundErrorDetailsWithLookupValues;
+
 export class NotFoundError extends Error {
-	public constructor(message: string) {
+	public details: NotFoundErrorDetails;
+
+	public constructor(message: string, details: NotFoundErrorDetails) {
 		super(message);
 		this.name = this.constructor.name;
+		this.details = details;
 	}
 }

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -1,4 +1,4 @@
-import { DatabaseError, InputValidationError, NotFoundError } from '../errors';
+import { DatabaseError, InputValidationError } from '../errors';
 import {
 	createBaseField,
 	loadBaseFields,
@@ -17,16 +17,7 @@ import {
 import type { Request, Response, NextFunction } from 'express';
 
 const assertBaseFieldExists = async (baseFieldId: number): Promise<void> => {
-	try {
-		await loadBaseField(baseFieldId);
-	} catch (err) {
-		if (err instanceof NotFoundError) {
-			throw new NotFoundError(
-				`The specified Base Field does not exist (${baseFieldId}).`,
-			);
-		}
-		throw err;
-	}
+	await loadBaseField(baseFieldId);
 };
 
 const getBaseFields = (

--- a/src/types/ProposalVersion.ts
+++ b/src/types/ProposalVersion.ts
@@ -11,7 +11,7 @@ import type { Source } from './Source';
 interface ProposalVersion {
 	readonly id: number;
 	proposalId: number;
-	readonly sourceId: number;
+	sourceId: number;
 	readonly source: Source;
 	readonly version: number;
 	applicationFormId: number;
@@ -35,6 +35,9 @@ const writableProposalVersionWithFieldValuesSchema: JSONSchemaType<WritablePropo
 			proposalId: {
 				type: 'integer',
 			},
+			sourceId: {
+				type: 'integer',
+			},
 			applicationFormId: {
 				type: 'integer',
 			},
@@ -43,7 +46,7 @@ const writableProposalVersionWithFieldValuesSchema: JSONSchemaType<WritablePropo
 				items: writableProposalFieldValueWithProposalVersionContextSchema,
 			},
 		},
-		required: ['proposalId', 'applicationFormId', 'fieldValues'],
+		required: ['proposalId', 'sourceId', 'applicationFormId', 'fieldValues'],
 	};
 
 const isWritableProposalVersionWithFieldValues = ajv.compile(


### PR DESCRIPTION
This PR improves the `POST /proposalVersions` endpoint to accept a sourceId.

It also makes an improvement to the `NotFoundError` to add structured data to the error type.