### PR TITLE
Type check test files too during lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:tsc && npm run lint:swagger",
 		"lint:eslint": "eslint ./src --ext .ts --max-warnings=0",
 		"lint:swagger": "swagger-spec-validator src/openapi.json",
-		"lint:tsc": "tsc --noEmit -p tsconfig.json",
+		"lint:tsc": "tsc --noEmit -p tsconfig.dev.json",
 		"lint:prettier": "prettier . --check",
 		"migrate": "ts-node src/scripts/migrate.ts | pino-pretty",
 		"start": "ts-node src/index.ts | pino-pretty",


### PR DESCRIPTION
This PR fixes our type check lint step to also check test files.

You can test to make sure this works by changing a test so it calls some function with improper parameters, running `yarn lint` and seeing that the linter properly flags the mistake.

Resolves #1208