### PR TITLE
Run our tests against Node.js 20, 22, and 23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: [20, 22, 23]
     services:
       postgres:
         image: postgres
@@ -27,7 +30,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.17.0
+          node-version: ${{ matrix.node_version }}
 
       - name: Install dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 	},
 	"homepage": "https://github.com/PhilanthropyDataCommons/pdc#readme",
 	"engines": {
-		"node": "20"
+		"node": ">=20",
+		"npm": ">=10.8"
 	},
 	"type": "commonjs",
 	"devDependencies": {


### PR DESCRIPTION
We are currently targeting Node.js 20, which is in maintenance LTS. 22 is the active LTS, and 23 is for current development.

Run our tests against all of these, so that we can be ready for new versions.