### PR TITLE
Improve Writable utility type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-import": "^2.31.0",
 				"eslint-plugin-sort-exports": "^0.9.1",
+				"expect-type": "^1.1.0",
 				"jest": "^28.1.1",
 				"jsonwebtoken": "^9.0.2",
 				"mock-jwks": "^1.0.10",
@@ -5416,6 +5417,16 @@
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+			"integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/express": {
@@ -14763,6 +14774,12 @@
 				"jest-message-util": "^28.1.3",
 				"jest-util": "^28.1.3"
 			}
+		},
+		"expect-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+			"integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+			"dev": true
 		},
 		"express": {
 			"version": "4.21.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-import": "^2.31.0",
 		"eslint-plugin-sort-exports": "^0.9.1",
+		"expect-type": "^1.1.0",
 		"jest": "^28.1.1",
 		"jsonwebtoken": "^9.0.2",
 		"mock-jwks": "^1.0.10",

--- a/src/types/__tests__/Writable.unit.test.ts
+++ b/src/types/__tests__/Writable.unit.test.ts
@@ -65,4 +65,13 @@ describe('Writable', () => {
 		};
 		expectTypeOf(writable).toEqualTypeOf<{ a: Map<string, { b: number }> }>();
 	});
+
+	it('should support optional parameters', () => {
+		interface Foo {
+			readonly a: string;
+			b?: number;
+		}
+		const writable: Writable<Foo> = {};
+		expectTypeOf(writable).toEqualTypeOf<{ b?: number }>();
+	});
 });

--- a/src/types/__tests__/Writable.unit.test.ts
+++ b/src/types/__tests__/Writable.unit.test.ts
@@ -1,0 +1,68 @@
+import { expectTypeOf } from 'expect-type';
+import type { Writable } from '../Writable';
+
+describe('Writable', () => {
+	it('should remove readonly parameters', () => {
+		interface Foo {
+			readonly a: string;
+			b: number;
+		}
+		const writable: Writable<Foo> = { b: 42 };
+		expectTypeOf(writable).toEqualTypeOf<{ b: number }>();
+	});
+
+	it('should keep writable parameters', () => {
+		interface Foo {
+			readonly a: string;
+			b: number;
+			c: boolean;
+		}
+		const writable: Writable<Foo> = {
+			b: 42,
+			c: true,
+		};
+		expectTypeOf(writable).toEqualTypeOf<{ b: number; c: boolean }>();
+	});
+
+	it('should convert Array attributes to have Array item types as Writable', () => {
+		interface Foo {
+			readonly a: string;
+			b: number;
+		}
+		interface Bar {
+			a: Foo[];
+		}
+		const writable: Writable<Bar> = {
+			a: [{ b: 42 }],
+		};
+		expectTypeOf(writable).toEqualTypeOf<{ a: { b: number }[] }>();
+	});
+
+	it('should convert Set attributes to have the Set item types as Writable', () => {
+		interface Foo {
+			readonly a: string;
+			b: number;
+		}
+		interface Bar {
+			a: Set<Foo>;
+		}
+		const writable: Writable<Bar> = {
+			a: new Set([{ b: 42 }]),
+		};
+		expectTypeOf(writable).toEqualTypeOf<{ a: Set<{ b: number }> }>();
+	});
+
+	it('should convert Map attributes to have the Map value types as Writable', () => {
+		interface Foo {
+			readonly a: string;
+			b: number;
+		}
+		interface Bar {
+			a: Map<string, Foo>;
+		}
+		const writable: Writable<Bar> = {
+			a: new Map([['baz', { b: 42 }]]),
+		};
+		expectTypeOf(writable).toEqualTypeOf<{ a: Map<string, { b: number }> }>();
+	});
+});


### PR DESCRIPTION
This PR fixes a bug in our `Writable` utility type which cause it to lose `optional` fields.

You can test it out by adding an optional field to a type and running it through `Writable` and seeing that the new type is now properly formed.