### PR TITLE
Add DELETE endpoint for UserChangemakerPermission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Manage user changemaker permissions using `GET`, `PUT`, and `DELETE` on `/user/{keycloakUserId}/changemakers/{changemakerId}/permissions/{permission}`.
+
 ### Changed
 
 - Upgraded to use OpenAPI Specification 3.1.

--- a/src/database/initialization/user_to_json.sql
+++ b/src/database/initialization/user_to_json.sql
@@ -16,6 +16,7 @@ BEGIN
       SELECT user_changemaker_permissions.changemaker_id, jsonb_agg(user_changemaker_permissions.permission) AS permissions
       FROM user_changemaker_permissions
       WHERE user_changemaker_permissions.user_keycloak_user_id = "user".keycloak_user_id
+        AND NOT is_expired(user_changemaker_permissions.not_after)
       GROUP BY user_changemaker_permissions.changemaker_id
     ) AS aggregated_user_changemaker_permissions
   );
@@ -28,6 +29,7 @@ BEGIN
       SELECT user_data_provider_permissions.data_provider_short_code, jsonb_agg(user_data_provider_permissions.permission) AS permissions
       FROM user_data_provider_permissions
       WHERE user_data_provider_permissions.user_keycloak_user_id = "user".keycloak_user_id
+        AND NOT is_expired(user_data_provider_permissions.not_after)
       GROUP BY user_data_provider_permissions.data_provider_short_code
     ) AS aggregated_user_data_provider_permissions );
 
@@ -39,6 +41,7 @@ BEGIN
       SELECT user_funder_permissions.funder_short_code, jsonb_agg(user_funder_permissions.permission) AS permissions
       FROM user_funder_permissions
       WHERE user_funder_permissions.user_keycloak_user_id = "user".keycloak_user_id
+        AND NOT is_expired(user_funder_permissions.not_after)
       GROUP BY user_funder_permissions.funder_short_code
     ) AS aggregated_user_funder_permissions
   );

--- a/src/database/migrations/0042-alter-permission-tables-add-not_after.sql
+++ b/src/database/migrations/0042-alter-permission-tables-add-not_after.sql
@@ -1,0 +1,15 @@
+ALTER TABLE user_changemaker_permissions
+  ADD COLUMN not_after timestamp with time zone DEFAULT NULL;
+ALTER TABLE user_funder_permissions
+  ADD COLUMN not_after timestamp with time zone DEFAULT NULL;
+ALTER TABLE user_data_provider_permissions
+  ADD COLUMN not_after timestamp with time zone DEFAULT NULL;
+
+CREATE OR REPLACE FUNCTION is_expired(
+  not_after timestamp with time zone DEFAULT NULL
+)
+RETURNS boolean AS $$
+BEGIN
+  RETURN NOT not_after IS NULL AND not_after < NOW();
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/operations/userChangemakerPermissions/assertUserChangemakerPermissionExists.ts
+++ b/src/database/operations/userChangemakerPermissions/assertUserChangemakerPermissionExists.ts
@@ -1,0 +1,37 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import { keycloakUserIdToString } from '../../../types';
+import type {
+	CheckResult,
+	Id,
+	KeycloakUserId,
+	Permission,
+} from '../../../types';
+
+const assertUserChangemakerPermissionExists = async (
+	userKeycloakUserId: KeycloakUserId,
+	changemakerId: Id,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql<CheckResult>(
+		'userChangemakerPermissions.checkExistsByPrimaryKey',
+		{
+			userKeycloakUserId,
+			changemakerId,
+			permission,
+		},
+	);
+
+	if (result.rows[0]?.result !== true) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'UserChangemakerPermission',
+			entityPrimaryKey: {
+				userKeycloakUserId: keycloakUserIdToString(userKeycloakUserId),
+				changemakerId,
+				permission,
+			},
+		});
+	}
+};
+
+export { assertUserChangemakerPermissionExists };

--- a/src/database/operations/userChangemakerPermissions/index.ts
+++ b/src/database/operations/userChangemakerPermissions/index.ts
@@ -1,1 +1,4 @@
+export * from './assertUserChangemakerPermissionExists';
 export * from './createOrUpdateUserChangemakerPermission';
+export * from './loadUserChangemakerPermission';
+export * from './removeUserChangemakerPermission';

--- a/src/database/operations/userChangemakerPermissions/loadUserChangemakerPermission.ts
+++ b/src/database/operations/userChangemakerPermissions/loadUserChangemakerPermission.ts
@@ -1,0 +1,37 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import {
+	keycloakUserIdToString,
+	type Id,
+	type JsonResultSet,
+	type KeycloakUserId,
+	type Permission,
+	type UserChangemakerPermission,
+} from '../../../types';
+
+export const loadUserChangemakerPermission = async (
+	userKeycloakUserId: KeycloakUserId,
+	changemakerId: Id,
+	permission: Permission,
+): Promise<UserChangemakerPermission> => {
+	const result = await db.sql<JsonResultSet<UserChangemakerPermission>>(
+		'userChangemakerPermissions.selectByPrimaryKey',
+		{
+			userKeycloakUserId,
+			changemakerId,
+			permission,
+		},
+	);
+	const object = result.rows[0]?.object;
+	if (object === undefined) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'UserchangemakerPermission',
+			entityPrimaryKey: {
+				userKeycloakUserId: keycloakUserIdToString(userKeycloakUserId),
+				changemakerId,
+				permission,
+			},
+		});
+	}
+	return object;
+};

--- a/src/database/operations/userChangemakerPermissions/removeUserChangemakerPermission.ts
+++ b/src/database/operations/userChangemakerPermissions/removeUserChangemakerPermission.ts
@@ -1,0 +1,32 @@
+import { NotFoundError } from '../../../errors';
+import { keycloakUserIdToString } from '../../../types';
+import { db } from '../../db';
+import type { KeycloakUserId, Permission } from '../../../types';
+
+const removeUserChangemakerPermission = async (
+	userKeycloakUserId: KeycloakUserId,
+	changemakerId: number,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql('userChangemakerPermissions.deleteOne', {
+		userKeycloakUserId,
+		permission,
+		changemakerId,
+	});
+
+	if (result.row_count === 0) {
+		throw new NotFoundError(
+			'The item did not exist and could not be deleted.',
+			{
+				entityType: 'UserChangemakerPermission',
+				entityPrimaryKey: {
+					userKeycloakUserId: keycloakUserIdToString(userKeycloakUserId),
+					permission,
+					changemakerId,
+				},
+			},
+		);
+	}
+};
+
+export { removeUserChangemakerPermission };

--- a/src/database/queries/userChangemakerPermissions/checkExistsByPrimaryKey.sql
+++ b/src/database/queries/userChangemakerPermissions/checkExistsByPrimaryKey.sql
@@ -1,0 +1,8 @@
+SELECT exists(
+  SELECT 1
+    FROM user_changemaker_permissions
+    WHERE user_keycloak_user_id = :userKeycloakUserId
+      AND changemaker_id = :changemakerId
+        AND permission = :permission
+        AND NOT is_expired(not_after)
+) AS result;

--- a/src/database/queries/userChangemakerPermissions/deleteOne.sql
+++ b/src/database/queries/userChangemakerPermissions/deleteOne.sql
@@ -1,0 +1,6 @@
+UPDATE user_changemaker_permissions
+  SET not_after = now()
+  WHERE user_keycloak_user_id = :userKeycloakUserId
+  AND permission = :permission::permission_t
+  AND changemaker_id = :changemakerId
+  AND NOT is_expired(not_after);

--- a/src/database/queries/userChangemakerPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userChangemakerPermissions/insertOrUpdateOne.sql
@@ -2,16 +2,16 @@ INSERT INTO user_changemaker_permissions (
   user_keycloak_user_id,
   permission,
   changemaker_id,
-  created_by
+  created_by,
+  not_after
 ) VALUES (
   :userKeycloakUserId,
   :permission::permission_t,
   :changemakerId,
-  :createdBy
+  :createdBy,
+  null
 )
--- We have to do an update in order to return the row,
--- even though this update is pointless
 ON CONFLICT (user_keycloak_user_id, permission, changemaker_id) DO UPDATE
-  SET user_keycloak_user_id = excluded.user_keycloak_user_id
+  SET not_after = null
 RETURNING user_changemaker_permission_to_json(user_changemaker_permissions)
   AS object;

--- a/src/database/queries/userChangemakerPermissions/selectByPrimaryKey.sql
+++ b/src/database/queries/userChangemakerPermissions/selectByPrimaryKey.sql
@@ -1,0 +1,8 @@
+SELECT user_changemaker_permission_to_json(
+  user_changemaker_permissions.*
+) AS object
+FROM user_changemaker_permissions
+WHERE user_keycloak_user_id = :userKeycloakUserId
+  AND changemaker_id = :changemakerId
+  AND permission = :permission
+  AND NOT is_expired(not_after);

--- a/src/database/queries/userDataProviderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userDataProviderPermissions/insertOrUpdateOne.sql
@@ -2,14 +2,18 @@ INSERT INTO user_data_provider_permissions (
   user_keycloak_user_id,
   permission,
   data_provider_short_code,
-  created_by
+  created_by,
+  not_after
 ) VALUES (
   :userKeycloakUserId,
   :permission::permission_t,
   :dataProviderShortCode,
-  :createdBy
+  :createdBy,
+  null
 )
-ON CONFLICT (user_keycloak_user_id, permission, data_provider_short_code)
-DO NOTHING
+ON CONFLICT (
+  user_keycloak_user_id, permission, data_provider_short_code
+) DO UPDATE
+  SET not_after = null
 RETURNING user_data_provider_permission_to_json(user_data_provider_permissions)
   AS object;

--- a/src/database/queries/userFunderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userFunderPermissions/insertOrUpdateOne.sql
@@ -2,13 +2,15 @@ INSERT INTO user_funder_permissions (
   user_keycloak_user_id,
   permission,
   funder_short_code,
-  created_by
+  created_by,
+  not_after
 ) VALUES (
   :userKeycloakUserId,
   :permission::permission_t,
   :funderShortCode,
-  :createdBy
+  :createdBy,
+  NULL
 )
-ON CONFLICT (user_keycloak_user_id, permission, funder_short_code)
-DO NOTHING
+ON CONFLICT (user_keycloak_user_id, permission, funder_short_code) DO UPDATE
+  SET not_after = NULL
 RETURNING user_funder_permission_to_json(user_funder_permissions) AS object;

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -2766,6 +2766,52 @@
 						}
 					}
 				}
+			},
+			"delete": {
+				"operationId": "deleteUserChangemakerPermission",
+				"summary": "Deletes a user-changemaker permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "userKeycloakUserId",
+						"description": "The keycloak user id of a user.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "changemakerId",
+						"description": "The id of a changemaker.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be deleted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Confirmation of successful deletion."
+					}
+				}
 			}
 		}
 	}

--- a/src/routers/usersRouter.ts
+++ b/src/routers/usersRouter.ts
@@ -15,5 +15,10 @@ usersRouter.put(
 	requireChangemakerPermission(Permission.MANAGE),
 	userChangemakerPermissionsHandlers.putUserChangemakerPermission,
 );
+usersRouter.delete(
+	'/:userKeycloakUserId/changemakers/:changemakerId/permissions/:permission',
+	requireChangemakerPermission(Permission.MANAGE),
+	userChangemakerPermissionsHandlers.deleteUserChangemakerPermission,
+);
 
 export { usersRouter };


### PR DESCRIPTION
This PR adds the ability to `DELETE` various permissions.

Related to #1351