### PR TITLE
Avoid union type

### DIFF
--- a/src/queryParameters/extractCreatedByParameters.ts
+++ b/src/queryParameters/extractCreatedByParameters.ts
@@ -14,24 +14,30 @@ interface CreatedByParameters {
 
 const createdByQueryParametersSchema: JSONSchemaType<CreatedByQueryParameters> =
 	{
-		type: 'object',
-		properties: {
-			createdBy: {
-				type: ['integer', 'string'],
-				oneOf: [
-					{
+		anyOf: [
+			{
+				type: 'object',
+				properties: {
+					createdBy: {
 						type: 'integer',
 						minimum: 1,
 						nullable: true,
 					},
-					{
-						enum: ['me'],
-					},
-				],
-				nullable: true,
+				},
+				required: [],
 			},
-		},
-		required: [],
+			{
+				type: 'object',
+				properties: {
+					createdBy: {
+						type: 'string',
+						enum: ['me'],
+						nullable: true,
+					},
+				},
+				required: [],
+			},
+		],
 	};
 
 const isCreatedByQueryParameters = ajv.compile(createdByQueryParametersSchema);


### PR DESCRIPTION
This PR changes one of our schema definitions to avoid a union type (which is not recommended for various reasons, and was generating a warning).

Resolves #1188 