### PR TITLE
Remove placeholder cases

### DIFF
--- a/src/database/queries/applicationFormFields/selectWithPagination.sql
+++ b/src/database/queries/applicationFormFields/selectWithPagination.sql
@@ -2,16 +2,11 @@ SELECT application_form_field_to_json(application_form_fields) AS "object"
 FROM application_form_fields
 WHERE
   CASE
-    WHEN :applicationFormId != 0 THEN
-      application_form_id = :applicationFormId
-    ELSE
+    WHEN :applicationFormId::integer IS NULL THEN
       true
+    ELSE
+      application_form_id = :applicationFormId
     END
 ORDER BY position, id
-LIMIT
-  CASE WHEN :limit != 0 THEN
-    :limit
-  ELSE
-    NULL
-  END
+LIMIT :limit
 OFFSET :offset

--- a/src/database/queries/applicationForms/selectWithPagination.sql
+++ b/src/database/queries/applicationForms/selectWithPagination.sql
@@ -1,10 +1,5 @@
 SELECT application_form_to_json(application_forms) AS "object"
 FROM application_forms
 ORDER BY id
-LIMIT
-  CASE WHEN :limit != 0 THEN
-    :limit
-  ELSE
-    NULL
-  END
+LIMIT :limit
 OFFSET :offset

--- a/src/database/queries/baseFieldLocalizations/createOrUpdateByPrimaryKey.sql
+++ b/src/database/queries/baseFieldLocalizations/createOrUpdateByPrimaryKey.sql
@@ -13,5 +13,4 @@ ON CONFLICT (base_field_id, language)
 DO UPDATE SET
   label = EXCLUDED.label,
   description = EXCLUDED.description
-WHERE EXCLUDED.base_field_id = :baseFieldId AND EXCLUDED.language = :language
 RETURNING base_field_localization_to_json(base_field_localizations) AS "object";

--- a/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
+++ b/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
@@ -2,16 +2,11 @@ SELECT base_field_localization_to_json(base_field_localizations) AS "object"
 FROM base_field_localizations
 WHERE
   CASE
-    WHEN :baseFieldId != 0 THEN
-      base_field_id = :baseFieldId
-    ELSE
+    WHEN :baseFieldId::integer IS NULL THEN
       true
+    ELSE
+      base_field_id = :baseFieldId
     END
 ORDER BY created_at
-LIMIT
-  CASE WHEN :limit != 0 THEN
-    :limit
-  ELSE
-    NULL
-  END
+LIMIT :limit
 OFFSET :offset

--- a/src/database/queries/bulkUploads/selectWithPagination.sql
+++ b/src/database/queries/bulkUploads/selectWithPagination.sql
@@ -2,25 +2,20 @@ SELECT bulk_upload_to_json(bulk_uploads.*) as "object"
 FROM bulk_uploads
 WHERE
   CASE
-    WHEN :createdBy != 0 THEN
-      bulk_uploads.created_by = :createdBy
-    ELSE
+    WHEN :createdBy::integer IS NULL THEN
       true
+    ELSE
+      bulk_uploads.created_by = :createdBy
     END
   AND CASE
-    WHEN :userId != 0 THEN
+    WHEN :userId::integer IS NULL THEN
+      true
+    ELSE
       (
         bulk_uploads.created_by = :userId
-        OR :isAdministrator
+        OR :isAdministrator::boolean
       )
-    ELSE
-      true
     END
 ORDER BY id DESC
-LIMIT
-  CASE WHEN :limit != 0 THEN
-    :limit
-  ELSE
-    NULL
-  END
+LIMIT :limit
 OFFSET :offset

--- a/src/database/queries/bulkUploads/updateById.sql
+++ b/src/database/queries/bulkUploads/updateById.sql
@@ -1,23 +1,8 @@
 UPDATE bulk_uploads
 SET
-  file_size =
-    CASE WHEN :fileSize != -1 THEN
-      :fileSize
-    ELSE
-      file_size
-    END,
-  source_key =
-    CASE WHEN :sourceKey::text != '' THEN
-      :sourceKey
-    ELSE
-      source_key
-    END,
-  status =
-    CASE WHEN :status::text != '' THEN
-      :status::bulk_upload_status
-    ELSE
-      status
-    END
+  file_size = COALESCE(:fileSize, file_size),
+  source_key = COALESCE(:sourceKey, source_key),
+  status = COALESCE(:status, status)
 WHERE id = :id
 RETURNING bulk_upload_to_json(bulk_uploads) AS "object";
 

--- a/src/database/queries/opportunities/selectWithPagination.sql
+++ b/src/database/queries/opportunities/selectWithPagination.sql
@@ -1,11 +1,6 @@
 SELECT opportunity_to_json(opportunities.*) AS "object"
 FROM opportunities
 ORDER BY id
-LIMIT
-  CASE WHEN :limit != 0 THEN
-    :limit
-  ELSE
-    NULL
-  END
+LIMIT :limit
 OFFSET :offset
 

--- a/src/database/queries/organizations/selectWithPagination.sql
+++ b/src/database/queries/organizations/selectWithPagination.sql
@@ -4,10 +4,10 @@ FROM organizations o
   LEFT JOIN organizations_proposals op on op.organization_id = o.id
 WHERE
   CASE
-    WHEN :proposalId != 0 THEN
-      op.proposal_id = :proposalId
-    ELSE
+    WHEN :proposalId::integer IS NULL THEN
       true
+    ELSE
+      op.proposal_id = :proposalId
     END
 ORDER BY o.id DESC
 OFFSET :offset FETCH NEXT :limit ROWS ONLY

--- a/src/database/queries/organizationsProposals/selectWithPagination.sql
+++ b/src/database/queries/organizationsProposals/selectWithPagination.sql
@@ -2,16 +2,16 @@ SELECT organization_proposal_to_json(organizations_proposals.*) as "object"
 FROM organizations_proposals
 WHERE
   CASE
-    WHEN :organizationId != 0 THEN
-      organization_id = :organizationId
-    ELSE
+    WHEN :organizationId::integer IS NULL THEN
       true
+    ELSE
+      organization_id = :organizationId
     END
   AND CASE
-    WHEN :proposalId != 0 THEN
-      proposal_id = :proposalId
-    ELSE
+    WHEN :proposalId::integer IS NULL THEN
       true
+    ELSE
+      proposal_id = :proposalId
     END
 ORDER BY id DESC
 OFFSET :offset FETCH NEXT :limit ROWS ONLY;

--- a/src/database/queries/proposals/checkAuthorization.sql
+++ b/src/database/queries/proposals/checkAuthorization.sql
@@ -4,12 +4,12 @@ SELECT EXISTS (
     WHERE id = :id
       AND
         CASE
-          WHEN :userId != 0 THEN
+          WHEN :userId::integer IS NULL THEN
+            true
+          ELSE
           (
             created_by = :userId
-            OR :isAdministrator
+            OR :isAdministrator::boolean
           )
-          ELSE
-            true
           END
 ) AS result

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -5,31 +5,32 @@ FROM proposals p
   LEFT JOIN organizations_proposals op on op.proposal_id = p.id
 WHERE
   CASE
-    WHEN :createdBy != 0 THEN
+    WHEN :createdBy::integer IS NULL THEN
+      true
+    ELSE
       p.created_by = :createdBy
-    ELSE
-      true
     END
   AND CASE
-    WHEN :search::text != '' THEN
+    WHEN (:search::text IS NULL
+      OR :search = '') THEN
+      true
+    ELSE
       pfv.value_search @@ websearch_to_tsquery('english', :search::text)
-    ELSE
-      true
     END
   AND CASE
-    WHEN :organizationId != 0 THEN
+    WHEN :organizationId::integer IS NULL THEN
+      true
+    ELSE
       op.organization_id = :organizationId
-    ELSE
-      true
     END
   AND CASE
-    WHEN :userId != 0 THEN
+    WHEN :userId::integer IS NULL THEN
+      true
+    ELSE
       (
         p.created_by = :userId
-        OR :isAdministrator
+        OR :isAdministrator::boolean
       )
-    ELSE
-      true
     END
 GROUP BY p.id
 ORDER BY p.id DESC

--- a/src/database/queries/users/selectWithPagination.sql
+++ b/src/database/queries/users/selectWithPagination.sql
@@ -2,19 +2,19 @@ SELECT user_to_json(users.*) as "object"
 FROM users
 WHERE
   CASE
-    WHEN :authenticationId != '' THEN
-      authentication_id = :authenticationId
-    ELSE
+    WHEN :authenticationId::text IS NULL THEN
       true
+    ELSE
+      (authentication_id = :authenticationId)
     END
   AND CASE
-    WHEN :userId != 0 THEN
+    WHEN :userId::integer IS NULL THEN
+      true
+    ELSE
       (
         id = :userId
-        OR :isAdministrator
+        OR :isAdministrator::boolean
       )
-    ELSE
-      true
     END
 GROUP BY id
 ORDER BY id DESC

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -44,8 +44,7 @@
 			},
 			"searchParam": {
 				"schema": {
-					"type": "string",
-					"default": ""
+					"type": "string"
 				},
 				"in": "query",
 				"name": "_content",

--- a/src/queryParameters/extractSearchParameters.ts
+++ b/src/queryParameters/extractSearchParameters.ts
@@ -1,10 +1,7 @@
-import apiSpecification from '../openapi.json';
 import type { Request } from 'express';
 
 export const extractSearchParameters = (request: Request) => ({
 	/* eslint-disable no-underscore-dangle */
-	search:
-		request.query._content?.toString() ??
-		apiSpecification.components.parameters.searchParam.schema.default,
+	search: request.query._content?.toString(),
 	/* eslint-enable no-underscore-dangle */
 });


### PR DESCRIPTION
This PR cleans up our queries to remove unnecessary CASE statements which were checking for various "placeholder" values that were meant to signify `NULL`.

It also corrects a default search querystring value to go from `''` to `undefined` (though it also makes sure to treat `''` as null at the query level still)

Resolves #1189