### PR TITLE
Deploy on DigitalOcean App Platform

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,74 @@
+spec:
+  databases:
+    - name: pdc-service-db
+  envs:
+    - key: AUTH_SERVER_ISSUER
+      scope: RUN_AND_BUILD_TIME
+      value: https://auth.example.com/realms/pdc
+    - key: OPENAPI_DOCS_AUTH_CLIENT_ID
+      scope: RUN_AND_BUILD_TIME
+      value: pdc-openapi-docs
+    - key: HOST
+      scope: RUN_AND_BUILD_TIME
+      value: 0.0.0.0
+    - key: S3_ACCESS_KEY_ID
+      scope: RUN_AND_BUILD_TIME
+      value: your_key_id
+    - key: S3_ACCESS_SECRET
+      scope: RUN_AND_BUILD_TIME
+      type: SECRET
+      value: your_key_secret
+    - key: S3_BUCKET
+      scope: RUN_AND_BUILD_TIME
+      value: your-bucket-name
+    - key: S3_ENDPOINT
+      scope: RUN_AND_BUILD_TIME
+      value: https://s3.example.com
+    - key: S3_PATH_STYLE
+      scope: RUN_AND_BUILD_TIME
+      value: 'false'
+    - key: S3_REGION
+      scope: RUN_AND_BUILD_TIME
+      value: your_s3_region
+    - key: PGHOST
+      scope: RUN_AND_BUILD_TIME
+      value: ${pdc-service-db.HOSTNAME}
+    - key: PGPORT
+      scope: RUN_AND_BUILD_TIME
+      value: ${pdc-service-db.PORT}
+    - key: PGUSER
+      scope: RUN_AND_BUILD_TIME
+      value: ${pdc-service-db.USERNAME}
+    - key: PGPASSWORD
+      scope: RUN_AND_BUILD_TIME
+      value: ${pdc-service-db.PASSWORD}
+    - key: PGDATABASE
+      scope: RUN_AND_BUILD_TIME
+      value: ${pdc-service-db.DATABASE}
+    - key: PGSSLMODE
+      scope: RUN_AND_BUILD_TIME
+      value: no-verify
+  jobs:
+    - environment_slug: node-js
+      github:
+        branch: main
+        repo: PhilanthropyDataCommons/service
+      instance_count: 1
+      instance_size_slug: basic-xxs
+      kind: PRE_DEPLOY
+      name: migrate
+      run_command: node dist/scripts/migrate.js
+  name: pdc-service
+  services:
+    - environment_slug: node-js
+      github:
+        branch: main
+        repo: PhilanthropyDataCommons/service
+      health_check:
+        http_path: /
+      http_port: 8080
+      instance_count: 1
+      instance_size_slug: apps-s-1vcpu-0.5gb
+      name: service
+      run_command: node dist/index.js
+      source_dir: /

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,24 @@
-## Database Settings
-PGUSER=${PGUSER}
+# Hosting settings: address and port to listen on
+HOST=localhost
+PORT=3001
+
+# Logging to stderr, filtered by log level
+# "fatal" | "error" | "warn" | "info" | "debug" | "trace"
+# https://github.com/pinojs/pino/blob/main/docs/api.md#level-1
+LOG_LEVEL=info
+
+# Set this when running in production, and unset it otherwise
+# https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production
+#NODE_ENV=production
+
+# Database Settings
+# https://node-postgres.com/features/connecting
+# https://www.postgresql.org/docs/current/libpq-envars.html
 PGHOST=${PGHOST}
+PGPORT=${PGPORT}
+PGUSER=${PGUSER}
 PGPASSWORD=${PGPASSWORD}
 PGDATABASE=${PGDATABASE}
-PGPORT=${PGPORT}
 
 # `AUTH_SERVER_ISSUER` serves two purposes related to authentication via JSON Web Tokens (JWTs):
 # 1. The "issuer" of a Bearer JWT in the Authorization header needs to match this value.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ While the PDC service layer will have its own web-browser-based searching and br
 
 See also the [technical architecture diagram](docs/ARCHITECTURE.md).
 
+## Hosting
+
+For notes on how to set up a production instance, see the [hosting documentation](docs/HOSTING.md).
+
 ## Development
 
 In order to run this software you need to set up a [Postgres 14](https://www.postgresql.org/) database.

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -1,0 +1,41 @@
+# Hosting
+
+## Keycloak
+
+The PDC API requires a [Keycloak](https://www.keycloak.org/) instance
+to handle authentication.
+
+We suggest creating a second realm named `pdc`
+to separate Keycloak administrator accounts from PDC accounts.
+
+## service
+
+The PDC API is a fairly standard Node.js application.
+It needs no special operating system permissions,
+and should be run as a non-root user.
+
+Add the environment variables in `.env.example`
+however your hosting environment needs.
+
+Be sure to set `NODE_ENV=production`,
+as recommended by the
+[Node.js documentation](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production)
+and the
+[Express documentation](https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production).
+
+### DigitalOcean App Platform
+
+The PDC API can be deployed on
+[DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform):
+
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/PhilanthropyDataCommons/service/tree/main)
+
+Although specified in the template,
+the API cannot be used with a DigitalOcean dev database,
+because [dev databases do not allow schema
+creation](https://www.digitalocean.com/community/questions/how-to-create-tables-with-app-platform-managed-dev-databases?comment=206323)
+and the PDC requires PostgreSQL schemas;
+the `migrate` job will fail with a permission denied error.
+Either delete the dev database and add a prod database with the same name during app creation,
+upgrade the generated dev database to a managed database after creating the app,
+or delete the dev database and configure the environment variables with credentials for a database hosted elsewhere.

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ const start = async () => {
 		throw err;
 	}
 	app.listen(port, host, () => {
-		logger.info(`Server running on http://${host}:${port}`);
+		const mode = process.env.NODE_ENV === 'production' ? 'production' : 'debug';
+		logger.info(`Server running on http://${host}:${port} in ${mode} mode`);
 	});
 };
 


### PR DESCRIPTION
> [DigitalOcean App Platform](https://docs.digitalocean.com/products/app-platform/) is a Platform-as-a-Service (PaaS) offering that allows developers to publish code directly to DigitalOcean servers without worrying about the underlying infrastructure.

The majority of the work in migrating is in configuring the application on the DigitalOcean side. To do so, some improved documentation and logging is helpful, as is capturing the configuration into an [app template](https://docs.digitalocean.com/products/app-platform/how-to/add-deploy-do-button/).

Issue https://github.com/PhilanthropyDataCommons/deploy/issues/118 Migrate to DigitalOcean Apps