### PR TITLE
Add `createdBy` to `ProposalVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgraded to use OpenAPI Specification 3.1.
 
+## 0.12.4 2024-09-19
+
+### Added
+
+- `createdBy` is now an attribute of `ProposalVersion`.
+
 ## 0.12.3 2024-09-19
 
 ### Added

--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -11,6 +11,7 @@ import {
 	createProposalFieldValue,
 	createProposalVersion,
 	loadSystemSource,
+	loadSystemUser,
 	loadTableMetrics,
 } from '../database';
 import { expectTimestamp, loadTestUser } from '../test/utils';
@@ -260,6 +261,7 @@ describe('/organizations', () => {
 
 		it('returns the latest valid value for a base field when auth id is sent', async () => {
 			const systemSource = await loadSystemSource();
+			const systemUser = await loadSystemUser();
 
 			// Make a base field associated with one opportunity/org, and we'll make three responses.
 			const baseFieldId = (
@@ -289,7 +291,7 @@ describe('/organizations', () => {
 				await createProposal({
 					opportunityId,
 					externalId: 'Proposal',
-					createdBy: 1,
+					createdBy: systemUser.id,
 				})
 			).id;
 			await createOrganizationProposal({
@@ -309,6 +311,7 @@ describe('/organizations', () => {
 						proposalId,
 						applicationFormId: applicationFormIdEarliest,
 						sourceId: systemSource.id,
+						createdBy: systemUser.id,
 					})
 				).id,
 				applicationFormFieldId: (
@@ -334,6 +337,7 @@ describe('/organizations', () => {
 						proposalId,
 						applicationFormId: applicationFormIdLatestValid,
 						sourceId: systemSource.id,
+						createdBy: systemUser.id,
 					})
 				).id,
 				applicationFormFieldId: (
@@ -360,6 +364,7 @@ describe('/organizations', () => {
 						proposalId,
 						applicationFormId: applicationFormIdLatest,
 						sourceId: systemSource.id,
+						createdBy: systemUser.id,
 					})
 				).id,
 				applicationFormFieldId: (

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -90,6 +90,7 @@ describe('/proposals', () => {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
+				createdBy: testUser.id,
 			});
 			await createApplicationFormField({
 				applicationFormId: 1,
@@ -135,6 +136,7 @@ describe('/proposals', () => {
 								source: systemSource,
 								applicationFormId: 1,
 								createdAt: expectTimestamp,
+								createdBy: testUser.id,
 								fieldValues: [
 									{
 										id: 1,
@@ -262,11 +264,13 @@ describe('/proposals', () => {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
+				createdBy: testUser.id,
 			});
 			await createProposalVersion({
 				proposalId: 2,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
+				createdBy: testUser.id,
 			});
 			await createApplicationFormField({
 				applicationFormId: 1,
@@ -310,6 +314,7 @@ describe('/proposals', () => {
 								version: 1,
 								applicationFormId: 1,
 								createdAt: expectTimestamp,
+								createdBy: testUser.id,
 								fieldValues: [
 									{
 										id: 1,
@@ -498,11 +503,13 @@ describe('/proposals', () => {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
+				createdBy: testUser.id,
 			});
 			await createProposalVersion({
 				proposalId: 2,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
+				createdBy: testUser.id,
 			});
 			await createApplicationFormField({
 				applicationFormId: 1,
@@ -546,6 +553,7 @@ describe('/proposals', () => {
 								version: 1,
 								applicationFormId: 1,
 								createdAt: expectTimestamp,
+								createdBy: testUser.id,
 								fieldValues: [
 									{
 										id: 1,
@@ -783,11 +791,13 @@ describe('/proposals', () => {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
+				createdBy: testUser.id,
 			});
 			await createProposalVersion({
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
+				createdBy: testUser.id,
 			});
 			await createProposalFieldValue({
 				proposalVersionId: 1,
@@ -836,6 +846,7 @@ describe('/proposals', () => {
 						applicationFormId: 1,
 						version: 2,
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 						fieldValues: [
 							{
 								id: 3,
@@ -901,6 +912,7 @@ describe('/proposals', () => {
 						applicationFormId: 1,
 						version: 1,
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 						fieldValues: [
 							{
 								id: 1,
@@ -993,11 +1005,13 @@ describe('/proposals', () => {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
+				createdBy: testUser.id,
 			});
 			await createProposalVersion({
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
+				createdBy: testUser.id,
 			});
 			await createProposalFieldValue({
 				proposalVersionId: 1,
@@ -1046,6 +1060,7 @@ describe('/proposals', () => {
 						applicationFormId: 1,
 						version: 2,
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 						fieldValues: [
 							{
 								id: 3,
@@ -1111,6 +1126,7 @@ describe('/proposals', () => {
 						applicationFormId: 1,
 						version: 1,
 						createdAt: expectTimestamp,
+						createdBy: testUser.id,
 						fieldValues: [
 							{
 								id: 1,

--- a/src/database/initialization/proposal_version_to_json.sql
+++ b/src/database/initialization/proposal_version_to_json.sql
@@ -25,7 +25,8 @@ BEGIN
     'applicationFormId', proposal_version.application_form_id,
     'version', proposal_version.version,
     'fieldValues', COALESCE(proposal_field_values_json, '[]'::JSONB),
-    'createdAt', proposal_version.created_at
+    'createdAt', proposal_version.created_at,
+    'createdBy', proposal_version.created_by
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/src/database/migrations/0035-alter-proposal_versions-add-created_by.sql
+++ b/src/database/migrations/0035-alter-proposal_versions-add-created_by.sql
@@ -1,0 +1,8 @@
+ALTER TABLE proposal_versions
+  ADD COLUMN created_by INTEGER NOT NULL DEFAULT select_system_user_id(),
+  ADD CONSTRAINT fk_createdBy
+    FOREIGN KEY (created_by)
+      REFERENCES users(id);
+
+ALTER TABLE proposal_versions
+  ALTER COLUMN created_by DROP DEFAULT;

--- a/src/database/operations/proposalVersions/createProposalVersion.ts
+++ b/src/database/operations/proposalVersions/createProposalVersion.ts
@@ -2,20 +2,21 @@ import { db as defaultDb } from '../../db';
 import type {
 	JsonResultSet,
 	ProposalVersion,
-	WritableProposalVersion,
+	InternallyWritableProposalVersion,
 } from '../../../types';
 
 const createProposalVersion = async (
-	createValues: WritableProposalVersion,
+	createValues: InternallyWritableProposalVersion,
 	db = defaultDb,
 ): Promise<ProposalVersion> => {
-	const { proposalId, applicationFormId, sourceId } = createValues;
+	const { proposalId, applicationFormId, sourceId, createdBy } = createValues;
 	const result = await db.sql<JsonResultSet<ProposalVersion>>(
 		'proposalVersions.insertOne',
 		{
 			proposalId,
 			applicationFormId,
 			sourceId,
+			createdBy,
 		},
 	);
 	const { object } = result.rows[0] ?? {};

--- a/src/database/queries/proposalVersions/insertOne.sql
+++ b/src/database/queries/proposalVersions/insertOne.sql
@@ -2,11 +2,13 @@ INSERT INTO proposal_versions (
   proposal_id,
   application_form_id,
   source_id,
+  created_by,
   version
 ) VALUES (
   :proposalId,
   :applicationFormId,
   :sourceId,
+  :createdBy,
   COALESCE(
     (
       SELECT MAX(pv.version) + 1

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for organizations seeking grants.",
-		"version": "0.12.3",
+		"version": "0.12.4",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"
@@ -408,6 +408,11 @@
 					"createdAt": {
 						"type": "string",
 						"format": "date-time",
+						"readOnly": true
+					},
+					"createdBy": {
+						"description": "The id of the PDC user that created this bulk upload",
+						"type": "integer",
 						"readOnly": true
 					}
 				},

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -333,8 +333,12 @@ describe('processBulkUpload', () => {
 	it('should download, process, and resolve the bulk upload if the sourceKey is accessible and contains a valid CSV bulk upload', async () => {
 		await createTestBaseFields();
 		const systemSource = await loadSystemSource();
+		const systemUser = await loadSystemUser();
 		const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
-		const bulkUpload = await createTestBulkUpload({ sourceKey });
+		const bulkUpload = await createTestBulkUpload({
+			sourceKey,
+			createdBy: systemUser.id,
+		});
 		const requests = await mockS3ResponsesForBulkUploadProcessing(
 			bulkUpload,
 			`${__dirname}/fixtures/processBulkUpload/validCsvTemplate.csv`,
@@ -383,6 +387,7 @@ describe('processBulkUpload', () => {
 						{
 							applicationFormId: 1,
 							createdAt: expectTimestamp,
+							createdBy: systemUser.id,
 							fieldValues: [
 								{
 									applicationFormField: {
@@ -458,6 +463,7 @@ describe('processBulkUpload', () => {
 						{
 							applicationFormId: 1,
 							createdAt: expectTimestamp,
+							createdBy: systemUser.id,
 							fieldValues: [
 								{
 									applicationFormField: {

--- a/src/tasks/processBulkUpload.ts
+++ b/src/tasks/processBulkUpload.ts
@@ -290,6 +290,7 @@ export const processBulkUpload = async (
 				proposalId: proposal.id,
 				applicationFormId: applicationForm.id,
 				sourceId: bulkUpload.sourceId,
+				createdBy: bulkUpload.createdBy,
 			});
 
 			const organizationName = record[organizationNameIndex];

--- a/src/types/ProposalVersion.ts
+++ b/src/types/ProposalVersion.ts
@@ -17,9 +17,13 @@ interface ProposalVersion {
 	applicationFormId: number;
 	readonly fieldValues: ProposalFieldValue[];
 	readonly createdAt: string;
+	readonly createdBy: number;
 }
 
 type WritableProposalVersion = Writable<ProposalVersion>;
+
+type InternallyWritableProposalVersion = WritableProposalVersion &
+	Pick<ProposalVersion, 'createdBy'>;
 
 type WritableProposalVersionWithFieldValues = WritableProposalVersion & {
 	fieldValues: WritableProposalFieldValueWithProposalVersionContext[];
@@ -51,7 +55,7 @@ const isWritableProposalVersionWithFieldValues = ajv.compile(
 );
 
 export {
-	WritableProposalVersion,
+	InternallyWritableProposalVersion,
 	ProposalVersion,
 	WritableProposalVersionWithFieldValues,
 	isWritableProposalVersionWithFieldValues,


### PR DESCRIPTION
This PR adds a new `createdBy` attribute for `ProposalVersion`.  This doesn't affect required fields from end users since this is populated basted on auth context, but will add to the returned object.

Resolves #1200
