### PR TITLE
Split test action into two jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  target_node:
+  tests:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -50,6 +50,35 @@ jobs:
           S3_ENDPOINT: https://fake-s3-endpoint
           S3_PATH_STYLE: false
           S3_REGION: fake-s3-region
+
+  coverage:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run build
+        run: npm run build
 
       - name: Run all tests (with coverage)
         run: npm run test:ci


### PR DESCRIPTION
The GitHub Action for running our tests was doing two things: checking that the tests passed, and then generating and uploading a test coverage report.

Unfortunately, our tests are somewhat slow, so running them twice in the same job takes a few minutes. Split them up so they can be run in parallel.

See also https://github.com/PhilanthropyDataCommons/service/pull/1333#issuecomment-2501752011 .

As with that PR, we'll need to update the branch protection rules.