### PR TITLE
Pin @typescript-eslint dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@typescript-eslint/eslint-plugin'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@typescript-eslint/parser'
+        update-types: ['version-update:semver-major']
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
Configure ignore rules to prevent @dependabot from attempting to upgrade `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` to v8, because `eslint-config-airbnb-typescript` still depends on v7.

Issue https://github.com/PhilanthropyDataCommons/meta/issues/153
Closes #1361