### PR TITLE
Log the execution of initialization SQL files

### DIFF
--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs/promises';
 import { TinyPg } from 'tinypg';
+import { getLogger } from '../logger';
 
 const initializationDirectory = path.join(__dirname, 'initialization');
 
@@ -9,6 +10,7 @@ const db = new TinyPg({
 });
 
 const initializeDatabase = async () => {
+	const logger = getLogger('initializeDatabase');
 	const initializationFiles = (
 		await fs.readdir(initializationDirectory)
 	).filter((file) => file.endsWith('.sql'));
@@ -16,6 +18,7 @@ const initializeDatabase = async () => {
 	await Promise.all(
 		initializationFiles.map(async (file) => {
 			const filePath = path.join(initializationDirectory, file);
+			logger.debug({ filePath }, 'Running SQL file');
 			const sql = (await fs.readFile(filePath)).toString();
 			await db.query(sql);
 		}),


### PR DESCRIPTION
While working on SQL linting, I wanted to make sure the initialization files were running as expected. Add a debug-level logging statement for each initialization SQL file.

Example output snippet:

```
[2024-11-23T00:03:43.213Z] DEBUG (2128009): Running SQL file
    source: "initializeDatabase"
    filePath: "src/database/initialization/data_provider_to_json.sql"
```