### PR TITLE
Split up lint jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  eslint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,4 +14,31 @@ jobs:
         with:
           node-version: 20.17.0
       - run: npm ci
-      - run: npm run lint
+      - run: npm run lint:eslint
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+      - run: npm ci
+      - run: npm run lint:prettier
+  swagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+      - run: npm ci
+      - run: npm run lint:swagger
+  tsc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+      - run: npm ci
+      - run: npm run lint:tsc


### PR DESCRIPTION
Run each linter in a separate GitHub Actions job, so that what exactly is wrong is more obvious at a glance, and to more easily add additional linters (like #321).

We will need to reconfigure our merge requirements, which are currently expecting the single job `lint`.