### PR TITLE
Add universal `drop_function` sql utility

### DIFF
--- a/src/database/initialization/application_form_field_to_json.sql
+++ b/src/database/initialization/application_form_field_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION application_form_field_to_json(application_form_field application_form_fields)
+SELECT drop_function('application_form_field_to_json');
+
+CREATE FUNCTION application_form_field_to_json(application_form_field application_form_fields)
 RETURNS JSONB AS $$
 DECLARE
   base_field_json JSONB;

--- a/src/database/initialization/application_form_to_json.sql
+++ b/src/database/initialization/application_form_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION application_form_to_json(application_form application_forms)
+SELECT drop_function('application_form_to_json');
+
+CREATE FUNCTION application_form_to_json(application_form application_forms)
 RETURNS JSONB AS $$
 DECLARE
   application_form_fields_json JSONB;

--- a/src/database/initialization/base_field_localization_to_json.sql
+++ b/src/database/initialization/base_field_localization_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION base_field_localization_to_json(base_field_localization base_field_localizations)
+SELECT drop_function('base_field_localization_to_json');
+
+CREATE FUNCTION base_field_localization_to_json(base_field_localization base_field_localizations)
 RETURNS JSONB AS $$
 BEGIN
   RETURN jsonb_build_object(

--- a/src/database/initialization/base_field_to_json.sql
+++ b/src/database/initialization/base_field_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION base_field_to_json(base_field base_fields)
+SELECT drop_function('base_field_to_json');
+
+CREATE FUNCTION base_field_to_json(base_field base_fields)
 RETURNS JSONB AS $$
 DECLARE
   localizations JSONB;

--- a/src/database/initialization/bulk_upload_to_json.sql
+++ b/src/database/initialization/bulk_upload_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION bulk_upload_to_json(bulk_upload bulk_uploads)
+SELECT drop_function('bulk_upload_to_json');
+
+CREATE FUNCTION bulk_upload_to_json(bulk_upload bulk_uploads)
 RETURNS JSONB AS $$
 DECLARE
   source_json JSONB;

--- a/src/database/initialization/data_provider_to_json.sql
+++ b/src/database/initialization/data_provider_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION data_provider_to_json(data_provider data_providers)
+SELECT drop_function('data_provider_to_json');
+
+CREATE FUNCTION data_provider_to_json(data_provider data_providers)
 RETURNS JSONB AS $$
 BEGIN
   RETURN jsonb_build_object(

--- a/src/database/initialization/funder_to_json.sql
+++ b/src/database/initialization/funder_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION funder_to_json(funder funders)
+SELECT drop_function('funder_to_json');
+
+CREATE FUNCTION funder_to_json(funder funders)
 RETURNS JSONB AS $$
 BEGIN
   RETURN jsonb_build_object(

--- a/src/database/initialization/opportunity_to_json.sql
+++ b/src/database/initialization/opportunity_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION opportunity_to_json(opportunity opportunities)
+SELECT drop_function('opportunity_to_json');
+
+CREATE FUNCTION opportunity_to_json(opportunity opportunities)
 RETURNS JSONB AS $$
 BEGIN
   RETURN jsonb_build_object(

--- a/src/database/initialization/organization_proposal_to_json.sql
+++ b/src/database/initialization/organization_proposal_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION organization_proposal_to_json(organization_proposal organizations_proposals)
+SELECT drop_function('organization_proposal_to_json');
+
+CREATE FUNCTION organization_proposal_to_json(organization_proposal organizations_proposals)
 RETURNS JSONB AS $$
 DECLARE
   proposal_json JSONB;

--- a/src/database/initialization/organization_to_json.sql
+++ b/src/database/initialization/organization_to_json.sql
@@ -1,6 +1,6 @@
--- An explicit DROP is needed to remove the old function instead of overloading it.
-DROP FUNCTION IF EXISTS organization_to_json(organizations);
-CREATE OR REPLACE FUNCTION organization_to_json(organization organizations, authenticationId VARCHAR DEFAULT NULL)
+SELECT drop_function('organization_to_json');
+
+CREATE FUNCTION organization_to_json(organization organizations, authenticationId VARCHAR DEFAULT NULL)
 RETURNS JSONB AS $$
 DECLARE
   proposal_field_values_json JSONB;

--- a/src/database/initialization/proposal_field_value_to_json.sql
+++ b/src/database/initialization/proposal_field_value_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION proposal_field_value_to_json(proposal_field_value proposal_field_values)
+SELECT drop_function('proposal_field_value_to_json');
+
+CREATE FUNCTION proposal_field_value_to_json(proposal_field_value proposal_field_values)
 RETURNS JSONB AS $$
 DECLARE
   application_form_field_json JSONB;

--- a/src/database/initialization/proposal_to_json.sql
+++ b/src/database/initialization/proposal_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION proposal_to_json(proposal proposals)
+SELECT drop_function('proposal_to_json');
+
+CREATE FUNCTION proposal_to_json(proposal proposals)
 RETURNS JSONB AS $$
 DECLARE
   proposal_versions_json JSONB;

--- a/src/database/initialization/proposal_version_to_json.sql
+++ b/src/database/initialization/proposal_version_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION proposal_version_to_json(proposal_version proposal_versions)
+SELECT drop_function('proposal_version_to_json');
+
+CREATE FUNCTION proposal_version_to_json(proposal_version proposal_versions)
 RETURNS JSONB AS $$
 DECLARE
   proposal_field_values_json JSONB;

--- a/src/database/initialization/source_to_json.sql
+++ b/src/database/initialization/source_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION source_to_json(source sources)
+SELECT drop_function('source_to_json');
+
+CREATE FUNCTION source_to_json(source sources)
 RETURNS JSONB AS $$
 DECLARE
   data_provider_json JSONB := NULL::JSONB;

--- a/src/database/initialization/user_to_json.sql
+++ b/src/database/initialization/user_to_json.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION user_to_json("user" users)
+SELECT drop_function('user_to_json');
+
+CREATE FUNCTION user_to_json("user" users)
 RETURNS JSONB AS $$
 BEGIN
   RETURN jsonb_build_object(

--- a/src/database/migrations/0036-create-function-drop_function.sql
+++ b/src/database/migrations/0036-create-function-drop_function.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE FUNCTION drop_function(function_name TEXT)
+RETURNS VOID AS $$
+DECLARE
+    r RECORD;
+    function_signature TEXT;
+BEGIN
+    FOR r IN
+        SELECT p.oid,
+               p.proname,
+               pg_catalog.pg_get_function_identity_arguments(p.oid) AS args
+        FROM pg_proc p
+        JOIN pg_namespace n ON p.pronamespace = n.oid
+        WHERE p.proname = function_name
+        AND n.nspname = current_schema()
+    LOOP
+        function_signature := r.proname || '(' || r.args || ')';
+        EXECUTE 'DROP FUNCTION IF EXISTS ' || function_signature;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
This PR creates and uses a sql helper function that will drop all versions of a given custom defined function in the database regardless of the function signature.

To test this out, try creating a named function that has a different signature as one of the initialized functions:

e.g. 
```
CREATE OR REPLACE FUNCTION application_form_to_json(application_form application_forms, foo VARCHAR DEFAULT NULL)
RETURNS VARCHAR AS $$
BEGIN
  RETURN 'hello';
END;
$$ LANGUAGE plpgsql;
```

Then start the application using `npm run start` and then check to see if your custom function still exists:

```
SELECT * from pg_catalog.pg_proc WHERE proname = 'application_form_to_json' and pg_function_is_visible(oid);
```

You should see the `hello` is removed.

Resolves #1180 