### PR TITLE
Enable SQLFluff indenting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Invoking prettier for the first time
 b16d4388c0457cd6fe02fc09947712d6f3afed7c
+
+# Re-indenting SQL with SQLFluff
+b555be039a94a139f31a1f0d1a8ccf9fcaa89c88

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -2,13 +2,14 @@
 dialect = postgres
 templater = placeholder
 exclude_rules =
-  layout.indent,
   # allow use of keywords as identifiers when unambiguous
   references.keywords,
 
 [sqlfluff:indentation]
-indent_unit = space
-tab_space_size = 2
+indent_unit = tab
+indented_ctes = True
+indented_joins = True
+indented_then = False
 
 [sqlfluff:rules:capitalisation.functions]
 extended_capitalisation_policy = lower

--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -44,6 +44,10 @@ src/database/migrations/0038-alter-users-use-keycloak_user_id-as-primary-key.sql
 src/database/migrations/0039-rename-organizations-to-changemakers.sql
 src/database/migrations/0040-create-permission-tables.sql
 src/database/migrations/0041-rename-bulk_uploads-to-bulk_upload_tasks.sql
+src/database/migrations/0042-alter-permission-tables-add-not_after.sql
+src/database/migrations/0043-alter-data_providers-add-keycloak_organization_id.sql
+src/database/migrations/0044-alter-funders-add-keycloak_organization_id.sql
+src/database/migrations/0045-alter-changemakers-add-keycloak_organization_id.sql
 
 # This file is very large, and is intended to be removed soon.
 src/database/seeds/0001-insert-base_fields.sql

--- a/src/database/initialization/application_form_field_to_json.sql
+++ b/src/database/initialization/application_form_field_to_json.sql
@@ -1,7 +1,7 @@
 SELECT drop_function('application_form_field_to_json');
 
 CREATE FUNCTION application_form_field_to_json(
-  application_form_field application_form_fields
+	application_form_field application_form_fields
 )
 RETURNS jsonb AS $$
 DECLARE

--- a/src/database/initialization/base_field_localization_to_json.sql
+++ b/src/database/initialization/base_field_localization_to_json.sql
@@ -1,7 +1,7 @@
 SELECT drop_function('base_field_localization_to_json');
 
 CREATE FUNCTION base_field_localization_to_json(
-  base_field_localization base_field_localizations
+	base_field_localization base_field_localizations
 )
 RETURNS jsonb AS $$
 BEGIN

--- a/src/database/initialization/changemaker_proposal_to_json.sql
+++ b/src/database/initialization/changemaker_proposal_to_json.sql
@@ -1,7 +1,7 @@
 SELECT drop_function('changemaker_proposal_to_json');
 
 CREATE FUNCTION changemaker_proposal_to_json(
-  changemaker_proposal changemakers_proposals
+	changemaker_proposal changemakers_proposals
 )
 RETURNS jsonb AS $$
 DECLARE

--- a/src/database/initialization/changemaker_to_json.sql
+++ b/src/database/initialization/changemaker_to_json.sql
@@ -1,8 +1,8 @@
 SELECT drop_function('changemaker_to_json');
 
 CREATE FUNCTION changemaker_to_json(
-  changemaker changemakers,
-  keycloakUserId uuid DEFAULT NULL
+	changemaker changemakers,
+	keycloakUserId uuid DEFAULT NULL
 )
 RETURNS jsonb AS $$
 DECLARE

--- a/src/database/initialization/proposal_field_value_to_json.sql
+++ b/src/database/initialization/proposal_field_value_to_json.sql
@@ -1,7 +1,7 @@
 SELECT drop_function('proposal_field_value_to_json');
 
 CREATE FUNCTION proposal_field_value_to_json(
-  proposal_field_value proposal_field_values
+	proposal_field_value proposal_field_values
 )
 RETURNS jsonb AS $$
 DECLARE

--- a/src/database/initialization/user_changemaker_permission_to_json.sql
+++ b/src/database/initialization/user_changemaker_permission_to_json.sql
@@ -1,7 +1,7 @@
 SELECT drop_function('user_changemaker_permission_to_json');
 
 CREATE FUNCTION user_changemaker_permission_to_json(
-  user_changemaker_permission user_changemaker_permissions
+	user_changemaker_permission user_changemaker_permissions
 )
 RETURNS jsonb AS $$
 BEGIN

--- a/src/database/initialization/user_data_provider_permission_to_json.sql
+++ b/src/database/initialization/user_data_provider_permission_to_json.sql
@@ -1,7 +1,7 @@
 SELECT drop_function('user_data_provider_permission_to_json');
 
 CREATE FUNCTION user_data_provider_permission_to_json(
-  user_data_provider_permission user_data_provider_permissions
+	user_data_provider_permission user_data_provider_permissions
 )
 RETURNS jsonb AS $$
 BEGIN

--- a/src/database/initialization/user_funder_permission_to_json.sql
+++ b/src/database/initialization/user_funder_permission_to_json.sql
@@ -1,7 +1,7 @@
 SELECT drop_function('user_funder_permission_to_json');
 
 CREATE FUNCTION user_funder_permission_to_json(
-  user_funder_permission user_funder_permissions
+	user_funder_permission user_funder_permissions
 )
 RETURNS jsonb AS $$
 BEGIN

--- a/src/database/queries/applicationFormFields/insertOne.sql
+++ b/src/database/queries/applicationFormFields/insertOne.sql
@@ -1,12 +1,12 @@
 INSERT INTO application_form_fields (
-  application_form_id,
-  base_field_id,
-  position,
-  label
+	application_form_id,
+	base_field_id,
+	position,
+	label
 ) VALUES (
-  :applicationFormId,
-  :baseFieldId,
-  :position,
-  :label
+	:applicationFormId,
+	:baseFieldId,
+	:position,
+	:label
 )
 RETURNING application_form_field_to_json(application_form_fields) AS object;

--- a/src/database/queries/applicationFormFields/selectWithPagination.sql
+++ b/src/database/queries/applicationFormFields/selectWithPagination.sql
@@ -1,11 +1,11 @@
 SELECT application_form_field_to_json(application_form_fields) AS object
 FROM application_form_fields
 WHERE
-  CASE
-    WHEN :applicationFormId::integer IS NULL THEN
-      TRUE
-    ELSE
-      application_form_id = :applicationFormId
-    END
+	CASE
+		WHEN :applicationFormId::integer IS NULL THEN
+			TRUE
+		ELSE
+			application_form_id = :applicationFormId
+	END
 ORDER BY position, id
 LIMIT :limit OFFSET :offset;

--- a/src/database/queries/applicationFormFields/selectWithPagination.sql
+++ b/src/database/queries/applicationFormFields/selectWithPagination.sql
@@ -8,5 +8,4 @@ WHERE
       application_form_id = :applicationFormId
     END
 ORDER BY position, id
-LIMIT :limit
-OFFSET :offset;
+LIMIT :limit OFFSET :offset;

--- a/src/database/queries/applicationForms/insertOne.sql
+++ b/src/database/queries/applicationForms/insertOne.sql
@@ -1,15 +1,15 @@
 INSERT INTO application_forms (
-  opportunity_id,
-  version
+	opportunity_id,
+	version
 ) VALUES (
-  :opportunityId,
-  coalesce(
-    (
-      SELECT max(af.version) + 1
-      FROM application_forms AS af
-      WHERE af.opportunity_id = :opportunityId
-    ),
-    1
-  )
+	:opportunityId,
+	coalesce(
+		(
+			SELECT max(af.version) + 1
+			FROM application_forms AS af
+			WHERE af.opportunity_id = :opportunityId
+		),
+		1
+	)
 )
 RETURNING application_form_to_json(application_forms) AS object;

--- a/src/database/queries/applicationForms/selectWithPagination.sql
+++ b/src/database/queries/applicationForms/selectWithPagination.sql
@@ -1,5 +1,4 @@
 SELECT application_form_to_json(application_forms) AS object
 FROM application_forms
 ORDER BY id
-LIMIT :limit
-OFFSET :offset;
+LIMIT :limit OFFSET :offset;

--- a/src/database/queries/baseFieldLocalizations/createOrUpdateByPrimaryKey.sql
+++ b/src/database/queries/baseFieldLocalizations/createOrUpdateByPrimaryKey.sql
@@ -1,16 +1,16 @@
 INSERT INTO base_field_localizations (
-  base_field_id,
-  language,
-  label,
-  description
+	base_field_id,
+	language,
+	label,
+	description
 ) VALUES (
-  :baseFieldId,
-  :language,
-  :label,
-  :description
+	:baseFieldId,
+	:language,
+	:label,
+	:description
 )
 ON CONFLICT (base_field_id, language)
 DO UPDATE SET
-  label = excluded.label,
-  description = excluded.description
+label = excluded.label,
+description = excluded.description
 RETURNING base_field_localization_to_json(base_field_localizations) AS object;

--- a/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
+++ b/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
@@ -8,5 +8,4 @@ WHERE
       base_field_id = :baseFieldId
     END
 ORDER BY created_at
-LIMIT :limit
-OFFSET :offset;
+LIMIT :limit OFFSET :offset;

--- a/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
+++ b/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
@@ -1,11 +1,11 @@
 SELECT base_field_localization_to_json(base_field_localizations) AS object
 FROM base_field_localizations
 WHERE
-  CASE
-    WHEN :baseFieldId::integer IS NULL THEN
-      TRUE
-    ELSE
-      base_field_id = :baseFieldId
-    END
+	CASE
+		WHEN :baseFieldId::integer IS NULL THEN
+			TRUE
+		ELSE
+			base_field_id = :baseFieldId
+	END
 ORDER BY created_at
 LIMIT :limit OFFSET :offset;

--- a/src/database/queries/baseFields/insertOne.sql
+++ b/src/database/queries/baseFields/insertOne.sql
@@ -1,15 +1,15 @@
 INSERT INTO base_fields (
-  label,
-  description,
-  short_code,
-  data_type,
-  scope
+	label,
+	description,
+	short_code,
+	data_type,
+	scope
 )
 VALUES (
-  :label,
-  :description,
-  :shortCode,
-  :dataType,
-  :scope
+	:label,
+	:description,
+	:shortCode,
+	:dataType,
+	:scope
 )
 RETURNING base_field_to_json(base_fields) AS object;

--- a/src/database/queries/baseFields/updateById.sql
+++ b/src/database/queries/baseFields/updateById.sql
@@ -1,8 +1,8 @@
 UPDATE base_fields SET
-  label = :label,
-  description = :description,
-  short_code = :shortCode,
-  data_type = :dataType,
-  scope = :scope
+	label = :label,
+	description = :description,
+	short_code = :shortCode,
+	data_type = :dataType,
+	scope = :scope
 WHERE id = :id
 RETURNING base_field_to_json(base_fields) AS object;

--- a/src/database/queries/bulkUploadTasks/insertOne.sql
+++ b/src/database/queries/bulkUploadTasks/insertOne.sql
@@ -1,15 +1,15 @@
 INSERT INTO bulk_upload_tasks (
-  source_id,
-  file_name,
-  source_key,
-  status,
-  created_by
+	source_id,
+	file_name,
+	source_key,
+	status,
+	created_by
 )
 VALUES (
-  :sourceId,
-  :fileName,
-  :sourceKey,
-  :status,
-  :createdBy
+	:sourceId,
+	:fileName,
+	:sourceKey,
+	:status,
+	:createdBy
 )
 RETURNING bulk_upload_task_to_json(bulk_upload_tasks) AS object;

--- a/src/database/queries/bulkUploadTasks/selectWithPagination.sql
+++ b/src/database/queries/bulkUploadTasks/selectWithPagination.sql
@@ -17,5 +17,4 @@ WHERE
       )
     END
 ORDER BY id DESC
-LIMIT :limit
-OFFSET :offset;
+LIMIT :limit OFFSET :offset;

--- a/src/database/queries/bulkUploadTasks/selectWithPagination.sql
+++ b/src/database/queries/bulkUploadTasks/selectWithPagination.sql
@@ -1,20 +1,20 @@
 SELECT bulk_upload_task_to_json(bulk_upload_tasks.*) AS object
 FROM bulk_upload_tasks
 WHERE
-  CASE
-    WHEN :createdBy::uuid IS NULL THEN
-      TRUE
-    ELSE
-      created_by = :createdBy
-    END
-  AND CASE
-    WHEN :authContextKeycloakUserId::uuid IS NULL THEN
-      TRUE
-    ELSE
-      (
-        created_by = :authContextKeycloakUserId
-        OR :authContextIsAdministrator::boolean
-      )
-    END
+	CASE
+		WHEN :createdBy::uuid IS NULL THEN
+			TRUE
+		ELSE
+			created_by = :createdBy
+	END
+	AND CASE
+		WHEN :authContextKeycloakUserId::uuid IS NULL THEN
+			TRUE
+		ELSE
+			(
+				created_by = :authContextKeycloakUserId
+				OR :authContextIsAdministrator::boolean
+			)
+	END
 ORDER BY id DESC
 LIMIT :limit OFFSET :offset;

--- a/src/database/queries/bulkUploadTasks/updateById.sql
+++ b/src/database/queries/bulkUploadTasks/updateById.sql
@@ -1,7 +1,7 @@
 UPDATE bulk_upload_tasks
 SET
-  file_size = coalesce(:fileSize, file_size),
-  source_key = coalesce(:sourceKey, source_key),
-  status = coalesce(:status, status)
+	file_size = coalesce(:fileSize, file_size),
+	source_key = coalesce(:sourceKey, source_key),
+	status = coalesce(:status, status)
 WHERE id = :id
 RETURNING bulk_upload_task_to_json(bulk_upload_tasks) AS object;

--- a/src/database/queries/changemakers/insertOne.sql
+++ b/src/database/queries/changemakers/insertOne.sql
@@ -1,10 +1,10 @@
 INSERT INTO changemakers (
-  tax_id,
-  name,
-  keycloak_organization_id
+	tax_id,
+	name,
+	keycloak_organization_id
 ) VALUES (
-  :taxId,
-  :name,
-  :keycloakOrganizationId
+	:taxId,
+	:name,
+	:keycloakOrganizationId
 )
 RETURNING changemaker_to_json(changemakers) AS object;

--- a/src/database/queries/changemakers/selectWithPagination.sql
+++ b/src/database/queries/changemakers/selectWithPagination.sql
@@ -1,13 +1,14 @@
-SELECT DISTINCT o.id,
-  changemaker_to_json(o.*, :keycloakUserId) AS object
+SELECT DISTINCT
+	o.id,
+	changemaker_to_json(o.*, :keycloakUserId) AS object
 FROM changemakers AS o
-  LEFT JOIN changemakers_proposals AS op ON o.id = op.changemaker_id
+	LEFT JOIN changemakers_proposals AS op ON o.id = op.changemaker_id
 WHERE
-  CASE
-    WHEN :proposalId::integer IS NULL THEN
-      TRUE
-    ELSE
-      op.proposal_id = :proposalId
-    END
+	CASE
+		WHEN :proposalId::integer IS NULL THEN
+			TRUE
+		ELSE
+			op.proposal_id = :proposalId
+	END
 ORDER BY o.id DESC
 LIMIT :limit OFFSET :offset;

--- a/src/database/queries/changemakersProposals/insertOne.sql
+++ b/src/database/queries/changemakersProposals/insertOne.sql
@@ -1,8 +1,8 @@
 INSERT INTO changemakers_proposals (
-  changemaker_id,
-  proposal_id
+	changemaker_id,
+	proposal_id
 ) VALUES (
-  :changemakerId,
-  :proposalId
+	:changemakerId,
+	:proposalId
 )
 RETURNING changemaker_proposal_to_json(changemakers_proposals) AS object;

--- a/src/database/queries/changemakersProposals/selectWithPagination.sql
+++ b/src/database/queries/changemakersProposals/selectWithPagination.sql
@@ -1,17 +1,17 @@
 SELECT changemaker_proposal_to_json(changemakers_proposals.*) AS object
 FROM changemakers_proposals
 WHERE
-  CASE
-    WHEN :changemakerId::integer IS NULL THEN
-      TRUE
-    ELSE
-      changemaker_id = :changemakerId
-    END
-  AND CASE
-    WHEN :proposalId::integer IS NULL THEN
-      TRUE
-    ELSE
-      proposal_id = :proposalId
-    END
+	CASE
+		WHEN :changemakerId::integer IS NULL THEN
+			TRUE
+		ELSE
+			changemaker_id = :changemakerId
+	END
+	AND CASE
+		WHEN :proposalId::integer IS NULL THEN
+			TRUE
+		ELSE
+			proposal_id = :proposalId
+	END
 ORDER BY id DESC
 LIMIT :limit OFFSET :offset;

--- a/src/database/queries/dataProviders/insertOrUpdateOne.sql
+++ b/src/database/queries/dataProviders/insertOrUpdateOne.sql
@@ -1,14 +1,14 @@
 INSERT INTO data_providers (
-  short_code,
-  name,
-  keycloak_organization_id
+	short_code,
+	name,
+	keycloak_organization_id
 ) VALUES (
-  :shortCode,
-  :name,
-  :keycloakOrganizationId
+	:shortCode,
+	:name,
+	:keycloakOrganizationId
 )
 ON CONFLICT (short_code)
 DO UPDATE SET
-  name = excluded.name,
-  keycloak_organization_id = excluded.keycloak_organization_id
+name = excluded.name,
+keycloak_organization_id = excluded.keycloak_organization_id
 RETURNING data_provider_to_json(data_providers) AS object;

--- a/src/database/queries/funders/insertOrUpdateOne.sql
+++ b/src/database/queries/funders/insertOrUpdateOne.sql
@@ -1,14 +1,14 @@
 INSERT INTO funders (
-  short_code,
-  name,
-  keycloak_organization_id
+	short_code,
+	name,
+	keycloak_organization_id
 ) VALUES (
-  :shortCode,
-  :name,
-  :keycloakOrganizationId
+	:shortCode,
+	:name,
+	:keycloakOrganizationId
 )
 ON CONFLICT (short_code)
 DO UPDATE SET
-  name = excluded.name,
-  keycloak_organization_id = excluded.keycloak_organization_id
+name = excluded.name,
+keycloak_organization_id = excluded.keycloak_organization_id
 RETURNING funder_to_json(funders) AS object;

--- a/src/database/queries/opportunities/selectWithPagination.sql
+++ b/src/database/queries/opportunities/selectWithPagination.sql
@@ -1,5 +1,4 @@
 SELECT opportunity_to_json(opportunities.*) AS object
 FROM opportunities
 ORDER BY id
-LIMIT :limit
-OFFSET :offset;
+LIMIT :limit OFFSET :offset;

--- a/src/database/queries/platformProviderResponses/insertOne.sql
+++ b/src/database/queries/platformProviderResponses/insertOne.sql
@@ -1,18 +1,19 @@
 INSERT INTO platform_provider_responses (
-  external_id,
-  platform_provider,
-  data
+	external_id,
+	platform_provider,
+	data
 )
 VALUES (
-  :externalId,
-  :platformProvider,
-  :data
+	:externalId,
+	:platformProvider,
+	:data
 )
 ON CONFLICT (external_id, platform_provider) DO UPDATE
 SET
-  data = excluded.data,
-  created_at = excluded.created_at
-RETURNING external_id AS "externalId",
-  platform_provider AS "platformProvider",
-  data,
-  created_at AS "createdAt";
+data = excluded.data,
+created_at = excluded.created_at
+RETURNING
+	external_id AS "externalId",
+	platform_provider AS "platformProvider",
+	data,
+	created_at AS "createdAt";

--- a/src/database/queries/platformProviderResponses/selectByExternalId.sql
+++ b/src/database/queries/platformProviderResponses/selectByExternalId.sql
@@ -1,8 +1,8 @@
 SELECT
-  external_id AS "externalId",
-  platform_provider AS "platformProvider",
-  data,
-  created_at AS "createdAt"
+	external_id AS "externalId",
+	platform_provider AS "platformProvider",
+	data,
+	created_at AS "createdAt"
 FROM platform_provider_responses
 WHERE external_id = :externalId
 ORDER BY created_at DESC;

--- a/src/database/queries/proposalFieldValues/insertOne.sql
+++ b/src/database/queries/proposalFieldValues/insertOne.sql
@@ -1,14 +1,14 @@
 INSERT INTO proposal_field_values (
-  proposal_version_id,
-  application_form_field_id,
-  value,
-  position,
-  is_valid
+	proposal_version_id,
+	application_form_field_id,
+	value,
+	position,
+	is_valid
 ) VALUES (
-  :proposalVersionId,
-  :applicationFormFieldId,
-  :value,
-  :position,
-  :isValid
+	:proposalVersionId,
+	:applicationFormFieldId,
+	:value,
+	:position,
+	:isValid
 )
 RETURNING proposal_field_value_to_json(proposal_field_values) AS object;

--- a/src/database/queries/proposalVersions/insertOne.sql
+++ b/src/database/queries/proposalVersions/insertOne.sql
@@ -1,21 +1,21 @@
 INSERT INTO proposal_versions (
-  proposal_id,
-  application_form_id,
-  source_id,
-  created_by,
-  version
+	proposal_id,
+	application_form_id,
+	source_id,
+	created_by,
+	version
 ) VALUES (
-  :proposalId,
-  :applicationFormId,
-  :sourceId,
-  :createdBy,
-  coalesce(
-    (
-      SELECT max(pv.version) + 1
-      FROM proposal_versions AS pv
-      WHERE pv.proposal_id = :proposalId
-    ),
-    1
-  )
+	:proposalId,
+	:applicationFormId,
+	:sourceId,
+	:createdBy,
+	coalesce(
+		(
+			SELECT max(pv.version) + 1
+			FROM proposal_versions AS pv
+			WHERE pv.proposal_id = :proposalId
+		),
+		1
+	)
 )
 RETURNING proposal_version_to_json(proposal_versions) AS object;

--- a/src/database/queries/proposals/checkAuthorization.sql
+++ b/src/database/queries/proposals/checkAuthorization.sql
@@ -1,15 +1,16 @@
 SELECT exists(
-  SELECT 1
-    FROM proposals
-    WHERE id = :id
-      AND
-        CASE
-          WHEN :authContextKeycloakUserId::uuid IS NULL THEN
-            TRUE
-          ELSE
-          (
-            created_by = :authContextKeycloakUserId
-            OR :authContextIsAdministrator::boolean
-          )
-          END
+	SELECT 1
+	FROM proposals
+	WHERE
+		id = :id
+		AND
+		CASE
+			WHEN :authContextKeycloakUserId::uuid IS NULL THEN
+				TRUE
+			ELSE
+				(
+					created_by = :authContextKeycloakUserId
+					OR :authContextIsAdministrator::boolean
+				)
+		END
 ) AS result;

--- a/src/database/queries/proposals/insertOne.sql
+++ b/src/database/queries/proposals/insertOne.sql
@@ -1,10 +1,10 @@
 INSERT INTO proposals (
-  external_id,
-  opportunity_id,
-  created_by
+	external_id,
+	opportunity_id,
+	created_by
 ) VALUES (
-  :externalId,
-  :opportunityId,
-  :createdBy
+	:externalId,
+	:opportunityId,
+	:createdBy
 )
 RETURNING proposal_to_json(proposals) AS object;

--- a/src/database/queries/proposals/selectById.sql
+++ b/src/database/queries/proposals/selectById.sql
@@ -1,3 +1,3 @@
 SELECT proposal_to_json(proposals.*) AS object
-  FROM proposals
-  WHERE id = :id;
+FROM proposals
+WHERE id = :id;

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -1,37 +1,39 @@
 SELECT proposal_to_json(p.*) AS object
 FROM proposals AS p
-  LEFT JOIN proposal_versions AS pv ON p.id = pv.proposal_id
-  LEFT JOIN proposal_field_values AS pfv ON pv.id = pfv.proposal_version_id
-  LEFT JOIN changemakers_proposals AS op ON p.id = op.proposal_id
+	LEFT JOIN proposal_versions AS pv ON p.id = pv.proposal_id
+	LEFT JOIN proposal_field_values AS pfv ON pv.id = pfv.proposal_version_id
+	LEFT JOIN changemakers_proposals AS op ON p.id = op.proposal_id
 WHERE
-  CASE
-    WHEN :createdBy::uuid IS NULL THEN
-      TRUE
-    ELSE
-      p.created_by = :createdBy
-    END
-  AND CASE
-    WHEN (:search::text IS NULL
-      OR :search = '') THEN
-      TRUE
-    ELSE
-      pfv.value_search @@ websearch_to_tsquery('english', :search::text)
-    END
-  AND CASE
-    WHEN :changemakerId::integer IS NULL THEN
-      TRUE
-    ELSE
-      op.changemaker_id = :changemakerId
-    END
-  AND CASE
-    WHEN :authContextKeycloakUserId::uuid IS NULL THEN
-      TRUE
-    ELSE
-      (
-        p.created_by = :authContextKeycloakUserId
-        OR :authContextIsAdministrator::boolean
-      )
-    END
+	CASE
+		WHEN :createdBy::uuid IS NULL THEN
+			TRUE
+		ELSE
+			p.created_by = :createdBy
+	END
+	AND CASE
+		WHEN (
+			:search::text IS NULL
+			OR :search = ''
+		) THEN
+			TRUE
+		ELSE
+			pfv.value_search @@ websearch_to_tsquery('english', :search::text)
+	END
+	AND CASE
+		WHEN :changemakerId::integer IS NULL THEN
+			TRUE
+		ELSE
+			op.changemaker_id = :changemakerId
+	END
+	AND CASE
+		WHEN :authContextKeycloakUserId::uuid IS NULL THEN
+			TRUE
+		ELSE
+			(
+				p.created_by = :authContextKeycloakUserId
+				OR :authContextIsAdministrator::boolean
+			)
+	END
 GROUP BY p.id
 ORDER BY p.id DESC
 LIMIT :limit OFFSET :offset;

--- a/src/database/queries/sources/checkExistsById.sql
+++ b/src/database/queries/sources/checkExistsById.sql
@@ -1,5 +1,5 @@
 SELECT exists(
-  SELECT 1
-    FROM sources
-    WHERE id = :sourceId
+	SELECT 1
+	FROM sources
+	WHERE id = :sourceId
 ) AS result;

--- a/src/database/queries/sources/insertOne.sql
+++ b/src/database/queries/sources/insertOne.sql
@@ -1,13 +1,13 @@
 INSERT INTO sources (
-  label,
-  data_provider_short_code,
-  funder_short_code,
-  changemaker_id
+	label,
+	data_provider_short_code,
+	funder_short_code,
+	changemaker_id
 )
 VALUES (
-  :label,
-  :dataProviderShortCode,
-  :funderShortCode,
-  :changemakerId
+	:label,
+	:dataProviderShortCode,
+	:funderShortCode,
+	:changemakerId
 )
 RETURNING source_to_json(sources) AS object;

--- a/src/database/queries/userChangemakerPermissions/checkExistsByPrimaryKey.sql
+++ b/src/database/queries/userChangemakerPermissions/checkExistsByPrimaryKey.sql
@@ -1,8 +1,9 @@
 SELECT exists(
-  SELECT 1
-    FROM user_changemaker_permissions
-    WHERE user_keycloak_user_id = :userKeycloakUserId
-      AND changemaker_id = :changemakerId
-        AND permission = :permission
-        AND NOT is_expired(not_after)
+	SELECT 1
+	FROM user_changemaker_permissions
+	WHERE
+		user_keycloak_user_id = :userKeycloakUserId
+		AND changemaker_id = :changemakerId
+		AND permission = :permission
+		AND NOT is_expired(not_after)
 ) AS result;

--- a/src/database/queries/userChangemakerPermissions/deleteOne.sql
+++ b/src/database/queries/userChangemakerPermissions/deleteOne.sql
@@ -1,6 +1,7 @@
 UPDATE user_changemaker_permissions
-  SET not_after = now()
-  WHERE user_keycloak_user_id = :userKeycloakUserId
-  AND permission = :permission::permission_t
-  AND changemaker_id = :changemakerId
-  AND NOT is_expired(not_after);
+SET not_after = now()
+WHERE
+	user_keycloak_user_id = :userKeycloakUserId
+	AND permission = :permission::permission_t
+	AND changemaker_id = :changemakerId
+	AND NOT is_expired(not_after);

--- a/src/database/queries/userChangemakerPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userChangemakerPermissions/insertOrUpdateOne.sql
@@ -1,17 +1,17 @@
 INSERT INTO user_changemaker_permissions (
-  user_keycloak_user_id,
-  permission,
-  changemaker_id,
-  created_by,
-  not_after
+	user_keycloak_user_id,
+	permission,
+	changemaker_id,
+	created_by,
+	not_after
 ) VALUES (
-  :userKeycloakUserId,
-  :permission::permission_t,
-  :changemakerId,
-  :createdBy,
-  null
+	:userKeycloakUserId,
+	:permission::permission_t,
+	:changemakerId,
+	:createdBy,
+	null
 )
 ON CONFLICT (user_keycloak_user_id, permission, changemaker_id) DO UPDATE
-  SET not_after = null
+SET not_after = null
 RETURNING user_changemaker_permission_to_json(user_changemaker_permissions)
-  AS object;
+	AS object;

--- a/src/database/queries/userChangemakerPermissions/selectByPrimaryKey.sql
+++ b/src/database/queries/userChangemakerPermissions/selectByPrimaryKey.sql
@@ -1,8 +1,10 @@
-SELECT user_changemaker_permission_to_json(
-  user_changemaker_permissions.*
-) AS object
+SELECT
+	user_changemaker_permission_to_json(
+		user_changemaker_permissions.*
+	) AS object
 FROM user_changemaker_permissions
-WHERE user_keycloak_user_id = :userKeycloakUserId
-  AND changemaker_id = :changemakerId
-  AND permission = :permission
-  AND NOT is_expired(not_after);
+WHERE
+	user_keycloak_user_id = :userKeycloakUserId
+	AND changemaker_id = :changemakerId
+	AND permission = :permission
+	AND NOT is_expired(not_after);

--- a/src/database/queries/userDataProviderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userDataProviderPermissions/insertOrUpdateOne.sql
@@ -1,19 +1,19 @@
 INSERT INTO user_data_provider_permissions (
-  user_keycloak_user_id,
-  permission,
-  data_provider_short_code,
-  created_by,
-  not_after
+	user_keycloak_user_id,
+	permission,
+	data_provider_short_code,
+	created_by,
+	not_after
 ) VALUES (
-  :userKeycloakUserId,
-  :permission::permission_t,
-  :dataProviderShortCode,
-  :createdBy,
-  null
+	:userKeycloakUserId,
+	:permission::permission_t,
+	:dataProviderShortCode,
+	:createdBy,
+	null
 )
 ON CONFLICT (
-  user_keycloak_user_id, permission, data_provider_short_code
+	user_keycloak_user_id, permission, data_provider_short_code
 ) DO UPDATE
-  SET not_after = null
+SET not_after = null
 RETURNING user_data_provider_permission_to_json(user_data_provider_permissions)
-  AS object;
+	AS object;

--- a/src/database/queries/userFunderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userFunderPermissions/insertOrUpdateOne.sql
@@ -1,16 +1,16 @@
 INSERT INTO user_funder_permissions (
-  user_keycloak_user_id,
-  permission,
-  funder_short_code,
-  created_by,
-  not_after
+	user_keycloak_user_id,
+	permission,
+	funder_short_code,
+	created_by,
+	not_after
 ) VALUES (
-  :userKeycloakUserId,
-  :permission::permission_t,
-  :funderShortCode,
-  :createdBy,
-  NULL
+	:userKeycloakUserId,
+	:permission::permission_t,
+	:funderShortCode,
+	:createdBy,
+	NULL
 )
 ON CONFLICT (user_keycloak_user_id, permission, funder_short_code) DO UPDATE
-  SET not_after = NULL
+SET not_after = NULL
 RETURNING user_funder_permission_to_json(user_funder_permissions) AS object;

--- a/src/database/queries/users/insertOne.sql
+++ b/src/database/queries/users/insertOne.sql
@@ -1,7 +1,7 @@
 INSERT INTO users (
-  keycloak_user_id
+	keycloak_user_id
 )
 VALUES (
-  :keycloakUserId
+	:keycloakUserId
 )
 RETURNING user_to_json(users) AS object;

--- a/src/database/queries/users/selectWithPagination.sql
+++ b/src/database/queries/users/selectWithPagination.sql
@@ -1,21 +1,21 @@
 SELECT user_to_json(users.*) AS object
 FROM users
 WHERE
-  CASE
-    WHEN :keycloakUserId::uuid IS NULL THEN
-      TRUE
-    ELSE
-      keycloak_user_id = :keycloakUserId
-    END
-  AND CASE
-    WHEN :authContextKeycloakUserId::uuid IS NULL THEN
-      TRUE
-    ELSE
-      (
-        keycloak_user_id = :authContextKeycloakUserId
-        OR :authContextIsAdministrator::boolean
-      )
-    END
+	CASE
+		WHEN :keycloakUserId::uuid IS NULL THEN
+			TRUE
+		ELSE
+			keycloak_user_id = :keycloakUserId
+	END
+	AND CASE
+		WHEN :authContextKeycloakUserId::uuid IS NULL THEN
+			TRUE
+		ELSE
+			(
+				keycloak_user_id = :authContextKeycloakUserId
+				OR :authContextIsAdministrator::boolean
+			)
+	END
 GROUP BY keycloak_user_id
 ORDER BY created_at DESC
 LIMIT :limit OFFSET :offset;


### PR DESCRIPTION
When introducing SQLFluff in PR #321, I intentionally left the [`layout.indent` rule](https://docs.sqlfluff.com/en/stable/reference/rules.html#rule-layout.indent) disabled. There were already so many non-whitespace changes involved that I thought reindenting the world would be too much.

Enable and configure the `layout.indent` rule, and apply it to our SQL code.

I configured it to use tabs, like the rest of our codebase. Beyond the type of indentation, there are several options available for [configuring layout](https://docs.sqlfluff.com/en/stable/configuration/layout.html); I chose the ones that made the most sense to me.

For the ease of reviewability, I split this into four commits: manually reformatting to avoid automatic reformatting issues, the automatic reformatting that includes multiline changes, the whitespace-only automatic reformatting, and the configuration changes. Note that **if you rebase this PR** you will need to **update the `.git-blame-ignore-revs` file** with the new commit hash.

I apologize for dropping this and then leaving; I meant to get it done earlier, but time got away from me. Please merge when/if you feel ready.