### PR TITLE
Let changemaker Keycloak organization ID be set

### DIFF
--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -17,6 +17,7 @@ import {
 	loadSystemUser,
 	loadTableMetrics,
 	createOrUpdateDataProvider,
+	updateChangemaker,
 } from '../database';
 import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
@@ -31,8 +32,10 @@ import {
 	Opportunity,
 	PostgresErrorCode,
 	Source,
+	stringToKeycloakId,
 	User,
 } from '../types';
+import { NotFoundError } from '../errors';
 
 const insertTestChangemakers = async () => {
 	await createChangemaker(db, null, {
@@ -847,6 +850,50 @@ describe('/changemakers', () => {
 					},
 				],
 			});
+		});
+	});
+
+	describe('Update keycloakOrganizationId', () => {
+		it('Successfully sets a keycloakOrganizationId where previously null', async () => {
+			const changemaker = await createChangemaker(db, null, {
+				taxId: '4833091201209397622311990956044204588593',
+				name: 'Changemaker 4833091201209397622311990956044204588593',
+				keycloakOrganizationId: null,
+			});
+			const newOrganizationId = stringToKeycloakId(
+				'64e6da25-a6ba-43ce-97ba-1c5958bcc7ae',
+			);
+			const result = await updateChangemaker(changemaker.id, newOrganizationId);
+			expect(result).toStrictEqual({
+				...changemaker,
+				keycloakOrganizationId: newOrganizationId,
+			});
+		});
+
+		it('Successfully sets a keycloakOrganizationId where previously non-null', async () => {
+			const changemaker = await createChangemaker(db, null, {
+				taxId: '1099594605318784561881495063299923285326',
+				name: 'Changemaker 1099594605318784561881495063299923285326',
+				keycloakOrganizationId: '7733cef4-8a08-4089-a699-9be1e5536733',
+			});
+			const newOrganizationId = stringToKeycloakId(
+				'0a78a90b-b2fe-42d0-8c46-b5ce959d6f24',
+			);
+			const result = await updateChangemaker(changemaker.id, newOrganizationId);
+			expect(result).toStrictEqual({
+				...changemaker,
+				keycloakOrganizationId: newOrganizationId,
+			});
+		});
+
+		it('Throws NotFoundError when the changemaker id does not exist', async () => {
+			const newOrganizationId = stringToKeycloakId(
+				'1377aea8-0ef5-4e0f-8beb-a799a93e898b',
+			);
+			const result = updateChangemaker(65222406, newOrganizationId);
+			await expect(async () => {
+				await result;
+			}).rejects.toThrowError(NotFoundError);
 		});
 	});
 });

--- a/src/database/operations/changemakers/index.ts
+++ b/src/database/operations/changemakers/index.ts
@@ -2,3 +2,4 @@ export * from './createChangemaker';
 export * from './loadChangemaker';
 export * from './loadChangemakerBundle';
 export * from './loadChangemakerByTaxId';
+export * from './updateChangemaker';

--- a/src/database/operations/changemakers/updateChangemaker.ts
+++ b/src/database/operations/changemakers/updateChangemaker.ts
@@ -1,0 +1,26 @@
+import { Changemaker, Id, JsonResultSet, KeycloakId } from '../../../types';
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+
+export const updateChangemaker = async (
+	changemakerId: Id,
+	keycloakOrganizationId: KeycloakId,
+): Promise<Changemaker> => {
+	const result = await db.sql<JsonResultSet<Changemaker>>(
+		'changemakers.updateById',
+		{
+			changemakerId,
+			keycloakOrganizationId,
+		},
+	);
+	const { object } = result.rows[0] ?? {};
+	if (object === undefined) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'Changemaker',
+			lookupValues: {
+				changemakerId,
+			},
+		});
+	}
+	return object;
+};

--- a/src/database/queries/changemakers/updateById.sql
+++ b/src/database/queries/changemakers/updateById.sql
@@ -1,0 +1,4 @@
+UPDATE changemakers
+SET keycloak_organization_id = :keycloakOrganizationId
+WHERE id = :changemakerId
+RETURNING changemaker_to_json(changemakers) AS object;


### PR DESCRIPTION
Without this commit, there would be no way for the PDC service code to set a changemaker's Keycloak organization UUID after initial creation. With this commit a function is available to set it. While the capability is not yet exposed to the HTTP API, the first use of the function is expected to be within the service, perhaps in middleware, and not yet exposed to users. Another reason to defer exposure in the HTTP API is to figure out whether we want to use `PUT` or `PATCH` for this purpose. Unlike the funder and data provider entities, changemaker has a synthetic key of `id` due to a compound natural key of `taxId` plus `name`.

Issue #1291