### PR TITLE
Use `keycloakUserId` as natural primary key for the `users` table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgraded to use OpenAPI Specification 3.1.
 
+## 0.14.0 2024-10-11
+
+### Changed
+
+- `Users.id` no longer exists; `keycloakUserId` is now the primary identifier of any given `User`.
+- `Proposal.createdBy` is now a UUID reference to the creator's `keycloakUserId`.
+- `ProposalVersion.createdBy` is now a UUID reference to the creator's `keycloakUserId`.
+- `BulkUpload.createdBy` is now a UUID reference to the creator's `keycloakUserId`.
+
 ## 0.13.0 2024-09-26
 
 ### Changed

--- a/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
+++ b/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
@@ -21,6 +21,7 @@ erDiagram
     int id
     int opportunityId
     string externalId
+		string createdBy
     datetime createdAt
   }
   Outcome {
@@ -62,6 +63,7 @@ erDiagram
     int proposalId
     int sourceId
     int version
+		string createdBy
     datetime createdAt
   }
   ProposalFieldValue {
@@ -94,8 +96,22 @@ erDiagram
     string funder_short_code
     int organization_id
     string data_provider_short_code
-    datetime createdAt
+    datetime created_at
   }
+	BulkUpload {
+		integer id
+		string file_name
+		string source_key
+		bulk_upload_status status
+		integer file_size
+		integer source_id
+		string created_by
+		timestamp created_at
+	}
+	User {
+		string keycloak_user_id
+    datetime created_at
+	}
 
   Organization ||--o{ Proposal : submits
   Proposal }|--|| Opportunity : "responds to"
@@ -113,6 +129,9 @@ erDiagram
   Source }|--o| DataProvider : "represents"
   ProposalVersion }o--|| Source : "comes from"
   ExternalFieldValue }o--|| Source : "comes from"
+	Proposal }o--|| User : "is created by"
+	ProposalVersion }o--|| User : "is created by"
+	BulkUpload }o--|| User : "is created by"
 ```
 
 ## Narrative

--- a/src/__tests__/bulkUploads.int.test.ts
+++ b/src/__tests__/bulkUploads.int.test.ts
@@ -13,7 +13,7 @@ import {
 	mockJwtWithoutSub as authHeaderWithNoSub,
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
 } from '../test/mockJwt';
-import { BulkUploadStatus } from '../types';
+import { BulkUploadStatus, keycloakUserIdToString } from '../types';
 
 describe('/bulkUploads', () => {
 	describe('GET /', () => {
@@ -47,28 +47,28 @@ describe('/bulkUploads', () => {
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: BulkUploadStatus.PENDING,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createBulkUpload({
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: BulkUploadStatus.COMPLETED,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createBulkUpload({
 				sourceId: systemSource.id,
 				fileName: 'baz.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-baz',
 				status: BulkUploadStatus.COMPLETED,
-				createdBy: systemUser.id,
+				createdBy: systemUser.keycloakUserId,
 			});
 			await createBulkUpload({
 				sourceId: systemSource.id,
 				fileName: 'boop.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-boop',
 				status: BulkUploadStatus.COMPLETED,
-				createdBy: thirdUser.id,
+				createdBy: thirdUser.keycloakUserId,
 			});
 
 			await request(app)
@@ -88,7 +88,7 @@ describe('/bulkUploads', () => {
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: BulkUploadStatus.COMPLETED,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 							},
 							{
 								id: 1,
@@ -99,7 +99,7 @@ describe('/bulkUploads', () => {
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 								status: BulkUploadStatus.PENDING,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 							},
 						],
 					}),
@@ -117,14 +117,14 @@ describe('/bulkUploads', () => {
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: BulkUploadStatus.PENDING,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createBulkUpload({
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: BulkUploadStatus.COMPLETED,
-				createdBy: anotherUser.id,
+				createdBy: anotherUser.keycloakUserId,
 			});
 
 			await request(app)
@@ -144,7 +144,7 @@ describe('/bulkUploads', () => {
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: BulkUploadStatus.COMPLETED,
 								createdAt: expectTimestamp,
-								createdBy: anotherUser.id,
+								createdBy: anotherUser.keycloakUserId,
 							},
 							{
 								id: 1,
@@ -155,7 +155,7 @@ describe('/bulkUploads', () => {
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 								status: BulkUploadStatus.PENDING,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 							},
 						],
 					}),
@@ -173,18 +173,20 @@ describe('/bulkUploads', () => {
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: BulkUploadStatus.PENDING,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createBulkUpload({
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: BulkUploadStatus.COMPLETED,
-				createdBy: anotherUser.id,
+				createdBy: anotherUser.keycloakUserId,
 			});
 
 			await request(app)
-				.get(`/bulkUploads?createdBy=${anotherUser.id}`)
+				.get(
+					`/bulkUploads?createdBy=${keycloakUserIdToString(anotherUser.keycloakUserId)}`,
+				)
 				.set(authHeaderWithAdminRole)
 				.expect(200)
 				.expect((res) =>
@@ -200,7 +202,7 @@ describe('/bulkUploads', () => {
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: BulkUploadStatus.COMPLETED,
 								createdAt: expectTimestamp,
-								createdBy: anotherUser.id,
+								createdBy: anotherUser.keycloakUserId,
 							},
 						],
 					}),
@@ -218,14 +220,14 @@ describe('/bulkUploads', () => {
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: BulkUploadStatus.PENDING,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createBulkUpload({
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: BulkUploadStatus.COMPLETED,
-				createdBy: anotherUser.id,
+				createdBy: anotherUser.keycloakUserId,
 			});
 
 			await request(app)
@@ -245,7 +247,7 @@ describe('/bulkUploads', () => {
 								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 								status: BulkUploadStatus.PENDING,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 							},
 						],
 					}),
@@ -262,7 +264,7 @@ describe('/bulkUploads', () => {
 					fileName: `bar-${i + 1}.csv`,
 					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 					status: BulkUploadStatus.COMPLETED,
-					createdBy: testUser.id,
+					createdBy: testUser.keycloakUserId,
 				});
 			}, Promise.resolve());
 
@@ -288,7 +290,7 @@ describe('/bulkUploads', () => {
 									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: BulkUploadStatus.COMPLETED,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 							},
 							{
 								id: 14,
@@ -300,7 +302,7 @@ describe('/bulkUploads', () => {
 									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: BulkUploadStatus.COMPLETED,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 							},
 							{
 								id: 13,
@@ -312,7 +314,7 @@ describe('/bulkUploads', () => {
 									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: BulkUploadStatus.COMPLETED,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 							},
 							{
 								id: 12,
@@ -324,7 +326,7 @@ describe('/bulkUploads', () => {
 									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: BulkUploadStatus.COMPLETED,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 							},
 							{
 								id: 11,
@@ -336,7 +338,7 @@ describe('/bulkUploads', () => {
 									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: BulkUploadStatus.COMPLETED,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 							},
 						],
 					}),
@@ -382,7 +384,7 @@ describe('/bulkUploads', () => {
 				sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: 'pending',
 				createdAt: expectTimestamp,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(1);
 		});

--- a/src/__tests__/organizationProposals.int.test.ts
+++ b/src/__tests__/organizationProposals.int.test.ts
@@ -36,12 +36,12 @@ describe('/organizationProposals', () => {
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				opportunityId: 1,
 				externalId: '2',
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createOrganizationProposal({
 				organizationId: 1,
@@ -74,7 +74,7 @@ describe('/organizationProposals', () => {
 							externalId: '2',
 							versions: [],
 							createdAt: expectTimestamp,
-							createdBy: testUser.id,
+							createdBy: testUser.keycloakUserId,
 						},
 						createdAt: expectTimestamp,
 					},
@@ -95,7 +95,7 @@ describe('/organizationProposals', () => {
 							externalId: '1',
 							versions: [],
 							createdAt: expectTimestamp,
-							createdBy: testUser.id,
+							createdBy: testUser.keycloakUserId,
 						},
 						createdAt: expectTimestamp,
 					},
@@ -113,12 +113,12 @@ describe('/organizationProposals', () => {
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				opportunityId: 1,
 				externalId: '2',
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createOrganizationProposal({
 				organizationId: 1,
@@ -151,7 +151,7 @@ describe('/organizationProposals', () => {
 							externalId: '1',
 							versions: [],
 							createdAt: expectTimestamp,
-							createdBy: testUser.id,
+							createdBy: testUser.keycloakUserId,
 						},
 						createdAt: expectTimestamp,
 					},
@@ -183,7 +183,7 @@ describe('/organizationProposals', () => {
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			const before = await loadTableMetrics('organizations_proposals');
 			const result = await request(app)
@@ -214,7 +214,7 @@ describe('/organizationProposals', () => {
 					externalId: '1',
 					versions: [],
 					createdAt: expectTimestamp,
-					createdBy: testUser.id,
+					createdBy: testUser.keycloakUserId,
 				},
 				createdAt: expectTimestamp,
 			});
@@ -230,7 +230,7 @@ describe('/organizationProposals', () => {
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			const result = await request(app)
 				.post('/organizationProposals')
@@ -255,7 +255,7 @@ describe('/organizationProposals', () => {
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			const result = await request(app)
 				.post('/organizationProposals')
@@ -298,7 +298,7 @@ describe('/organizationProposals', () => {
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			const result = await request(app)
 				.post('/organizationProposals')
@@ -323,7 +323,7 @@ describe('/organizationProposals', () => {
 			await createProposal({
 				opportunityId: 1,
 				externalId: '1',
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createOrganizationProposal({
 				organizationId: 1,

--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -139,7 +139,7 @@ describe('/organizations', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createOrganization({
 				taxId: '123-123-123',
@@ -179,12 +179,12 @@ describe('/organizations', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createOrganization({
 				taxId: '123-123-123',
@@ -291,7 +291,7 @@ describe('/organizations', () => {
 				await createProposal({
 					opportunityId,
 					externalId: 'Proposal',
-					createdBy: systemUser.id,
+					createdBy: systemUser.keycloakUserId,
 				})
 			).id;
 			await createOrganizationProposal({
@@ -311,7 +311,7 @@ describe('/organizations', () => {
 						proposalId,
 						applicationFormId: applicationFormIdEarliest,
 						sourceId: systemSource.id,
-						createdBy: systemUser.id,
+						createdBy: systemUser.keycloakUserId,
 					})
 				).id,
 				applicationFormFieldId: (
@@ -337,7 +337,7 @@ describe('/organizations', () => {
 						proposalId,
 						applicationFormId: applicationFormIdLatestValid,
 						sourceId: systemSource.id,
-						createdBy: systemUser.id,
+						createdBy: systemUser.keycloakUserId,
 					})
 				).id,
 				applicationFormFieldId: (
@@ -364,7 +364,7 @@ describe('/organizations', () => {
 						proposalId,
 						applicationFormId: applicationFormIdLatest,
 						sourceId: systemSource.id,
-						createdBy: systemUser.id,
+						createdBy: systemUser.keycloakUserId,
 					})
 				).id,
 				applicationFormFieldId: (

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -46,7 +46,7 @@ describe('/proposalVersions', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -82,7 +82,7 @@ describe('/proposalVersions', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -212,7 +212,7 @@ describe('/proposalVersions', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -246,7 +246,7 @@ describe('/proposalVersions', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -280,7 +280,7 @@ describe('/proposalVersions', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -321,7 +321,7 @@ describe('/proposalVersions', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -366,7 +366,7 @@ describe('/proposalVersions', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -413,7 +413,7 @@ describe('/proposalVersions', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -22,7 +22,11 @@ import {
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
 } from '../test/mockJwt';
 import { PostgresErrorCode } from '../types/PostgresErrorCode';
-import { BaseFieldDataType, BaseFieldScope } from '../types';
+import {
+	BaseFieldDataType,
+	BaseFieldScope,
+	keycloakUserIdToString,
+} from '../types';
 
 const createTestBaseFields = async () => {
 	await createBaseField({
@@ -71,17 +75,17 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: 'proposal-3',
 				opportunityId: 1,
-				createdBy: secondUser.id,
+				createdBy: secondUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -90,7 +94,7 @@ describe('/proposals', () => {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationFormField({
 				applicationFormId: 1,
@@ -118,7 +122,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-2',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						versions: [],
 					},
 					{
@@ -126,7 +130,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-1',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						versions: [
 							{
 								id: 1,
@@ -136,7 +140,7 @@ describe('/proposals', () => {
 								source: systemSource,
 								applicationFormId: 1,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 								fieldValues: [
 									{
 										id: 1,
@@ -183,12 +187,12 @@ describe('/proposals', () => {
 			const proposal = await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			const organization = await createOrganization({
 				taxId: '123-123-123',
@@ -210,7 +214,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-1',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						versions: [],
 					},
 				],
@@ -250,12 +254,12 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -264,13 +268,13 @@ describe('/proposals', () => {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposalVersion({
 				proposalId: 2,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationFormField({
 				applicationFormId: 1,
@@ -304,7 +308,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-1',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						versions: [
 							{
 								id: 1,
@@ -314,7 +318,7 @@ describe('/proposals', () => {
 								version: 1,
 								applicationFormId: 1,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 								fieldValues: [
 									{
 										id: 1,
@@ -364,12 +368,12 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
-				createdBy: anotherUser.id,
+				createdBy: anotherUser.keycloakUserId,
 			});
 			const response = await request(app)
 				.get('/proposals')
@@ -383,7 +387,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-2',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
-						createdBy: anotherUser.id,
+						createdBy: anotherUser.keycloakUserId,
 						versions: [],
 					},
 					{
@@ -391,7 +395,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-1',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						versions: [],
 					},
 				],
@@ -411,15 +415,17 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
-				createdBy: anotherUser.id,
+				createdBy: anotherUser.keycloakUserId,
 			});
 			const response = await request(app)
-				.get(`/proposals?createdBy=${testUser.id}`)
+				.get(
+					`/proposals?createdBy=${keycloakUserIdToString(testUser.keycloakUserId)}`,
+				)
 				.set(authHeaderWithAdminRole)
 				.expect(200);
 			expect(response.body).toEqual({
@@ -430,7 +436,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-1',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						versions: [],
 					},
 				],
@@ -450,12 +456,12 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: 'proposal-1',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: 'proposal-2',
 				opportunityId: 1,
-				createdBy: anotherUser.id,
+				createdBy: anotherUser.keycloakUserId,
 			});
 			const response = await request(app)
 				.get(`/proposals?createdBy=me`)
@@ -469,7 +475,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-1',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						versions: [],
 					},
 				],
@@ -489,12 +495,12 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: 'proposal-4999',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: 'proposal-5003',
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationForm({
 				opportunityId: 1,
@@ -503,13 +509,13 @@ describe('/proposals', () => {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposalVersion({
 				proposalId: 2,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createApplicationFormField({
 				applicationFormId: 1,
@@ -543,7 +549,7 @@ describe('/proposals', () => {
 						externalId: 'proposal-4999',
 						opportunityId: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						versions: [
 							{
 								id: 1,
@@ -553,7 +559,7 @@ describe('/proposals', () => {
 								version: 1,
 								applicationFormId: 1,
 								createdAt: expectTimestamp,
-								createdBy: testUser.id,
+								createdBy: testUser.keycloakUserId,
 								fieldValues: [
 									{
 										id: 1,
@@ -601,7 +607,7 @@ describe('/proposals', () => {
 				await createProposal({
 					externalId: `proposal-${i + 1}`,
 					opportunityId: 1,
-					createdBy: testUser.id,
+					createdBy: testUser.keycloakUserId,
 				});
 			}, Promise.resolve());
 			const response = await request(app)
@@ -621,7 +627,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 					},
 					{
 						id: 14,
@@ -629,7 +635,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 					},
 					{
 						id: 13,
@@ -637,7 +643,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 					},
 					{
 						id: 12,
@@ -645,7 +651,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 					},
 					{
 						id: 11,
@@ -653,7 +659,7 @@ describe('/proposals', () => {
 						opportunityId: 1,
 						versions: [],
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 					},
 				],
 			});
@@ -695,7 +701,7 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: `proposal-1`,
 				opportunityId: 1,
-				createdBy: anotherUser.id,
+				createdBy: anotherUser.keycloakUserId,
 			});
 
 			const response = await request(app)
@@ -738,12 +744,12 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: `proposal-1`,
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposal({
 				externalId: `proposal-2`,
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 
 			const response = await request(app)
@@ -756,7 +762,7 @@ describe('/proposals', () => {
 				versions: [],
 				opportunityId: 1,
 				createdAt: expectTimestamp,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 		});
 
@@ -785,19 +791,19 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: `proposal-2525-01-04T00Z`,
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposalVersion({
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposalVersion({
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposalFieldValue({
 				proposalVersionId: 1,
@@ -836,7 +842,7 @@ describe('/proposals', () => {
 				opportunityId: 1,
 				externalId: 'proposal-2525-01-04T00Z',
 				createdAt: expectTimestamp,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 				versions: [
 					{
 						id: 2,
@@ -846,7 +852,7 @@ describe('/proposals', () => {
 						applicationFormId: 1,
 						version: 2,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						fieldValues: [
 							{
 								id: 3,
@@ -912,7 +918,7 @@ describe('/proposals', () => {
 						applicationFormId: 1,
 						version: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						fieldValues: [
 							{
 								id: 1,
@@ -999,19 +1005,19 @@ describe('/proposals', () => {
 			await createProposal({
 				externalId: `proposal-2525-01-04T00Z`,
 				opportunityId: 1,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposalVersion({
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposalVersion({
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			await createProposalFieldValue({
 				proposalVersionId: 1,
@@ -1050,7 +1056,7 @@ describe('/proposals', () => {
 				opportunityId: 1,
 				externalId: 'proposal-2525-01-04T00Z',
 				createdAt: expectTimestamp,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 				versions: [
 					{
 						id: 2,
@@ -1060,7 +1066,7 @@ describe('/proposals', () => {
 						applicationFormId: 1,
 						version: 2,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						fieldValues: [
 							{
 								id: 3,
@@ -1126,7 +1132,7 @@ describe('/proposals', () => {
 						applicationFormId: 1,
 						version: 1,
 						createdAt: expectTimestamp,
-						createdBy: testUser.id,
+						createdBy: testUser.keycloakUserId,
 						fieldValues: [
 							{
 								id: 1,
@@ -1223,7 +1229,7 @@ describe('/proposals', () => {
 				externalId: 'proposal123',
 				opportunityId: 1,
 				createdAt: expectTimestamp,
-				createdBy: testUser.id,
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(1);
 		});

--- a/src/__tests__/users.int.test.ts
+++ b/src/__tests__/users.int.test.ts
@@ -77,7 +77,6 @@ describe('/users', () => {
 		});
 
 		it('returns according to pagination parameters', async () => {
-			const { count: baseUserCount } = await loadTableMetrics('users');
 			const uuids = Array.from(Array(20)).map(() => uuidv4());
 			await uuids.reduce(async (p, uuid) => {
 				await p;
@@ -99,27 +98,22 @@ describe('/users', () => {
 				total: userCount,
 				entries: [
 					{
-						id: 15 + baseUserCount,
 						keycloakUserId: uuids[14],
 						createdAt: expectTimestamp,
 					},
 					{
-						id: 14 + baseUserCount,
 						keycloakUserId: uuids[13],
 						createdAt: expectTimestamp,
 					},
 					{
-						id: 13 + baseUserCount,
 						keycloakUserId: uuids[12],
 						createdAt: expectTimestamp,
 					},
 					{
-						id: 12 + baseUserCount,
 						keycloakUserId: uuids[11],
 						createdAt: expectTimestamp,
 					},
 					{
-						id: 11 + baseUserCount,
 						keycloakUserId: uuids[10],
 						createdAt: expectTimestamp,
 					},

--- a/src/database/initialization/user_to_json.sql
+++ b/src/database/initialization/user_to_json.sql
@@ -4,7 +4,6 @@ CREATE FUNCTION user_to_json("user" users)
 RETURNS JSONB AS $$
 BEGIN
   RETURN jsonb_build_object(
-    'id', "user".id,
     'keycloakUserId', "user".keycloak_user_id,
     'createdAt', "user".created_at
   );

--- a/src/database/migrations/0038-alter-users-use-keycloak_user_id-as-primary-key.sql
+++ b/src/database/migrations/0038-alter-users-use-keycloak_user_id-as-primary-key.sql
@@ -1,0 +1,54 @@
+-- Create new columns which will become the foreign keys
+ALTER TABLE bulk_uploads ADD COLUMN created_by_keycloak_user_id UUID;
+ALTER TABLE proposals ADD COLUMN created_by_keycloak_user_id UUID;
+ALTER TABLE proposal_versions ADD COLUMN created_by_keycloak_user_id UUID;
+
+-- Update the new columns with appropriate values
+UPDATE bulk_uploads
+  SET created_by_keycloak_user_id = (
+    SELECT keycloak_user_id FROM users WHERE id = bulk_uploads.created_by
+  );
+UPDATE proposals
+  SET created_by_keycloak_user_id = (
+    SELECT keycloak_user_id FROM users WHERE id = proposals.created_by
+  );
+UPDATE proposal_versions
+  SET created_by_keycloak_user_id = (
+    SELECT keycloak_user_id FROM users WHERE id = proposal_versions.created_by
+  );
+
+-- Add not null constraints
+ALTER TABLE bulk_uploads ALTER COLUMN created_by_keycloak_user_id SET NOT NULL;
+ALTER TABLE proposals ALTER COLUMN created_by_keycloak_user_id SET NOT NULL;
+ALTER TABLE proposal_versions ALTER COLUMN created_by_keycloak_user_id SET NOT NULL;
+
+-- Drop the existing foreign key constraints
+ALTER TABLE bulk_uploads DROP CONSTRAINT fk_createdBy;
+ALTER TABLE proposals DROP CONSTRAINT fk_createdBy;
+ALTER TABLE proposal_versions DROP CONSTRAINT fk_createdBy;
+
+-- Drop the existing foreign key columns
+ALTER TABLE bulk_uploads DROP COLUMN created_by;
+ALTER TABLE proposals DROP COLUMN created_by;
+ALTER TABLE proposal_versions DROP COLUMN created_by;
+
+-- Rename the new columns to replace the old column
+ALTER TABLE bulk_uploads RENAME COLUMN created_by_keycloak_user_id TO created_by;
+ALTER TABLE proposals RENAME COLUMN created_by_keycloak_user_id TO created_by;
+ALTER TABLE proposal_versions RENAME COLUMN created_by_keycloak_user_id TO created_by;
+
+-- Update the primary key on the users table
+ALTER TABLE users
+  DROP CONSTRAINT users_pkey,
+  ADD PRIMARY KEY (keycloak_user_id);
+
+-- Remove redundant unique constraint on keycloak_user_id
+ALTER TABLE users DROP CONSTRAINT users_authentication_id_key;
+
+-- Drop the previous foreign key column
+ALTER TABLE users DROP COLUMN id;
+
+-- Add the new foreign key constraints
+ALTER TABLE bulk_uploads ADD CONSTRAINT fk_created_by FOREIGN KEY (created_by) REFERENCES users(keycloak_user_id);
+ALTER TABLE proposals ADD CONSTRAINT fk_created_by FOREIGN KEY (created_by) REFERENCES users(keycloak_user_id);
+ALTER TABLE proposal_versions ADD CONSTRAINT fk_created_by FOREIGN KEY (created_by) REFERENCES users(keycloak_user_id);

--- a/src/database/operations/bulkUploads/loadBulkUploadBundle.ts
+++ b/src/database/operations/bulkUploads/loadBulkUploadBundle.ts
@@ -4,15 +4,16 @@ import type {
 	Bundle,
 	BulkUpload,
 	AuthContext,
+	KeycloakUserId,
 } from '../../../types';
 
 export const loadBulkUploadBundle = async (
 	authContext: AuthContext | undefined,
-	createdBy: number | undefined,
+	createdBy: KeycloakUserId | undefined,
 	limit: number | undefined,
 	offset: number,
 ): Promise<Bundle<BulkUpload>> => {
-	const userId = authContext?.user.id;
+	const userId = authContext?.user.keycloakUserId;
 	const isAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<BulkUpload>>(

--- a/src/database/operations/bulkUploads/loadBulkUploadBundle.ts
+++ b/src/database/operations/bulkUploads/loadBulkUploadBundle.ts
@@ -13,17 +13,17 @@ export const loadBulkUploadBundle = async (
 	limit: number | undefined,
 	offset: number,
 ): Promise<Bundle<BulkUpload>> => {
-	const userId = authContext?.user.keycloakUserId;
-	const isAdministrator = authContext?.role.isAdministrator;
+	const authContextKeycloakUserId = authContext?.user.keycloakUserId;
+	const authContextIsAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<BulkUpload>>(
 		'bulkUploads.selectWithPagination',
 		{
+			authContextIsAdministrator,
+			authContextKeycloakUserId,
 			createdBy,
-			isAdministrator,
 			limit,
 			offset,
-			userId,
 		},
 		'bulk_uploads',
 	);

--- a/src/database/operations/proposals/assertProposalAuthorization.ts
+++ b/src/database/operations/proposals/assertProposalAuthorization.ts
@@ -7,7 +7,7 @@ export const assertProposalAuthorization = async (
 	authContext: AuthContext,
 ): Promise<void> => {
 	const {
-		user: { id: userId },
+		user: { keycloakUserId: userId },
 	} = authContext;
 	const {
 		role: { isAdministrator },

--- a/src/database/operations/proposals/assertProposalAuthorization.ts
+++ b/src/database/operations/proposals/assertProposalAuthorization.ts
@@ -6,17 +6,13 @@ export const assertProposalAuthorization = async (
 	id: number,
 	authContext: AuthContext,
 ): Promise<void> => {
-	const {
-		user: { keycloakUserId: userId },
-	} = authContext;
-	const {
-		role: { isAdministrator },
-	} = authContext;
+	const authContextKeycloakUserId = authContext.user.keycloakUserId;
+	const authContextIsAdministrator = authContext.role.isAdministrator;
 
 	const result = await db.sql<CheckResult>('proposals.checkAuthorization', {
+		authContextIsAdministrator,
+		authContextKeycloakUserId,
 		id,
-		userId,
-		isAdministrator,
 	});
 
 	if (result.rows[0]?.result !== true) {

--- a/src/database/operations/proposals/loadProposalBundle.ts
+++ b/src/database/operations/proposals/loadProposalBundle.ts
@@ -15,19 +15,19 @@ export const loadProposalBundle = async (
 	limit: number | undefined,
 	offset: number,
 ): Promise<Bundle<Proposal>> => {
-	const userId = authContext?.user.keycloakUserId;
-	const isAdministrator = authContext?.role.isAdministrator;
+	const authContextKeycloakUserId = authContext?.user.keycloakUserId;
+	const authContextIsAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<Proposal>>(
 		'proposals.selectWithPagination',
 		{
+			authContextIsAdministrator,
+			authContextKeycloakUserId,
 			createdBy,
-			isAdministrator,
 			limit,
 			offset,
 			organizationId,
 			search,
-			userId,
 		},
 		'proposals',
 	);

--- a/src/database/operations/proposals/loadProposalBundle.ts
+++ b/src/database/operations/proposals/loadProposalBundle.ts
@@ -4,17 +4,18 @@ import type {
 	Bundle,
 	Proposal,
 	AuthContext,
+	KeycloakUserId,
 } from '../../../types';
 
 export const loadProposalBundle = async (
 	authContext: AuthContext | undefined,
-	createdBy: number | undefined,
+	createdBy: KeycloakUserId | undefined,
 	organizationId: number | undefined,
 	search: string | undefined,
 	limit: number | undefined,
 	offset: number,
 ): Promise<Bundle<Proposal>> => {
-	const userId = authContext?.user.id;
+	const userId = authContext?.user.keycloakUserId;
 	const isAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<Proposal>>(

--- a/src/database/operations/users/loadUserBundle.ts
+++ b/src/database/operations/users/loadUserBundle.ts
@@ -13,7 +13,7 @@ export const loadUserBundle = async (
 	limit: number | undefined,
 	offset: number,
 ): Promise<Bundle<User>> => {
-	const userId = authContext?.user.id;
+	const userId = authContext?.user.keycloakUserId;
 	const isAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<User>>(

--- a/src/database/operations/users/loadUserBundle.ts
+++ b/src/database/operations/users/loadUserBundle.ts
@@ -13,17 +13,17 @@ export const loadUserBundle = async (
 	limit: number | undefined,
 	offset: number,
 ): Promise<Bundle<User>> => {
-	const userId = authContext?.user.keycloakUserId;
-	const isAdministrator = authContext?.role.isAdministrator;
+	const authContextKeycloakUserId = authContext?.user.keycloakUserId;
+	const authContextIsAdministrator = authContext?.role.isAdministrator;
 
 	const bundle = await loadBundle<JsonResultSet<User>>(
 		'users.selectWithPagination',
 		{
+			authContextIsAdministrator,
+			authContextKeycloakUserId,
 			keycloakUserId,
-			isAdministrator,
 			limit,
 			offset,
-			userId,
 		},
 		'users',
 	);

--- a/src/database/queries/bulkUploads/selectWithPagination.sql
+++ b/src/database/queries/bulkUploads/selectWithPagination.sql
@@ -2,13 +2,13 @@ SELECT bulk_upload_to_json(bulk_uploads.*) as "object"
 FROM bulk_uploads
 WHERE
   CASE
-    WHEN :createdBy::integer IS NULL THEN
+    WHEN :createdBy::UUID IS NULL THEN
       true
     ELSE
       bulk_uploads.created_by = :createdBy
     END
   AND CASE
-    WHEN :userId::integer IS NULL THEN
+    WHEN :userId::UUID IS NULL THEN
       true
     ELSE
       (

--- a/src/database/queries/bulkUploads/selectWithPagination.sql
+++ b/src/database/queries/bulkUploads/selectWithPagination.sql
@@ -8,12 +8,12 @@ WHERE
       bulk_uploads.created_by = :createdBy
     END
   AND CASE
-    WHEN :userId::UUID IS NULL THEN
+    WHEN :authContextKeycloakUserId::UUID IS NULL THEN
       true
     ELSE
       (
-        bulk_uploads.created_by = :userId
-        OR :isAdministrator::boolean
+        bulk_uploads.created_by = :authContextKeycloakUserId
+        OR :authContextIsAdministrator::boolean
       )
     END
 ORDER BY id DESC

--- a/src/database/queries/proposals/checkAuthorization.sql
+++ b/src/database/queries/proposals/checkAuthorization.sql
@@ -4,7 +4,7 @@ SELECT EXISTS (
     WHERE id = :id
       AND
         CASE
-          WHEN :userId::integer IS NULL THEN
+          WHEN :userId::UUID IS NULL THEN
             true
           ELSE
           (

--- a/src/database/queries/proposals/checkAuthorization.sql
+++ b/src/database/queries/proposals/checkAuthorization.sql
@@ -4,12 +4,12 @@ SELECT EXISTS (
     WHERE id = :id
       AND
         CASE
-          WHEN :userId::UUID IS NULL THEN
+          WHEN :authContextKeycloakUserId::UUID IS NULL THEN
             true
           ELSE
           (
-            created_by = :userId
-            OR :isAdministrator::boolean
+            created_by = :authContextKeycloakUserId
+            OR :authContextIsAdministrator::boolean
           )
           END
 ) AS result

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -5,7 +5,7 @@ FROM proposals p
   LEFT JOIN organizations_proposals op on op.proposal_id = p.id
 WHERE
   CASE
-    WHEN :createdBy::integer IS NULL THEN
+    WHEN :createdBy::UUID IS NULL THEN
       true
     ELSE
       p.created_by = :createdBy
@@ -24,7 +24,7 @@ WHERE
       op.organization_id = :organizationId
     END
   AND CASE
-    WHEN :userId::integer IS NULL THEN
+    WHEN :userId::UUID IS NULL THEN
       true
     ELSE
       (

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -24,12 +24,12 @@ WHERE
       op.organization_id = :organizationId
     END
   AND CASE
-    WHEN :userId::UUID IS NULL THEN
+    WHEN :authContextKeycloakUserId::UUID IS NULL THEN
       true
     ELSE
       (
-        p.created_by = :userId
-        OR :isAdministrator::boolean
+        p.created_by = :authContextKeycloakUserId
+        OR :authContextIsAdministrator::boolean
       )
     END
 GROUP BY p.id

--- a/src/database/queries/users/selectSystemUser.sql
+++ b/src/database/queries/users/selectSystemUser.sql
@@ -1,3 +1,3 @@
 SELECT user_to_json(users.*) AS "object"
 FROM users
-WHERE id = system_user_id()
+WHERE keycloak_user_id = system_keycloak_user_id()

--- a/src/database/queries/users/selectWithPagination.sql
+++ b/src/database/queries/users/selectWithPagination.sql
@@ -8,14 +8,14 @@ WHERE
       keycloak_user_id = :keycloakUserId
     END
   AND CASE
-    WHEN :userId::integer IS NULL THEN
+    WHEN :userId::UUID IS NULL THEN
       true
     ELSE
       (
-        id = :userId
+        keycloak_user_id = :userId
         OR :isAdministrator::boolean
       )
     END
-GROUP BY id
-ORDER BY id DESC
+GROUP BY keycloak_user_id
+ORDER BY created_at DESC
 OFFSET :offset FETCH NEXT :limit ROWS ONLY;

--- a/src/database/queries/users/selectWithPagination.sql
+++ b/src/database/queries/users/selectWithPagination.sql
@@ -8,12 +8,12 @@ WHERE
       keycloak_user_id = :keycloakUserId
     END
   AND CASE
-    WHEN :userId::UUID IS NULL THEN
+    WHEN :authContextKeycloakUserId::UUID IS NULL THEN
       true
     ELSE
       (
-        keycloak_user_id = :userId
-        OR :isAdministrator::boolean
+        keycloak_user_id = :authContextKeycloakUserId
+        OR :authContextIsAdministrator::boolean
       )
     END
 GROUP BY keycloak_user_id

--- a/src/handlers/bulkUploadsHandlers.ts
+++ b/src/handlers/bulkUploadsHandlers.ts
@@ -45,7 +45,7 @@ const postBulkUpload = (
 	}
 
 	const { sourceId, fileName, sourceKey } = req.body;
-	const createdBy = req.user.id;
+	const createdBy = req.user.keycloakUserId;
 
 	if (!sourceKey.startsWith(`${S3_UNPROCESSED_KEY_PREFIX}/`)) {
 		throw new InputValidationError(

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -131,7 +131,7 @@ const postProposalVersion = (
 	}
 
 	const { sourceId, fieldValues, proposalId, applicationFormId } = req.body;
-	const createdBy = req.user.id;
+	const createdBy = req.user.keycloakUserId;
 
 	Promise.all([
 		assertApplicationFormExistsForProposal(

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -102,7 +102,7 @@ const postProposal = (
 	}
 
 	const { externalId, opportunityId } = req.body;
-	const createdBy = req.user.id;
+	const createdBy = req.user.keycloakUserId;
 
 	createProposal({
 		opportunityId,

--- a/src/middleware/__tests__/requireAdministratorRole.int.test.ts
+++ b/src/middleware/__tests__/requireAdministratorRole.int.test.ts
@@ -6,7 +6,6 @@ import type { Request as JWTRequest } from 'express-jwt';
 import type { User } from '../../types';
 
 const getMockedUser = (): User => ({
-	id: 1,
 	keycloakUserId: getTestUserKeycloakUserId(),
 	createdAt: '',
 });

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for organizations seeking grants.",
-		"version": "0.13.0",
+		"version": "0.14.0",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"
@@ -74,8 +74,8 @@
 				"schema": {
 					"oneOf": [
 						{
-							"type": "integer",
-							"minimum": 1,
+							"type": "string",
+							"format": "uuid",
 							"nullable": true
 						},
 						{
@@ -86,7 +86,7 @@
 				"in": "query",
 				"name": "createdBy",
 				"required": false,
-				"description": "A reference (ID) to a user entity, or 'me'."
+				"description": "A reference to a user entity, or 'me'."
 			}
 		},
 		"securitySchemes": {
@@ -153,8 +153,9 @@
 						]
 					},
 					"createdBy": {
-						"description": "The id of the PDC user that created this bulk upload",
-						"type": "integer",
+						"description": "The keycloak user id of the PDC user that created this bulk upload",
+						"type": "string",
+						"format": "uuid",
 						"readOnly": true
 					},
 					"createdAt": {
@@ -357,8 +358,9 @@
 						"readOnly": true
 					},
 					"createdBy": {
-						"description": "The id of the PDC user that created this proposal",
-						"type": "integer",
+						"description": "The keycloak user id of the PDC user that created this proposal",
+						"type": "string",
+						"format": "uuid",
 						"readOnly": true
 					}
 				},
@@ -411,8 +413,9 @@
 						"readOnly": true
 					},
 					"createdBy": {
-						"description": "The id of the PDC user that created this bulk upload",
-						"type": "integer",
+						"description": "The keycloak user id of the PDC user that created this bulk upload",
+						"type": "string",
+						"format": "uuid",
 						"readOnly": true
 					}
 				},
@@ -947,11 +950,6 @@
 			"User": {
 				"type": "object",
 				"properties": {
-					"id": {
-						"type": "integer",
-						"readOnly": true,
-						"example": 3407
-					},
 					"keycloakUserId": {
 						"type": "string",
 						"example": "550e8400-e29b-41d4-a716-446655440000"
@@ -962,7 +960,7 @@
 						"readOnly": true
 					}
 				},
-				"required": ["id", "keycloakUserId", "createdAt"]
+				"required": ["keycloakUserId", "createdAt"]
 			},
 			"UserBundle": {
 				"allOf": [

--- a/src/queryParameters/__tests__/extractCreatedByParameters.int.test.ts
+++ b/src/queryParameters/__tests__/extractCreatedByParameters.int.test.ts
@@ -12,14 +12,14 @@ describe('extractCreatedByParameters', () => {
 		});
 	});
 
-	it('should pass along the numeric value when one is provided', () => {
+	it('should pass along the uuid value when one is provided', () => {
 		const paginationParameters = extractCreatedByParameters({
 			query: {
-				createdBy: '42',
+				createdBy: '12345678-1234-1234-1234-123456789012',
 			},
 		});
 		expect(paginationParameters).toEqual({
-			createdBy: 42,
+			createdBy: '12345678-1234-1234-1234-123456789012',
 		});
 	});
 
@@ -39,35 +39,15 @@ describe('extractCreatedByParameters', () => {
 			user: testUser,
 		});
 		expect(createdByParameters).toEqual({
-			createdBy: testUser.id,
+			createdBy: testUser.keycloakUserId,
 		});
 	});
 
-	it('should throw an error when strings that parse to NaN are provided', () => {
+	it('should throw an error when a non-uuid is provided', () => {
 		expect(() =>
 			extractCreatedByParameters({
 				query: {
-					createdBy: 'forty two',
-				},
-			}),
-		).toThrow(InputValidationError);
-	});
-
-	it('should throw an error when strings that parse to floats are provided', () => {
-		expect(() =>
-			extractCreatedByParameters({
-				query: {
-					createdBy: '42.6',
-				},
-			}),
-		).toThrow(InputValidationError);
-	});
-
-	it('should throw an error when strings that parse to numbers less than 1 are provided', () => {
-		expect(() =>
-			extractCreatedByParameters({
-				query: {
-					createdBy: '0',
+					createdBy: 'this is not a UUID',
 				},
 			}),
 		).toThrow(InputValidationError);

--- a/src/queryParameters/extractCreatedByParameters.ts
+++ b/src/queryParameters/extractCreatedByParameters.ts
@@ -1,15 +1,16 @@
 import { ajv } from '../ajv';
 import { InputValidationError } from '../errors';
+import { keycloakUserIdSchema } from '../types';
 import type { JSONSchemaType } from 'ajv';
 import type { Request } from 'express';
-import type { AuthContext } from '../types';
+import type { KeycloakUserId, AuthContext } from '../types';
 
 interface CreatedByQueryParameters {
-	createdBy: number | 'me' | undefined;
+	createdBy: KeycloakUserId | 'me' | undefined;
 }
 
 interface CreatedByParameters {
-	createdBy: number | undefined;
+	createdBy: KeycloakUserId | undefined;
 }
 
 const createdByQueryParametersSchema: JSONSchemaType<CreatedByQueryParameters> =
@@ -19,8 +20,7 @@ const createdByQueryParametersSchema: JSONSchemaType<CreatedByQueryParameters> =
 				type: 'object',
 				properties: {
 					createdBy: {
-						type: 'integer',
-						minimum: 1,
+						...keycloakUserIdSchema,
 						nullable: true,
 					},
 				},
@@ -54,7 +54,7 @@ const extractCreatedByParameters = (
 	}
 
 	const createdBy =
-		query.createdBy === 'me' ? request.user?.id : query.createdBy;
+		query.createdBy === 'me' ? request.user?.keycloakUserId : query.createdBy;
 
 	return {
 		createdBy,

--- a/src/tasks/__tests__/processBulkUpload.int.test.ts
+++ b/src/tasks/__tests__/processBulkUpload.int.test.ts
@@ -58,7 +58,7 @@ const createTestBulkUpload = async (
 		sourceId: systemSource.id,
 		sourceKey: TEST_UNPROCESSED_SOURCE_KEY,
 		status: BulkUploadStatus.PENDING,
-		createdBy: systemUser.id,
+		createdBy: systemUser.keycloakUserId,
 	};
 	return createBulkUpload({
 		...defaultValues,
@@ -337,7 +337,7 @@ describe('processBulkUpload', () => {
 		const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
 		const bulkUpload = await createTestBulkUpload({
 			sourceKey,
-			createdBy: systemUser.id,
+			createdBy: systemUser.keycloakUserId,
 		});
 		const requests = await mockS3ResponsesForBulkUploadProcessing(
 			bulkUpload,
@@ -383,7 +383,7 @@ describe('processBulkUpload', () => {
 			entries: [
 				{
 					createdAt: expectTimestamp,
-					createdBy: 1,
+					createdBy: systemUser.keycloakUserId,
 					externalId: '2',
 					id: 2,
 					opportunityId: 1,
@@ -391,7 +391,7 @@ describe('processBulkUpload', () => {
 						{
 							applicationFormId: 1,
 							createdAt: expectTimestamp,
-							createdBy: systemUser.id,
+							createdBy: systemUser.keycloakUserId,
 							fieldValues: [
 								{
 									applicationFormField: {
@@ -459,7 +459,7 @@ describe('processBulkUpload', () => {
 				},
 				{
 					createdAt: expectTimestamp,
-					createdBy: 1,
+					createdBy: systemUser.keycloakUserId,
 					externalId: '1',
 					id: 1,
 					opportunityId: 1,
@@ -467,7 +467,7 @@ describe('processBulkUpload', () => {
 						{
 							applicationFormId: 1,
 							createdAt: expectTimestamp,
-							createdBy: systemUser.id,
+							createdBy: systemUser.keycloakUserId,
 							fieldValues: [
 								{
 									applicationFormField: {

--- a/src/types/BulkUpload.ts
+++ b/src/types/BulkUpload.ts
@@ -2,6 +2,7 @@ import { ajv } from '../ajv';
 import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
 import type { Source } from './Source';
+import type { KeycloakUserId } from './KeycloakUserId';
 
 enum BulkUploadStatus {
 	PENDING = 'pending',
@@ -20,7 +21,7 @@ interface BulkUpload {
 	readonly status: BulkUploadStatus;
 	readonly fileSize?: number | null; // see https://github.com/ajv-validator/ajv/issues/2163
 	readonly createdAt: string;
-	readonly createdBy: number;
+	readonly createdBy: KeycloakUserId;
 }
 
 type WritableBulkUpload = Writable<BulkUpload>;

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -2,6 +2,7 @@ import { ajv } from '../ajv';
 import type { JSONSchemaType } from 'ajv';
 import type { ProposalVersion } from './ProposalVersion';
 import type { Writable } from './Writable';
+import type { KeycloakUserId } from './KeycloakUserId';
 
 interface Proposal {
 	readonly id: number;
@@ -9,7 +10,7 @@ interface Proposal {
 	externalId: string;
 	readonly versions: ProposalVersion[];
 	readonly createdAt: string;
-	readonly createdBy: number;
+	readonly createdBy: KeycloakUserId;
 }
 
 type WritableProposal = Writable<Proposal>;

--- a/src/types/ProposalVersion.ts
+++ b/src/types/ProposalVersion.ts
@@ -7,6 +7,7 @@ import type {
 } from './ProposalFieldValue';
 import type { Writable } from './Writable';
 import type { Source } from './Source';
+import type { KeycloakUserId } from './KeycloakUserId';
 
 interface ProposalVersion {
 	readonly id: number;
@@ -17,7 +18,7 @@ interface ProposalVersion {
 	applicationFormId: number;
 	readonly fieldValues: ProposalFieldValue[];
 	readonly createdAt: string;
-	readonly createdBy: number;
+	readonly createdBy: KeycloakUserId;
 }
 
 type WritableProposalVersion = Writable<ProposalVersion>;

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -4,7 +4,6 @@ import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
 
 interface User {
-	readonly id: number;
 	keycloakUserId: KeycloakUserId;
 	readonly createdAt: string;
 }
@@ -12,15 +11,12 @@ interface User {
 const userSchema: JSONSchemaType<User> = {
 	type: 'object',
 	properties: {
-		id: {
-			type: 'number',
-		},
 		keycloakUserId: keycloakUserIdSchema,
 		createdAt: {
 			type: 'string',
 		},
 	},
-	required: ['id', 'keycloakUserId', 'createdAt'],
+	required: ['keycloakUserId', 'createdAt'],
 };
 
 type WritableUser = Writable<User>;


### PR DESCRIPTION
This PR updates the `users` table to use `keycloakUserId` as the primary key along with any foreign key relationships with other entities.

This change prompted an immediate improvement to the clarity  names of a few authentication-related query parameters.

Resolves #1155