### PR TITLE
Add `sourceId` to `BulkUpload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgraded to use OpenAPI Specification 3.1.
 
+## 0.12.3 2024-09-19
+
+### Added
+
+- New `Funder` entity type with corresponding `PUT` and `GET` endpoints.
+- New `DataProvider` entity type with corresponding `PUT` and `GET` endpoints.
+- New `Source` entity type with corresponding `PUT` and `GET` endpoints.
+- `sourceId` is now an attribute of `BulkUpload`.
+- `sourceId` is now an attribute of `ProposalVersion`.
+
 ## 0.11.0 2024-05-20
 
 ### Added

--- a/src/__tests__/bulkUploads.int.test.ts
+++ b/src/__tests__/bulkUploads.int.test.ts
@@ -3,6 +3,7 @@ import { app } from '../app';
 import {
 	createBulkUpload,
 	createUser,
+	loadSystemSource,
 	loadSystemUser,
 	loadTableMetrics,
 } from '../database';
@@ -36,29 +37,34 @@ describe('/bulkUploads', () => {
 
 		it('returns bulk uploads associated with the requesting user', async () => {
 			const systemUser = await loadSystemUser();
+			const systemSource = await loadSystemSource();
 			const testUser = await loadTestUser();
 			const thirdUser = await createUser({
 				authenticationId: 'totallyDifferentUser@example.com',
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: BulkUploadStatus.PENDING,
 				createdBy: testUser.id,
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: BulkUploadStatus.COMPLETED,
 				createdBy: testUser.id,
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'baz.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-baz',
 				status: BulkUploadStatus.COMPLETED,
 				createdBy: systemUser.id,
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'boop.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-boop',
 				status: BulkUploadStatus.COMPLETED,
@@ -75,6 +81,8 @@ describe('/bulkUploads', () => {
 						entries: [
 							{
 								id: 2,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'bar.csv',
 								fileSize: null,
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -84,6 +92,8 @@ describe('/bulkUploads', () => {
 							},
 							{
 								id: 1,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'foo.csv',
 								fileSize: null,
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
@@ -97,17 +107,20 @@ describe('/bulkUploads', () => {
 		});
 
 		it('returns all bulk uploads for administrative users', async () => {
+			const systemSource = await loadSystemSource();
 			const testUser = await loadTestUser();
 			const anotherUser = await createUser({
 				authenticationId: 'totallyDifferentUser@example.com',
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: BulkUploadStatus.PENDING,
 				createdBy: testUser.id,
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: BulkUploadStatus.COMPLETED,
@@ -124,6 +137,8 @@ describe('/bulkUploads', () => {
 						entries: [
 							{
 								id: 2,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'bar.csv',
 								fileSize: null,
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -133,6 +148,8 @@ describe('/bulkUploads', () => {
 							},
 							{
 								id: 1,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'foo.csv',
 								fileSize: null,
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
@@ -146,17 +163,20 @@ describe('/bulkUploads', () => {
 		});
 
 		it('returns uploads for specified createdBy user', async () => {
+			const systemSource = await loadSystemSource();
 			const testUser = await loadTestUser();
 			const anotherUser = await createUser({
 				authenticationId: 'totallyDifferentUser@example.com',
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: BulkUploadStatus.PENDING,
 				createdBy: testUser.id,
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: BulkUploadStatus.COMPLETED,
@@ -173,6 +193,8 @@ describe('/bulkUploads', () => {
 						entries: [
 							{
 								id: 2,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'bar.csv',
 								fileSize: null,
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -186,17 +208,20 @@ describe('/bulkUploads', () => {
 		});
 
 		it('returns uploads for the admin user when createdBy is set to me as an admin', async () => {
+			const systemSource = await loadSystemSource();
 			const testUser = await loadTestUser();
 			const anotherUser = await createUser({
 				authenticationId: 'totallyDifferentUser@example.com',
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: BulkUploadStatus.PENDING,
 				createdBy: testUser.id,
 			});
 			await createBulkUpload({
+				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: BulkUploadStatus.COMPLETED,
@@ -213,6 +238,8 @@ describe('/bulkUploads', () => {
 						entries: [
 							{
 								id: 1,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'foo.csv',
 								fileSize: null,
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
@@ -226,10 +253,12 @@ describe('/bulkUploads', () => {
 		});
 
 		it('supports pagination', async () => {
+			const systemSource = await loadSystemSource();
 			const testUser = await loadTestUser();
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
 				await createBulkUpload({
+					sourceId: systemSource.id,
 					fileName: `bar-${i + 1}.csv`,
 					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 					status: BulkUploadStatus.COMPLETED,
@@ -251,6 +280,8 @@ describe('/bulkUploads', () => {
 						entries: [
 							{
 								id: 15,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'bar-15.csv',
 								fileSize: null,
 								sourceKey:
@@ -261,6 +292,8 @@ describe('/bulkUploads', () => {
 							},
 							{
 								id: 14,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'bar-14.csv',
 								fileSize: null,
 								sourceKey:
@@ -271,6 +304,8 @@ describe('/bulkUploads', () => {
 							},
 							{
 								id: 13,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'bar-13.csv',
 								fileSize: null,
 								sourceKey:
@@ -281,6 +316,8 @@ describe('/bulkUploads', () => {
 							},
 							{
 								id: 12,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'bar-12.csv',
 								fileSize: null,
 								sourceKey:
@@ -291,6 +328,8 @@ describe('/bulkUploads', () => {
 							},
 							{
 								id: 11,
+								sourceId: systemSource.id,
+								source: systemSource,
 								fileName: 'bar-11.csv',
 								fileSize: null,
 								sourceKey:
@@ -318,12 +357,14 @@ describe('/bulkUploads', () => {
 		});
 
 		it('creates exactly one bulk upload', async () => {
+			const systemSource = await loadSystemSource();
 			const before = await loadTableMetrics('bulk_uploads');
 			const result = await request(app)
 				.post('/bulkUploads')
 				.type('application/json')
 				.set(authHeader)
 				.send({
+					sourceId: systemSource.id,
 					fileName: 'foo.csv',
 					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				})
@@ -334,6 +375,8 @@ describe('/bulkUploads', () => {
 			expect(before.count).toEqual(0);
 			expect(result.body).toEqual({
 				id: expect.any(Number) as number,
+				sourceId: systemSource.id,
+				source: systemSource,
 				fileName: 'foo.csv',
 				fileSize: null,
 				sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -345,11 +388,13 @@ describe('/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when no file name is provided', async () => {
+			const systemSource = await loadSystemSource();
 			const result = await request(app)
 				.post('/bulkUploads')
 				.type('application/json')
 				.set(authHeader)
 				.send({
+					sourceId: systemSource.id,
 					sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				})
 				.expect(400);
@@ -360,11 +405,13 @@ describe('/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when an invalid file name is provided', async () => {
+			const systemSource = await loadSystemSource();
 			const result = await request(app)
 				.post('/bulkUploads')
 				.type('application/json')
 				.set(authHeader)
 				.send({
+					sourceId: systemSource.id,
 					fileName: 'foo.png',
 					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				})

--- a/src/__tests__/bulkUploads.int.test.ts
+++ b/src/__tests__/bulkUploads.int.test.ts
@@ -366,7 +366,7 @@ describe('/bulkUploads', () => {
 				.set(authHeader)
 				.send({
 					fileName: 'foo.png',
-					sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				})
 				.expect(400);
 			expect(result.body).toMatchObject({

--- a/src/database/initialization/bulk_upload_to_json.sql
+++ b/src/database/initialization/bulk_upload_to_json.sql
@@ -1,8 +1,17 @@
 CREATE OR REPLACE FUNCTION bulk_upload_to_json(bulk_upload bulk_uploads)
 RETURNS JSONB AS $$
+DECLARE
+  source_json JSONB;
 BEGIN
+  SELECT source_to_json(sources.*)
+  INTO source_json
+  FROM sources
+  WHERE sources.id = bulk_upload.source_id;
+
   RETURN jsonb_build_object(
     'id', bulk_upload.id,
+    'sourceId', bulk_upload.source_id,
+    'source', source_json,
     'fileName', bulk_upload.file_name,
     'sourceKey', bulk_upload.source_key,
     'status', bulk_upload.status,

--- a/src/database/migrations/0034-alter-bulk_uploads-add-source_id.sql
+++ b/src/database/migrations/0034-alter-bulk_uploads-add-source_id.sql
@@ -1,0 +1,12 @@
+ALTER TABLE bulk_uploads
+  ADD COLUMN source_id INTEGER NOT NULL DEFAULT system_source_id(),
+  ADD CONSTRAINT fk_source_id
+    FOREIGN KEY(source_id)
+      REFERENCES sources(id);
+
+ALTER TABLE bulk_uploads
+  ALTER COLUMN source_id DROP DEFAULT;
+
+
+COMMENT ON COLUMN bulk_uploads.source_id IS
+  'The PDC source that the contents of the bulk upload came from.';

--- a/src/database/operations/bulkUploads/createBulkUpload.ts
+++ b/src/database/operations/bulkUploads/createBulkUpload.ts
@@ -8,11 +8,12 @@ import type {
 export const createBulkUpload = async (
 	createValues: InternallyWritableBulkUpload,
 ): Promise<BulkUpload> => {
-	const { fileName, sourceKey, status, createdBy } = createValues;
+	const { sourceId, fileName, sourceKey, status, createdBy } = createValues;
 
 	const result = await db.sql<JsonResultSet<BulkUpload>>(
 		'bulkUploads.insertOne',
 		{
+			sourceId,
 			fileName,
 			sourceKey,
 			status,

--- a/src/database/operations/proposalVersions/createProposalVersion.ts
+++ b/src/database/operations/proposalVersions/createProposalVersion.ts
@@ -2,11 +2,11 @@ import { db as defaultDb } from '../../db';
 import type {
 	JsonResultSet,
 	ProposalVersion,
-	InternallyWritableProposalVersion,
+	WritableProposalVersion,
 } from '../../../types';
 
 const createProposalVersion = async (
-	createValues: InternallyWritableProposalVersion,
+	createValues: WritableProposalVersion,
 	db = defaultDb,
 ): Promise<ProposalVersion> => {
 	const { proposalId, applicationFormId, sourceId } = createValues;

--- a/src/database/queries/bulkUploads/insertOne.sql
+++ b/src/database/queries/bulkUploads/insertOne.sql
@@ -1,10 +1,12 @@
 INSERT INTO bulk_uploads (
+  source_id,
   file_name,
   source_key,
   status,
   created_by
 )
 VALUES (
+  :sourceId,
   :fileName,
   :sourceKey,
   :status,

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for organizations seeking grants.",
-		"version": "0.12.2",
+		"version": "0.12.3",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"
@@ -116,6 +116,13 @@
 						"readOnly": true,
 						"example": 3407
 					},
+					"sourceId": {
+						"type": "integer"
+					},
+					"source": {
+						"$ref": "#/components/schemas/Source",
+						"readOnly": true
+					},
 					"fileName": {
 						"type": "string",
 						"example": "upload.csv",
@@ -158,6 +165,7 @@
 				},
 				"required": [
 					"id",
+					"sourceId",
 					"fileName",
 					"sourceKey",
 					"status",

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -376,8 +376,7 @@
 						"example": 3709
 					},
 					"sourceId": {
-						"type": "integer",
-						"readOnly": true
+						"type": "integer"
 					},
 					"source": {
 						"$ref": "#/components/schemas/Source",
@@ -407,6 +406,7 @@
 				"required": [
 					"id",
 					"proposalId",
+					"sourceId",
 					"applicationFormId",
 					"version",
 					"fieldValues",

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -52,8 +52,10 @@ const createTestBulkUpload = async (
 	overrideValues?: Partial<InternallyWritableBulkUpload>,
 ): Promise<BulkUpload> => {
 	const systemUser = await loadSystemUser();
+	const systemSource = await loadSystemSource();
 	const defaultValues = {
 		fileName: 'bar.csv',
+		sourceId: systemSource.id,
 		sourceKey: TEST_UNPROCESSED_SOURCE_KEY,
 		status: BulkUploadStatus.PENDING,
 		createdBy: systemUser.id,

--- a/src/tasks/processBulkUpload.ts
+++ b/src/tasks/processBulkUpload.ts
@@ -20,7 +20,6 @@ import {
 	loadBaseFields,
 	loadBulkUpload,
 	loadOrganizationByTaxId,
-	loadSystemSource,
 	updateBulkUpload,
 } from '../database/operations';
 import { BulkUploadStatus, isProcessBulkUploadJobPayload } from '../types';
@@ -269,9 +268,6 @@ export const processBulkUpload = async (
 			opportunityId: opportunity.id,
 		});
 
-		// TODO: Once accounts are associated with sources we should replace this system source with a real source.
-		// See Issue https://github.com/PhilanthropyDataCommons/service/issues/1146
-		const source = await loadSystemSource();
 		const applicationFormFields =
 			await createApplicationFormFieldsForBulkUpload(
 				bulkUploadFile.path,
@@ -293,7 +289,7 @@ export const processBulkUpload = async (
 			const proposalVersion = await createProposalVersion({
 				proposalId: proposal.id,
 				applicationFormId: applicationForm.id,
-				sourceId: source.id,
+				sourceId: bulkUpload.sourceId,
 			});
 
 			const organizationName = record[organizationNameIndex];

--- a/src/types/BulkUpload.ts
+++ b/src/types/BulkUpload.ts
@@ -1,6 +1,7 @@
 import { ajv } from '../ajv';
 import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
+import type { Source } from './Source';
 
 enum BulkUploadStatus {
 	PENDING = 'pending',
@@ -12,6 +13,8 @@ enum BulkUploadStatus {
 
 interface BulkUpload {
 	readonly id: number;
+	sourceId: number;
+	readonly source: Source;
 	fileName: string;
 	sourceKey: string;
 	readonly status: BulkUploadStatus;
@@ -28,6 +31,9 @@ type InternallyWritableBulkUpload = WritableBulkUpload &
 const writableBulkUploadSchema: JSONSchemaType<WritableBulkUpload> = {
 	type: 'object',
 	properties: {
+		sourceId: {
+			type: 'integer',
+		},
 		fileName: {
 			type: 'string',
 			pattern: '^.+\\.csv$',
@@ -37,7 +43,7 @@ const writableBulkUploadSchema: JSONSchemaType<WritableBulkUpload> = {
 			minLength: 1,
 		},
 	},
-	required: ['fileName', 'sourceKey'],
+	required: ['sourceId', 'fileName', 'sourceKey'],
 };
 
 const isWritableBulkUpload = ajv.compile(writableBulkUploadSchema);

--- a/src/types/ProposalVersion.ts
+++ b/src/types/ProposalVersion.ts
@@ -21,9 +21,6 @@ interface ProposalVersion {
 
 type WritableProposalVersion = Writable<ProposalVersion>;
 
-type InternallyWritableProposalVersion = WritableProposalVersion &
-	Pick<ProposalVersion, 'sourceId'>;
-
 type WritableProposalVersionWithFieldValues = WritableProposalVersion & {
 	fieldValues: WritableProposalFieldValueWithProposalVersionContext[];
 };
@@ -54,7 +51,7 @@ const isWritableProposalVersionWithFieldValues = ajv.compile(
 );
 
 export {
-	InternallyWritableProposalVersion,
+	WritableProposalVersion,
 	ProposalVersion,
 	WritableProposalVersionWithFieldValues,
 	isWritableProposalVersionWithFieldValues,


### PR DESCRIPTION
This PR adds the `sourceId` attribute to the `BulkUpload` type and requires it as a parameter when creating a bulk upload.

It also includes a few little fixes of issues I saw when implementing the feature.

Resolves #1192 