### PR TITLE
Add `userChangemakerPermission` endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgraded to use OpenAPI Specification 3.1.
 
-## 0.17.0 2024-11-07
+## 0.16.2 2024-11-12
+
+### Fixed
+
+- `User` type had an inaccurate specification regarding permission attributes.
+
+## 0.16.1 2024-11-07
 
 ### Changed
 

--- a/src/__tests__/userChangemakerPermissions.int.test.ts
+++ b/src/__tests__/userChangemakerPermissions.int.test.ts
@@ -1,0 +1,156 @@
+import request from 'supertest';
+import { app } from '../app';
+import {
+	createChangemaker,
+	createOrUpdateUserChangemakerPermission,
+	loadSystemUser,
+} from '../database';
+import { expectTimestamp, loadTestUser } from '../test/utils';
+import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
+} from '../test/mockJwt';
+import { keycloakUserIdToString, Permission } from '../types';
+
+describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
+	describe('PUT /', () => {
+		it('returns 401 if the request lacks authentication', async () => {
+			const user = await loadTestUser();
+			const changemaker = await createChangemaker({
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+			});
+			await request(app)
+				.put(
+					`/users/${keycloakUserIdToString(user.keycloakUserId)}/changemakers/${changemaker.id}/permissions/${Permission.MANAGE}`,
+				)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 401 if the authenticated user lacks permission', async () => {
+			const user = await loadTestUser();
+			const changemaker = await createChangemaker({
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+			});
+			await request(app)
+				.put(
+					`/users/${keycloakUserIdToString(user.keycloakUserId)}/changemakers/${changemaker.id}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 400 if the userId is not a valid keycloak user ID', async () => {
+			await request(app)
+				.put(`/users/notaguid/changemakers/1/permissions/${Permission.MANAGE}`)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the changemaker ID is not a valid ID', async () => {
+			const user = await loadTestUser();
+			await request(app)
+				.put(
+					`/users/${keycloakUserIdToString(user.keycloakUserId)}/changemakers/notanId/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the permission is not a valid permission', async () => {
+			const user = await loadTestUser();
+			await request(app)
+				.put(
+					`/users/${keycloakUserIdToString(user.keycloakUserId)}/changemakers/1/permissions/notAPermission`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('creates and returns the new user changemaker permission when user has administrative credentials', async () => {
+			const user = await loadTestUser();
+			const changemaker = await createChangemaker({
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+			});
+
+			const response = await request(app)
+				.put(
+					`/users/${keycloakUserIdToString(user.keycloakUserId)}/changemakers/${changemaker.id}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				changemakerId: changemaker.id,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+		});
+
+		it('creates and returns the new user changemaker permission when user has permission to manage the changemaker', async () => {
+			const user = await loadTestUser();
+			const changemaker = await createChangemaker({
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+			});
+			await createOrUpdateUserChangemakerPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				changemakerId: changemaker.id,
+				permission: Permission.MANAGE,
+				createdBy: user.keycloakUserId,
+			});
+			const response = await request(app)
+				.put(
+					`/users/${keycloakUserIdToString(user.keycloakUserId)}/changemakers/${changemaker.id}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				changemakerId: changemaker.id,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+		});
+
+		it('does not update `createdBy`, but returns the user changemaker permission when user has permission to manage the changemaker', async () => {
+			const user = await loadTestUser();
+			const systemUser = await loadSystemUser();
+			const changemaker = await createChangemaker({
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+			});
+			await createOrUpdateUserChangemakerPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				changemakerId: changemaker.id,
+				permission: Permission.MANAGE,
+				createdBy: systemUser.keycloakUserId,
+			});
+			const response = await request(app)
+				.put(
+					`/users/${keycloakUserIdToString(user.keycloakUserId)}/changemakers/${changemaker.id}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				changemakerId: changemaker.id,
+				createdAt: expectTimestamp,
+				createdBy: systemUser.keycloakUserId,
+				permission: Permission.MANAGE,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+		});
+	});
+});

--- a/src/database/queries/userChangemakerPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userChangemakerPermissions/insertOrUpdateOne.sql
@@ -9,6 +9,7 @@ INSERT INTO user_changemaker_permissions (
   :changemakerId,
   :createdBy
 )
-ON CONFLICT (user_keycloak_user_id, permission, changemaker_id)
-DO NOTHING
+ON CONFLICT (user_keycloak_user_id, permission, changemaker_id) DO UPDATE
+  -- We have to do an update in order to return the row, even though this update is pointless
+  SET user_keycloak_user_id = EXCLUDED.user_keycloak_user_id
 RETURNING user_changemaker_permission_to_json(user_changemaker_permissions) AS "object";

--- a/src/handlers/userChangemakerPermissionsHandlers.ts
+++ b/src/handlers/userChangemakerPermissionsHandlers.ts
@@ -1,0 +1,92 @@
+import { createOrUpdateUserChangemakerPermission } from '../database';
+import {
+	isAuthContext,
+	isId,
+	isKeycloakUserId,
+	isPermission,
+	isTinyPgErrorWithQueryContext,
+	isWritableUserChangemakerPermission,
+} from '../types';
+import {
+	DatabaseError,
+	FailedMiddlewareError,
+	InputValidationError,
+} from '../errors';
+import type { Request, Response, NextFunction } from 'express';
+
+const putUserChangemakerPermission = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
+
+	const { userKeycloakUserId, changemakerId, permission } = req.params;
+	const createdBy = req.user.keycloakUserId;
+
+	if (!isKeycloakUserId(userKeycloakUserId)) {
+		next(
+			new InputValidationError(
+				'Invalid userKeycloakUserId parameter.',
+				isKeycloakUserId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isId(changemakerId)) {
+		next(
+			new InputValidationError(
+				'Invalid changemakerId parameter.',
+				isId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isPermission(permission)) {
+		next(
+			new InputValidationError(
+				'Invalid permission parameter.',
+				isPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isWritableUserChangemakerPermission(req.body)) {
+		next(
+			new InputValidationError(
+				'Invalid request body.',
+				isWritableUserChangemakerPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+
+	(async () => {
+		const userChangemakerPermission =
+			await createOrUpdateUserChangemakerPermission({
+				userKeycloakUserId,
+				changemakerId,
+				permission,
+				createdBy,
+			});
+		res
+			.status(201)
+			.contentType('application/json')
+			.send(userChangemakerPermission);
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error creating item.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const userChangemakerPermissionsHandlers = {
+	putUserChangemakerPermission,
+};
+
+export { userChangemakerPermissionsHandlers };

--- a/src/middleware/__tests__/requireAdministratorRole.int.test.ts
+++ b/src/middleware/__tests__/requireAdministratorRole.int.test.ts
@@ -8,6 +8,11 @@ import type { User } from '../../types';
 const getMockedUser = (): User => ({
 	keycloakUserId: getTestUserKeycloakUserId(),
 	createdAt: '',
+	permissions: {
+		changemaker: {},
+		dataProvider: {},
+		funder: {},
+	},
 });
 
 describe('requireAuthentication', () => {

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -4,3 +4,4 @@ export * from './errorHandler';
 export * from './processJwt';
 export * from './requireAdministratorRole';
 export * from './requireAuthentication';
+export * from './requireChangemakerPermission';

--- a/src/middleware/requireChangemakerPermission.ts
+++ b/src/middleware/requireChangemakerPermission.ts
@@ -1,0 +1,52 @@
+/**
+ * Middleware to require a specific changemaker permission for a request.
+ *
+ * @param {Permission} permission - The required permission to check for.
+ * @returns {Function} Middleware function to validate the changemaker permission.
+ *
+ * The middleware does the following:
+ * 1. Ensures the request contains an AuthContext.
+ * 2. Allows the request to proceed if the user is an administrator.
+ * 3. Validates the `changemakerId` parameter in the request.
+ * 4. Checks if the authenticated user has the required permission for the specified changemaker.
+ *
+ * If any of the checks fail, the middleware will pass an appropriate error to the next middleware.
+ */
+import { Response, NextFunction } from 'express';
+import { InputValidationError, UnauthorizedError } from '../errors';
+import { isAuthContext, isId } from '../types';
+import type { Permission } from '../types';
+import type { Request } from 'express';
+
+const requireChangemakerPermission =
+	(permission: Permission) =>
+	(req: Request, res: Response, next: NextFunction) => {
+		if (!isAuthContext(req)) {
+			next(new UnauthorizedError('The request lacks an AuthContext.'));
+			return;
+		}
+		if (req.role?.isAdministrator === true) {
+			next();
+			return;
+		}
+		const { changemakerId } = req.params;
+		if (!isId(changemakerId)) {
+			next(
+				new InputValidationError('Invalid changemakerId.', isId.errors ?? []),
+			);
+			return;
+		}
+		const { user } = req;
+		const permissions = user.permissions.changemaker[changemakerId] ?? [];
+		if (!permissions.includes(permission)) {
+			next(
+				new UnauthorizedError(
+					'Authenticated user does not have permission to perform this action.',
+				),
+			);
+			return;
+		}
+		next();
+	};
+
+export { requireChangemakerPermission };

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.16.1",
+		"version": "0.16.2",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"
@@ -1077,26 +1077,35 @@
 						"type": "string",
 						"example": "550e8400-e29b-41d4-a716-446655440000"
 					},
-					"roles": {
+					"permissions": {
 						"type": "object",
 						"readOnly": true,
 						"properties": {
 							"changemaker": {
 								"type": "object",
 								"additionalProperties": {
-									"$ref": "#/components/schemas/RoleMap"
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Permission"
+									}
 								}
 							},
 							"dataProvider": {
 								"type": "object",
 								"additionalProperties": {
-									"$ref": "#/components/schemas/RoleMap"
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Permission"
+									}
 								}
 							},
 							"funder": {
 								"type": "object",
 								"additionalProperties": {
-									"$ref": "#/components/schemas/RoleMap"
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Permission"
+									}
 								}
 							}
 						},

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1137,6 +1137,35 @@
 						"required": ["entries"]
 					}
 				]
+			},
+			"UserChangemakerPermission": {
+				"type": "object",
+				"properties": {
+					"permission": {
+						"$ref": "#/components/schemas/Permission",
+						"readOnly": true
+					},
+					"changemakerId": {
+						"type": "integer",
+						"readOnly": true
+					},
+					"userKeycloakUserId": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdBy": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"readOnly": true
+					}
+				},
+				"required": ["id", "", "createdAt"]
 			}
 		}
 	},
@@ -2624,6 +2653,61 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/UserBundle"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/users/{userKeycloakUserId}/changemakers/{changemakerId}/permissions/{permission}": {
+			"put": {
+				"operationId": "createOrUpdateUserChangemakerPermission",
+				"summary": "Creates or updates a user-changemaker permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "userKeycloakUserId",
+						"description": "The keycloak user id of a user.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "changemakerId",
+						"description": "The id of a changemaker.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be granted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "The resulting permission.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UserChangemakerPermission"
 								}
 							}
 						}

--- a/src/routers/usersRouter.ts
+++ b/src/routers/usersRouter.ts
@@ -1,9 +1,19 @@
 import express from 'express';
+import { userChangemakerPermissionsHandlers } from '../handlers/userChangemakerPermissionsHandlers';
 import { usersHandlers } from '../handlers/usersHandlers';
-import { requireAuthentication } from '../middleware';
+import {
+	requireAuthentication,
+	requireChangemakerPermission,
+} from '../middleware';
+import { Permission } from '../types';
 
 const usersRouter = express.Router();
 
 usersRouter.get('/', requireAuthentication, usersHandlers.getUsers);
+usersRouter.put(
+	'/:userKeycloakUserId/changemakers/:changemakerId/permissions/:permission',
+	requireChangemakerPermission(Permission.MANAGE),
+	userChangemakerPermissionsHandlers.putUserChangemakerPermission,
+);
 
 export { usersRouter };

--- a/src/types/Permission.ts
+++ b/src/types/Permission.ts
@@ -1,7 +1,17 @@
+import { ajv } from '../ajv';
+import type { JSONSchemaType } from 'ajv';
+
 enum Permission {
 	MANAGE = 'manage',
 	EDIT = 'edit',
 	VIEW = 'view',
 }
 
-export { Permission };
+const permissionSchema: JSONSchemaType<Permission> = {
+	type: 'string',
+	enum: Object.values(Permission),
+};
+
+const isPermission = ajv.compile(permissionSchema);
+
+export { Permission, permissionSchema, isPermission };

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,10 +1,17 @@
 import { keycloakUserIdSchema } from './KeycloakUserId';
+import { permissionSchema } from './Permission';
 import type { KeycloakUserId } from './KeycloakUserId';
 import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
+import type { Permission } from './Permission';
 
 interface User {
 	keycloakUserId: KeycloakUserId;
+	readonly permissions: {
+		changemaker: Record<string, Permission[]>;
+		dataProvider: Record<string, Permission[]>;
+		funder: Record<string, Permission[]>;
+	};
 	readonly createdAt: string;
 }
 
@@ -12,11 +19,41 @@ const userSchema: JSONSchemaType<User> = {
 	type: 'object',
 	properties: {
 		keycloakUserId: keycloakUserIdSchema,
+		permissions: {
+			type: 'object',
+			properties: {
+				changemaker: {
+					type: 'object',
+					additionalProperties: {
+						type: 'array',
+						items: permissionSchema,
+					},
+					required: [],
+				},
+				dataProvider: {
+					type: 'object',
+					additionalProperties: {
+						type: 'array',
+						items: permissionSchema,
+					},
+					required: [],
+				},
+				funder: {
+					type: 'object',
+					additionalProperties: {
+						type: 'array',
+						items: permissionSchema,
+					},
+					required: [],
+				},
+			},
+			required: ['changemaker', 'dataProvider', 'funder'],
+		},
 		createdAt: {
 			type: 'string',
 		},
 	},
-	required: ['keycloakUserId', 'createdAt'],
+	required: ['keycloakUserId', 'permissions', 'createdAt'],
 };
 
 type WritableUser = Writable<User>;


### PR DESCRIPTION
This PR adds a set of endpoints for the creation and deletion of changemaker permissions for users.

Similar endpoints need to be added for the dataProvider and funder permissions, but I figure starting here to confirm the pattern makes sense.

This PR also fixes a bug related to the User type as it relates to permissions.

Related to Issue #150