### PR TITLE
Use lowercase for SQL function and type names

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -10,6 +10,9 @@ exclude_rules =
 indent_unit = space
 tab_space_size = 2
 
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = lower
+
 [sqlfluff:rules:capitalisation.types]
 extended_capitalisation_policy = lower
 

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -10,6 +10,9 @@ exclude_rules =
 indent_unit = space
 tab_space_size = 2
 
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = lower
+
 [sqlfluff:rules:convention.terminator]
 multiline_newline = False
 require_final_semicolon = True

--- a/src/database/queries/bulkUploadTasks/selectWithPagination.sql
+++ b/src/database/queries/bulkUploadTasks/selectWithPagination.sql
@@ -2,18 +2,18 @@ SELECT bulk_upload_task_to_json(bulk_upload_tasks.*) AS object
 FROM bulk_upload_tasks
 WHERE
   CASE
-    WHEN :createdBy::UUID IS NULL THEN
+    WHEN :createdBy::uuid IS NULL THEN
       TRUE
     ELSE
       created_by = :createdBy
     END
   AND CASE
-    WHEN :authContextKeycloakUserId::UUID IS NULL THEN
+    WHEN :authContextKeycloakUserId::uuid IS NULL THEN
       TRUE
     ELSE
       (
         created_by = :authContextKeycloakUserId
-        OR :authContextIsAdministrator::BOOLEAN
+        OR :authContextIsAdministrator::boolean
       )
     END
 ORDER BY id DESC

--- a/src/database/queries/proposals/checkAuthorization.sql
+++ b/src/database/queries/proposals/checkAuthorization.sql
@@ -4,12 +4,12 @@ SELECT EXISTS(
     WHERE id = :id
       AND
         CASE
-          WHEN :authContextKeycloakUserId::UUID IS NULL THEN
+          WHEN :authContextKeycloakUserId::uuid IS NULL THEN
             TRUE
           ELSE
           (
             created_by = :authContextKeycloakUserId
-            OR :authContextIsAdministrator::BOOLEAN
+            OR :authContextIsAdministrator::boolean
           )
           END
 ) AS result;

--- a/src/database/queries/proposals/checkAuthorization.sql
+++ b/src/database/queries/proposals/checkAuthorization.sql
@@ -1,4 +1,4 @@
-SELECT EXISTS(
+SELECT exists(
   SELECT 1
     FROM proposals
     WHERE id = :id

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -5,31 +5,31 @@ FROM proposals AS p
   LEFT JOIN changemakers_proposals AS op ON p.id = op.proposal_id
 WHERE
   CASE
-    WHEN :createdBy::UUID IS NULL THEN
+    WHEN :createdBy::uuid IS NULL THEN
       TRUE
     ELSE
       p.created_by = :createdBy
     END
   AND CASE
-    WHEN (:search::TEXT IS NULL
+    WHEN (:search::text IS NULL
       OR :search = '') THEN
       TRUE
     ELSE
-      pfv.value_search @@ websearch_to_tsquery('english', :search::TEXT)
+      pfv.value_search @@ websearch_to_tsquery('english', :search::text)
     END
   AND CASE
-    WHEN :changemakerId::INTEGER IS NULL THEN
+    WHEN :changemakerId::integer IS NULL THEN
       TRUE
     ELSE
       op.changemaker_id = :changemakerId
     END
   AND CASE
-    WHEN :authContextKeycloakUserId::UUID IS NULL THEN
+    WHEN :authContextKeycloakUserId::uuid IS NULL THEN
       TRUE
     ELSE
       (
         p.created_by = :authContextKeycloakUserId
-        OR :authContextIsAdministrator::BOOLEAN
+        OR :authContextIsAdministrator::boolean
       )
     END
 GROUP BY p.id

--- a/src/database/queries/sources/checkExistsById.sql
+++ b/src/database/queries/sources/checkExistsById.sql
@@ -1,4 +1,4 @@
-SELECT EXISTS(
+SELECT exists(
   SELECT 1
     FROM sources
     WHERE id = :sourceId


### PR DESCRIPTION
As discussed in https://github.com/PhilanthropyDataCommons/service/pull/1259#discussion_r1878726661 and https://github.com/PhilanthropyDataCommons/service/pull/1259#discussion_r1878727869, set the SQLFluff capitalization policy for function names and type names to be lowercase.