### PR TITLE
Ignore engine spec when testing with latest Node

### DIFF
--- a/.github/workflows/test-current-node.yml
+++ b/.github/workflows/test-current-node.yml
@@ -31,7 +31,7 @@ jobs:
           check-latest: true
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-engine-strict
 
       - name: Run build
         run: npm run build


### PR DESCRIPTION
We are defining the version of Node we support with the [`engines` directive](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#engines) in `package.json` - as we should be. However, when testing against the latest version of Node, we need to override that. Turn off [`engine-strict`](https://docs.npmjs.com/cli/v10/using-npm/config#engine-strict) via the command line, so that Node will install our dependencies.

Follow-up to #1374 