### PR TITLE
Test against current Node.js weekly

### DIFF
--- a/.github/workflows/test-current-node.yml
+++ b/.github/workflows/test-current-node.yml
@@ -1,0 +1,53 @@
+name: Test on current Node.js
+
+on:
+  schedule:
+    - cron: '00 00 * * 1'
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: current
+          check-latest: true
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run build
+        run: npm run build
+
+      - name: Run all tests (without coverage)
+        run: npm run test:ci -- --coverage=false
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          AUTH_SERVER_ISSUER: https://totally-fake-server-name/realms/pdc
+          OPENAPI_DOCS_AUTH_CLIENT_ID: pdc-fake-client-id
+          S3_ACCESS_KEY_ID: fake-access-key-id
+          S3_ACCESS_SECRET: fake-access-key-secret
+          S3_BUCKET: fake-s3-bucket
+          S3_ENDPOINT: https://fake-s3-endpoint
+          S3_PATH_STYLE: false
+          S3_REGION: fake-s3-region


### PR DESCRIPTION
Add a scheduled task to run against the [current](https://github.com/actions/setup-node/blob/39370e3970a6d050c480ffad4ff0ed4d3fdee5af/README.md#supported-version-syntax) version of Node.js, so that we can be aware of upcoming breaking changes.

Resolves #1367 Testing against "Current" node