### PR TITLE
Normalize bundle operation parameters

### DIFF
--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -3,12 +3,12 @@ import { app } from '../app';
 import {
 	createBaseField,
 	createOrUpdateBaseFieldLocalization,
-	loadBaseFieldLocalizationsBundle,
+	loadBaseFieldLocalizationsBundleByBaseFieldId,
 	loadBaseFields,
 	loadTableMetrics,
 } from '../database';
 import { BaseFieldDataType, BaseFieldScope, PostgresErrorCode } from '../types';
-import { expectTimestamp } from '../test/utils';
+import { expectTimestamp, NO_LIMIT, NO_OFFSET } from '../test/utils';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as adminUserAuthHeader,
@@ -575,7 +575,7 @@ describe('/baseFields', () => {
 		});
 
 		it('creates the specified base field localization if it does not exist', async () => {
-			await createTestBaseField();
+			const testBaseField = await createTestBaseField();
 			const before = await loadTableMetrics('base_field_localizations');
 			await request(app)
 				.put('/baseFields/1/localizations/fr')
@@ -587,9 +587,12 @@ describe('/baseFields', () => {
 				})
 				.expect(200);
 			const after = await loadTableMetrics('base_field_localizations');
-			const baseFieldLocalizations = await loadBaseFieldLocalizationsBundle({
-				baseFieldId: 1,
-			});
+			const baseFieldLocalizations =
+				await loadBaseFieldLocalizationsBundleByBaseFieldId(
+					testBaseField.id,
+					NO_LIMIT,
+					NO_OFFSET,
+				);
 			expect(before.count).toEqual(0);
 			expect(baseFieldLocalizations.entries[0]).toMatchObject({
 				baseFieldId: 1,
@@ -601,7 +604,7 @@ describe('/baseFields', () => {
 		});
 
 		it('updates only the specified base field if it does exist', async () => {
-			await createTestBaseField();
+			const testBaseField = await createTestBaseField();
 			await createOrUpdateBaseFieldLocalization({
 				baseFieldId: 1,
 				language: 'fr',
@@ -625,9 +628,12 @@ describe('/baseFields', () => {
 				})
 				.expect(200);
 			const after = await loadTableMetrics('base_field_localizations');
-			const baseFieldLocalizations = await loadBaseFieldLocalizationsBundle({
-				baseFieldId: 1,
-			});
+			const baseFieldLocalizations =
+				await loadBaseFieldLocalizationsBundleByBaseFieldId(
+					testBaseField.id,
+					NO_LIMIT,
+					NO_OFFSET,
+				);
 			expect(before.count).toEqual(2);
 			expect(baseFieldLocalizations.entries[0]).toMatchObject({
 				baseFieldId: 1,

--- a/src/database/operations/applicationFormFields/loadApplicationFormFieldBundle.ts
+++ b/src/database/operations/applicationFormFields/loadApplicationFormFieldBundle.ts
@@ -5,21 +5,17 @@ import type {
 	JsonResultSet,
 } from '../../../types';
 
-export const loadApplicationFormFieldBundle = async (queryParameters: {
-	offset?: number;
-	limit?: number;
-	applicationFormId?: number;
-}): Promise<Bundle<ApplicationFormField>> => {
-	const defaultQueryParameters = {
-		applicationFormId: 0,
-		offset: 0,
-		limit: 0,
-	};
+export const loadApplicationFormFieldBundle = async (
+	applicationFormId: number | undefined,
+	limit: number | undefined,
+	offset: number,
+): Promise<Bundle<ApplicationFormField>> => {
 	const bundle = await loadBundle<JsonResultSet<ApplicationFormField>>(
 		'applicationFormFields.selectWithPagination',
 		{
-			...defaultQueryParameters,
-			...queryParameters,
+			applicationFormId,
+			limit,
+			offset,
 		},
 		'application_form_fields',
 	);

--- a/src/database/operations/applicationForms/loadApplicationFormBundle.ts
+++ b/src/database/operations/applicationForms/loadApplicationFormBundle.ts
@@ -2,20 +2,14 @@ import { loadBundle } from '../generic/loadBundle';
 import type { JsonResultSet, Bundle, ApplicationForm } from '../../../types';
 
 export const loadApplicationFormBundle = async (
-	queryParameters: {
-		offset?: number;
-		limit?: number;
-	} = {},
+	limit: number | undefined,
+	offset: number,
 ): Promise<Bundle<ApplicationForm>> => {
-	const defaultQueryParameters = {
-		offset: 0,
-		limit: 0,
-	};
 	const bundle = await loadBundle<JsonResultSet<ApplicationForm>>(
 		'applicationForms.selectWithPagination',
 		{
-			...defaultQueryParameters,
-			...queryParameters,
+			limit,
+			offset,
 		},
 		'application_forms',
 	);

--- a/src/database/operations/baseFieldLocalization/index.ts
+++ b/src/database/operations/baseFieldLocalization/index.ts
@@ -1,2 +1,2 @@
 export * from './createOrUpdateBaseFieldLocalizations';
-export * from './loadBaseFieldLocalizationsBundle';
+export * from './loadBaseFieldLocalizationsBundleByBaseFieldId';

--- a/src/database/operations/baseFieldLocalization/loadBaseFieldLocalizationsBundleByBaseFieldId.ts
+++ b/src/database/operations/baseFieldLocalization/loadBaseFieldLocalizationsBundleByBaseFieldId.ts
@@ -5,21 +5,17 @@ import type {
 	BaseFieldLocalization,
 } from '../../../types';
 
-export const loadBaseFieldLocalizationsBundle = async (queryParameters: {
-	offset?: number;
-	limit?: number;
-	baseFieldId?: number;
-}): Promise<Bundle<BaseFieldLocalization>> => {
-	const defaultQueryParameters = {
-		baseFieldId: 0,
-		offset: 0,
-		limit: 0,
-	};
+const loadBaseFieldLocalizationsBundleByBaseFieldId = async (
+	baseFieldId: number,
+	limit: number | undefined,
+	offset: number,
+): Promise<Bundle<BaseFieldLocalization>> => {
 	const bundle = await loadBundle<JsonResultSet<BaseFieldLocalization>>(
 		'baseFieldLocalizations.selectWithPagination',
 		{
-			...defaultQueryParameters,
-			...queryParameters,
+			baseFieldId,
+			limit,
+			offset,
 		},
 		'base_field_localizations',
 	);
@@ -30,3 +26,5 @@ export const loadBaseFieldLocalizationsBundle = async (queryParameters: {
 		entries,
 	};
 };
+
+export { loadBaseFieldLocalizationsBundleByBaseFieldId };

--- a/src/database/operations/bulkUploads/loadBulkUploadBundle.ts
+++ b/src/database/operations/bulkUploads/loadBulkUploadBundle.ts
@@ -7,31 +7,22 @@ import type {
 } from '../../../types';
 
 export const loadBulkUploadBundle = async (
-	queryParameters: {
-		offset: number;
-		limit: number;
-		createdBy?: number;
-	},
-	authContext?: AuthContext,
+	authContext: AuthContext | undefined,
+	createdBy: number | undefined,
+	limit: number | undefined,
+	offset: number,
 ): Promise<Bundle<BulkUpload>> => {
-	const defaultQueryParameters = {
-		createdBy: 0,
-		userId: 0,
-		isAdministrator: false,
-	};
-	const { offset, limit, createdBy } = queryParameters;
 	const userId = authContext?.user.id;
 	const isAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<BulkUpload>>(
 		'bulkUploads.selectWithPagination',
 		{
-			...defaultQueryParameters,
-			offset,
-			limit,
 			createdBy,
-			userId,
 			isAdministrator,
+			limit,
+			offset,
+			userId,
 		},
 		'bulk_uploads',
 	);

--- a/src/database/operations/dataProviders/loadDataProviderBundle.ts
+++ b/src/database/operations/dataProviders/loadDataProviderBundle.ts
@@ -2,19 +2,14 @@ import { loadBundle } from '../generic/loadBundle';
 import type { Bundle, DataProvider, JsonResultSet } from '../../../types';
 
 const loadDataProviderBundle = async (
+	limit: number | undefined,
 	offset: number,
-	limit: number,
 ): Promise<Bundle<DataProvider>> => {
-	const defaultQueryParameters = {
-		offset: 0,
-		limit: 0,
-	};
 	const bundle = await loadBundle<JsonResultSet<DataProvider>>(
 		'dataProviders.selectWithPagination',
 		{
-			...defaultQueryParameters,
-			offset,
 			limit,
+			offset,
 		},
 		'data_providers',
 	);

--- a/src/database/operations/funders/loadFunderBundle.ts
+++ b/src/database/operations/funders/loadFunderBundle.ts
@@ -2,14 +2,14 @@ import { loadBundle } from '../generic/loadBundle';
 import type { Bundle, JsonResultSet, Funder } from '../../../types';
 
 const loadFunderBundle = async (
+	limit: number | undefined,
 	offset: number,
-	limit: number,
 ): Promise<Bundle<Funder>> => {
 	const bundle = await loadBundle<JsonResultSet<Funder>>(
 		'funders.selectWithPagination',
 		{
-			offset,
 			limit,
+			offset,
 		},
 		'funders',
 	);

--- a/src/database/operations/opportunities/loadOpportunityBundle.ts
+++ b/src/database/operations/opportunities/loadOpportunityBundle.ts
@@ -2,23 +2,14 @@ import { loadBundle } from '../generic/loadBundle';
 import type { Bundle, JsonResultSet, Opportunity } from '../../../types';
 
 const loadOpportunityBundle = async (
-	queryParameters: {
-		offset?: number;
-		limit?: number;
-	} = {},
+	limit: number | undefined,
+	offset: number,
 ): Promise<Bundle<Opportunity>> => {
-	const defaultQueryParameters = {
-		offset: 0,
-		limit: 0,
-	};
-	const { offset, limit } = queryParameters;
-
 	const bundle = await loadBundle<JsonResultSet<Opportunity>>(
 		'opportunities.selectWithPagination',
 		{
-			...defaultQueryParameters,
-			offset,
 			limit,
+			offset,
 		},
 		'opportunities',
 	);

--- a/src/database/operations/organizations/loadOrganization.ts
+++ b/src/database/operations/organizations/loadOrganization.ts
@@ -1,11 +1,17 @@
 import { db } from '../../db';
 import { NotFoundError } from '../../../errors';
-import type { Id, JsonResultSet, Organization } from '../../../types';
+import type {
+	AuthContext,
+	Id,
+	JsonResultSet,
+	Organization,
+} from '../../../types';
 
 export const loadOrganization = async (
+	authContext: AuthContext | undefined,
 	id: Id,
-	authenticationId?: string,
 ): Promise<Organization> => {
+	const authenticationId = authContext?.user?.authenticationId;
 	const result = await db.sql<JsonResultSet<Organization>>(
 		'organizations.selectById',
 		{

--- a/src/database/operations/organizations/loadOrganizationBundle.ts
+++ b/src/database/operations/organizations/loadOrganizationBundle.ts
@@ -1,23 +1,25 @@
 import { loadBundle } from '../generic/loadBundle';
-import type { Bundle, JsonResultSet, Organization } from '../../../types';
+import type {
+	AuthContext,
+	Bundle,
+	JsonResultSet,
+	Organization,
+} from '../../../types';
 
 export const loadOrganizationBundle = async (
-	queryParameters: {
-		offset: number;
-		limit: number;
-		proposalId?: number;
-	},
-	authenticationId?: string,
+	authContext: AuthContext | undefined,
+	proposalId: number | undefined,
+	limit: number | undefined,
+	offset: number,
 ): Promise<Bundle<Organization>> => {
-	const defaultQueryParameters = {
-		proposalId: 0,
-	};
+	const authenticationId = authContext?.user?.authenticationId;
 	const jsonResultSetBundle = await loadBundle<JsonResultSet<Organization>>(
 		'organizations.selectWithPagination',
 		{
-			...defaultQueryParameters,
-			...queryParameters,
 			authenticationId,
+			limit,
+			offset,
+			proposalId,
 		},
 		'organizations',
 	);

--- a/src/database/operations/organizationsProposals/loadOrganizationProposalBundle.ts
+++ b/src/database/operations/organizationsProposals/loadOrganizationProposalBundle.ts
@@ -5,17 +5,12 @@ import type {
 	OrganizationProposal,
 } from '../../../types';
 
-interface LoadOrganizationProposalBundleParameters {
-	organizationId?: number;
-	proposalId?: number;
-	offset: number;
-	limit: number;
-}
-
 export const loadOrganizationProposalBundle = async (
-	queryParameters: LoadOrganizationProposalBundleParameters,
+	organizationId: number | undefined,
+	proposalId: number | undefined,
+	limit: number | undefined,
+	offset: number,
 ): Promise<Bundle<OrganizationProposal>> => {
-	const { organizationId, proposalId, offset, limit } = queryParameters;
 	const bundle = await loadBundle<JsonResultSet<OrganizationProposal>>(
 		'organizationsProposals.selectWithPagination',
 		{

--- a/src/database/operations/proposals/loadProposalBundle.ts
+++ b/src/database/operations/proposals/loadProposalBundle.ts
@@ -7,37 +7,26 @@ import type {
 } from '../../../types';
 
 export const loadProposalBundle = async (
-	queryParameters: {
-		offset: number;
-		limit: number;
-		search?: string;
-		organizationId?: number;
-		createdBy?: number;
-	},
-	authContext?: AuthContext,
+	authContext: AuthContext | undefined,
+	createdBy: number | undefined,
+	organizationId: number | undefined,
+	search: string | undefined,
+	limit: number | undefined,
+	offset: number,
 ): Promise<Bundle<Proposal>> => {
-	const defaultQueryParameters = {
-		search: '',
-		organizationId: 0,
-		createdBy: 0,
-		userId: 0,
-		isAdministrator: false,
-	};
-	const { offset, limit, search, organizationId, createdBy } = queryParameters;
 	const userId = authContext?.user.id;
 	const isAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<Proposal>>(
 		'proposals.selectWithPagination',
 		{
-			...defaultQueryParameters,
-			offset,
-			limit,
-			search,
-			organizationId,
 			createdBy,
-			userId,
 			isAdministrator,
+			limit,
+			offset,
+			organizationId,
+			search,
+			userId,
 		},
 		'proposals',
 	);

--- a/src/database/operations/sources/loadSourceBundle.ts
+++ b/src/database/operations/sources/loadSourceBundle.ts
@@ -2,14 +2,14 @@ import { loadBundle } from '../generic/loadBundle';
 import type { Bundle, JsonResultSet, Source } from '../../../types';
 
 const loadSourceBundle = async (
+	limit: number | undefined,
 	offset: number,
-	limit: number,
 ): Promise<Bundle<Source>> => {
 	const bundle = await loadBundle<JsonResultSet<Source>>(
 		'sources.selectWithPagination',
 		{
-			offset,
 			limit,
+			offset,
 		},
 		'sources',
 	);

--- a/src/database/operations/users/loadUserBundle.ts
+++ b/src/database/operations/users/loadUserBundle.ts
@@ -2,31 +2,22 @@ import { loadBundle } from '../generic/loadBundle';
 import type { JsonResultSet, Bundle, User, AuthContext } from '../../../types';
 
 export const loadUserBundle = async (
-	queryParameters: {
-		offset: number;
-		limit: number;
-		authenticationId?: string;
-	},
-	authContext?: AuthContext,
+	authContext: AuthContext | undefined,
+	authenticationId: string | undefined,
+	limit: number | undefined,
+	offset: number,
 ): Promise<Bundle<User>> => {
-	const defaultQueryParameters = {
-		authenticationId: '',
-		userId: 0,
-		isAdministrator: false,
-	};
-	const { offset, limit, authenticationId } = queryParameters;
 	const userId = authContext?.user.id;
 	const isAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<User>>(
 		'users.selectWithPagination',
 		{
-			...defaultQueryParameters,
-			offset,
-			limit,
 			authenticationId,
-			userId,
 			isAdministrator,
+			limit,
+			offset,
+			userId,
 		},
 		'users',
 	);

--- a/src/database/parameters/getLimitValues.ts
+++ b/src/database/parameters/getLimitValues.ts
@@ -3,7 +3,7 @@ import { InternalValidationError } from '../../errors';
 import type { PaginationParameters } from '../../types';
 
 interface LimitValues {
-	limit: number;
+	limit: number | undefined;
 	offset: number;
 }
 

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -1,6 +1,7 @@
 import {
 	createApplicationForm,
 	createApplicationFormField,
+	getLimitValues,
 	loadApplicationForm,
 	loadApplicationFormBundle,
 } from '../database';
@@ -10,6 +11,7 @@ import {
 	isId,
 } from '../types';
 import { DatabaseError, InputValidationError } from '../errors';
+import { extractPaginationParameters } from '../queryParameters';
 import type { Request, Response, NextFunction } from 'express';
 
 const getApplicationForms = (
@@ -17,7 +19,9 @@ const getApplicationForms = (
 	res: Response,
 	next: NextFunction,
 ): void => {
-	loadApplicationFormBundle()
+	const paginationParameters = extractPaginationParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	loadApplicationFormBundle(limit, offset)
 		.then((applicationForms) => {
 			res.status(200).contentType('application/json').send(applicationForms);
 		})

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -4,9 +4,11 @@ import {
 	loadBaseFields,
 	updateBaseField,
 	createOrUpdateBaseFieldLocalization,
-	loadBaseFieldLocalizationsBundle,
+	loadBaseFieldLocalizationsBundleByBaseFieldId,
 	loadBaseField,
+	getLimitValues,
 } from '../database';
+import { extractPaginationParameters } from '../queryParameters';
 import {
 	isTinyPgErrorWithQueryContext,
 	isValidLanguageTag,
@@ -110,9 +112,11 @@ const getBaseFieldLocalizationsByBaseFieldId = (
 		next(new InputValidationError('Invalid id parameter.', isId.errors ?? []));
 		return;
 	}
+	const paginationParameters = extractPaginationParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
 	assertBaseFieldExists(baseFieldId)
 		.then(() => {
-			loadBaseFieldLocalizationsBundle({ baseFieldId })
+			loadBaseFieldLocalizationsBundleByBaseFieldId(baseFieldId, limit, offset)
 				.then((baseFieldLocalizations) => {
 					res
 						.status(200)

--- a/src/handlers/bulkUploadsHandlers.ts
+++ b/src/handlers/bulkUploadsHandlers.ts
@@ -99,14 +99,14 @@ const getBulkUploads = (
 		return;
 	}
 	const paginationParameters = extractPaginationParameters(req);
-	const createdByParameters = extractCreatedByParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	const { createdBy } = extractCreatedByParameters(req);
 	(async () => {
 		const bulkUploadBundle = await loadBulkUploadBundle(
-			{
-				...getLimitValues(paginationParameters),
-				...createdByParameters,
-			},
 			req,
+			createdBy,
+			limit,
+			offset,
 		);
 
 		res.status(200).contentType('application/json').send(bulkUploadBundle);

--- a/src/handlers/dataProvidersHandlers.ts
+++ b/src/handlers/dataProvidersHandlers.ts
@@ -31,7 +31,7 @@ const getDataProviders = (
 	const paginationParameters = extractPaginationParameters(req);
 	(async () => {
 		const { offset, limit } = getLimitValues(paginationParameters);
-		const bundle = await loadDataProviderBundle(offset, limit);
+		const bundle = await loadDataProviderBundle(limit, offset);
 
 		res.status(200).contentType('application/json').send(bundle);
 	})().catch((error: unknown) => {

--- a/src/handlers/fundersHandlers.ts
+++ b/src/handlers/fundersHandlers.ts
@@ -31,7 +31,7 @@ const getFunders = (
 	const paginationParameters = extractPaginationParameters(req);
 	(async () => {
 		const { offset, limit } = getLimitValues(paginationParameters);
-		const funderBundle = await loadFunderBundle(offset, limit);
+		const funderBundle = await loadFunderBundle(limit, offset);
 
 		res.status(200).contentType('application/json').send(funderBundle);
 	})().catch((error: unknown) => {

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -19,9 +19,8 @@ const getOpportunities = (
 	next: NextFunction,
 ): void => {
 	const paginationParameters = extractPaginationParameters(req);
-	loadOpportunityBundle({
-		...getLimitValues(paginationParameters),
-	})
+	const { offset, limit } = getLimitValues(paginationParameters);
+	loadOpportunityBundle(limit, offset)
 		.then((opportunityBundle) => {
 			res.status(200).contentType('application/json').send(opportunityBundle);
 		})

--- a/src/handlers/organizationProposalsHandlers.ts
+++ b/src/handlers/organizationProposalsHandlers.ts
@@ -21,15 +21,17 @@ const getOrganizationProposals = (
 	next: NextFunction,
 ): void => {
 	const paginationParameters = extractPaginationParameters(req);
-	const organizationParameters = extractOrganizationParameters(req);
-	const proposalParameters = extractProposalParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	const { organizationId } = extractOrganizationParameters(req);
+	const { proposalId } = extractProposalParameters(req);
 
 	(async () => {
-		const organizationProposalBundle = await loadOrganizationProposalBundle({
-			...getLimitValues(paginationParameters),
-			...organizationParameters,
-			...proposalParameters,
-		});
+		const organizationProposalBundle = await loadOrganizationProposalBundle(
+			organizationId,
+			proposalId,
+			limit,
+			offset,
+		);
 		res
 			.status(200)
 			.contentType('application/json')

--- a/src/handlers/organizationsHandlers.ts
+++ b/src/handlers/organizationsHandlers.ts
@@ -77,8 +77,8 @@ const getOrganization = (
 		next(new InputValidationError('Invalid request body.', isId.errors ?? []));
 		return;
 	}
-	const authenticationId = req.user?.authenticationId;
-	loadOrganization(organizationId, authenticationId)
+	const authContext = isAuthContext(req) ? req : undefined;
+	loadOrganization(authContext, organizationId)
 		.then((organization) => {
 			res.status(200).contentType('application/json').send(organization);
 		})

--- a/src/handlers/organizationsHandlers.ts
+++ b/src/handlers/organizationsHandlers.ts
@@ -9,6 +9,7 @@ import {
 	isWritableOrganization,
 	isTinyPgErrorWithQueryContext,
 	AuthenticatedRequest,
+	isAuthContext,
 } from '../types';
 import { DatabaseError, InputValidationError } from '../errors';
 import {
@@ -50,15 +51,10 @@ const getOrganizations = (
 	next: NextFunction,
 ): void => {
 	const paginationParameters = extractPaginationParameters(req);
-	const proposalParameters = extractProposalParameters(req);
-	const authenticationId = req.user?.authenticationId;
-	loadOrganizationBundle(
-		{
-			...getLimitValues(paginationParameters),
-			...proposalParameters,
-		},
-		authenticationId,
-	)
+	const { limit, offset } = getLimitValues(paginationParameters);
+	const { proposalId } = extractProposalParameters(req);
+	const authContext = isAuthContext(req) ? req : undefined;
+	loadOrganizationBundle(authContext, proposalId, limit, offset)
 		.then((organizationBundle) => {
 			res.status(200).contentType('application/json').send(organizationBundle);
 		})

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -35,19 +35,19 @@ const getProposals = (
 		return;
 	}
 	const paginationParameters = extractPaginationParameters(req);
-	const searchParameters = extractSearchParameters(req);
-	const organizationParameters = extractOrganizationParameters(req);
-	const createdByParameters = extractCreatedByParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	const { search } = extractSearchParameters(req);
+	const { organizationId } = extractOrganizationParameters(req);
+	const { createdBy } = extractCreatedByParameters(req);
 
 	(async () => {
 		const proposalBundle = await loadProposalBundle(
-			{
-				...getLimitValues(paginationParameters),
-				...searchParameters,
-				...organizationParameters,
-				...createdByParameters,
-			},
 			req,
+			createdBy,
+			organizationId,
+			search,
+			limit,
+			offset,
 		);
 
 		res.status(200).contentType('application/json').send(proposalBundle);

--- a/src/handlers/sourcesHandlers.ts
+++ b/src/handlers/sourcesHandlers.ts
@@ -66,7 +66,7 @@ const getSources = (
 	const paginationParameters = extractPaginationParameters(req);
 	(async () => {
 		const { offset, limit } = getLimitValues(paginationParameters);
-		const bundle = await loadSourceBundle(offset, limit);
+		const bundle = await loadSourceBundle(limit, offset);
 
 		res.status(200).contentType('application/json').send(bundle);
 	})().catch((error: unknown) => {

--- a/src/handlers/usersHandlers.ts
+++ b/src/handlers/usersHandlers.ts
@@ -8,7 +8,6 @@ import { DatabaseError, FailedMiddlewareError } from '../errors';
 import {
 	extractAuthenticationIdParameters,
 	extractPaginationParameters,
-	extractSearchParameters,
 } from '../queryParameters';
 import type { Response, NextFunction } from 'express';
 
@@ -22,17 +21,15 @@ const getUsers = (
 		return;
 	}
 	const paginationParameters = extractPaginationParameters(req);
-	const searchParameters = extractSearchParameters(req);
-	const authenticationIdParameters = extractAuthenticationIdParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	const { authenticationId } = extractAuthenticationIdParameters(req);
 
 	(async () => {
 		const userBundle = await loadUserBundle(
-			{
-				...getLimitValues(paginationParameters),
-				...searchParameters,
-				...authenticationIdParameters,
-			},
 			req,
+			authenticationId,
+			limit,
+			offset,
 		);
 
 		res.status(200).contentType('application/json').send(userBundle);

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -21,7 +21,7 @@ import {
 	BulkUploadStatus,
 	Proposal,
 } from '../../types';
-import { expectTimestamp } from '../../test/utils';
+import { expectTimestamp, NO_LIMIT, NO_OFFSET } from '../../test/utils';
 import type {
 	BulkUpload,
 	InternallyWritableBulkUpload,
@@ -354,14 +354,14 @@ describe('processBulkUpload', () => {
 
 		const {
 			entries: [opportunity],
-		} = await loadOpportunityBundle();
+		} = await loadOpportunityBundle(NO_LIMIT, NO_OFFSET);
 		if (opportunity === undefined) {
 			throw new Error('The opportunity was not created');
 		}
 
 		const {
 			entries: [applicationForm],
-		} = await loadApplicationFormBundle();
+		} = await loadApplicationFormBundle(NO_LIMIT, NO_OFFSET);
 		if (applicationForm === undefined) {
 			fail('The application form was not created');
 		}
@@ -371,10 +371,14 @@ describe('processBulkUpload', () => {
 			createdAt: expectTimestamp,
 		});
 
-		const proposalBundle = await loadProposalBundle({
-			limit: 100,
-			offset: 0,
-		});
+		const proposalBundle = await loadProposalBundle(
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
 		expect(proposalBundle).toEqual({
 			entries: [
 				{
@@ -533,19 +537,23 @@ describe('processBulkUpload', () => {
 			total: 2,
 		});
 
-		const organizationBundle = await loadOrganizationBundle({
-			limit: 100,
-			offset: 0,
-		});
+		const organizationBundle = await loadOrganizationBundle(
+			undefined,
+			undefined,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
 		expect(organizationBundle).toEqual({
 			entries: [],
 			total: 0,
 		});
 
-		const organizationProposalBundle = await loadOrganizationProposalBundle({
-			limit: 100,
-			offset: 0,
-		});
+		const organizationProposalBundle = await loadOrganizationProposalBundle(
+			undefined,
+			undefined,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
 		expect(organizationProposalBundle).toEqual({
 			entries: [],
 			total: 0,
@@ -573,15 +581,19 @@ describe('processBulkUpload', () => {
 			getMockJobHelpers(),
 		);
 
-		const organizationBundle = await loadOrganizationBundle({
-			limit: 100,
-			offset: 0,
-		});
+		const organizationBundle = await loadOrganizationBundle(
+			undefined,
+			undefined,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
 
-		const organizationProposalBundle = await loadOrganizationProposalBundle({
-			limit: 100,
-			offset: 0,
-		});
+		const organizationProposalBundle = await loadOrganizationProposalBundle(
+			undefined,
+			undefined,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
 
 		expect(organizationBundle).toEqual({
 			entries: [

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -30,3 +30,7 @@ export const createTestUser = async () =>
 
 export const loadTestUser = async () =>
 	loadUserByAuthenticationId(getTestUserAuthenticationId());
+
+export const NO_OFFSET = 0;
+
+export const NO_LIMIT = undefined;


### PR DESCRIPTION
This PR improves (and normalizes) bundle operation parameters.  Specifically it adds `offset` and `limit` as required parameters, and it also moves all optional parameters into an `options` object.

This should not result in any functional changes.

Resolves #1186