### PR TITLE
Use built-in type definitions for uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
 				"@types/pg": "^8.11.10",
 				"@types/supertest": "^6.0.2",
 				"@types/swagger-ui-express": "^4.1.7",
-				"@types/uuid": "^10.0.0",
 				"@typescript-eslint/eslint-plugin": "^7.18.0",
 				"@typescript-eslint/parser": "^7.18.0",
 				"copyfiles": "^2.4.1",
@@ -3403,12 +3402,6 @@
 				"@types/express": "*",
 				"@types/serve-static": "*"
 			}
-		},
-		"node_modules/@types/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-			"dev": true
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.20",
@@ -10320,6 +10313,7 @@
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
+			"license": "MIT",
 			"bin": {
 				"uuid": "dist/esm/bin/uuid"
 			}
@@ -13309,12 +13303,6 @@
 				"@types/express": "*",
 				"@types/serve-static": "*"
 			}
-		},
-		"@types/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-			"dev": true
 		},
 		"@types/yargs": {
 			"version": "17.0.20",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
 		"@types/pg": "^8.11.10",
 		"@types/supertest": "^6.0.2",
 		"@types/swagger-ui-express": "^4.1.7",
-		"@types/uuid": "^10.0.0",
 		"@typescript-eslint/eslint-plugin": "^7.18.0",
 		"@typescript-eslint/parser": "^7.18.0",
 		"copyfiles": "^2.4.1",


### PR DESCRIPTION
[Version 11 of the uuid library](https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md#1100-2024-10-26) included a migration to TypeScript, so the externally-provided `@types/uuid` is no longer needed. Uninstall it.

We upgraded to version 11 in PR https://github.com/PhilanthropyDataCommons/service/pull/1285.