### PR TITLE
Add `PUT` and `DELETE` endpoints for UserFunderPermissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Manage user-funder permissions using `PUT`, and `DELETE` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
+
 ## 0.16.6 2024-12-23
 
 ### Changed

--- a/src/__tests__/userFunderPermissions.int.test.ts
+++ b/src/__tests__/userFunderPermissions.int.test.ts
@@ -4,6 +4,8 @@ import {
 	createOrUpdateFunder,
 	createOrUpdateUserFunderPermission,
 	loadSystemUser,
+	loadUserFunderPermission,
+	removeUserFunderPermission,
 } from '../database';
 import { expectTimestamp, loadTestUser } from '../test/utils';
 import {
@@ -11,6 +13,7 @@ import {
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
 } from '../test/mockJwt';
 import { keycloakIdToString, Permission } from '../types';
+import { NotFoundError } from '../errors';
 
 describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 	describe('PUT /', () => {
@@ -161,6 +164,200 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				permission: Permission.MANAGE,
 				userKeycloakUserId: user.keycloakUserId,
 			});
+		});
+	});
+
+	describe('DELETE /', () => {
+		it('returns 401 if the request lacks authentication', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await request(app)
+				.delete(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.send()
+				.expect(401);
+		});
+
+		it('returns 401 if the authenticated user lacks permission', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await request(app)
+				.delete(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send()
+				.expect(401);
+		});
+
+		it('returns 400 if the userId is not a valid keycloak user ID', async () => {
+			await request(app)
+				.delete(`/users/notaguid/funders/1/permissions/${Permission.MANAGE}`)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(400);
+		});
+
+		it('returns 400 if the funder shortCode is not a valid shortCode', async () => {
+			const user = await loadTestUser();
+			await request(app)
+				.delete(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/not a valid short code/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(400);
+		});
+
+		it('returns 400 if the permission is not a valid permission', async () => {
+			const user = await loadTestUser();
+			await request(app)
+				.delete(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/ExampleInc/permissions/notAPermission`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(400);
+		});
+
+		it('returns 404 if the permission does not exist', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await request(app)
+				.delete(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(404);
+		});
+
+		it('returns 404 if the permission had existed and previously been deleted', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await createOrUpdateUserFunderPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				funderShortCode: funder.shortCode,
+				permission: Permission.EDIT,
+				createdBy: user.keycloakUserId,
+			});
+			await removeUserFunderPermission(
+				user.keycloakUserId,
+				funder.shortCode,
+				Permission.EDIT,
+			);
+			await request(app)
+				.delete(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(404);
+		});
+
+		it('deletes the user funder permission when the user has administrative credentials', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await createOrUpdateUserFunderPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				funderShortCode: funder.shortCode,
+				permission: Permission.EDIT,
+				createdBy: user.keycloakUserId,
+			});
+			const permission = await loadUserFunderPermission(
+				user.keycloakUserId,
+				funder.shortCode,
+				Permission.EDIT,
+			);
+			expect(permission).toEqual({
+				funderShortCode: funder.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+			await request(app)
+				.delete(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(204);
+			await expect(
+				loadUserFunderPermission(
+					user.keycloakUserId,
+					funder.shortCode,
+					Permission.EDIT,
+				),
+			).rejects.toThrow(NotFoundError);
+		});
+
+		it('deletes the user funder permission when the user has permission to manage the funder', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await createOrUpdateUserFunderPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				funderShortCode: funder.shortCode,
+				permission: Permission.MANAGE,
+				createdBy: user.keycloakUserId,
+			});
+			await createOrUpdateUserFunderPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				funderShortCode: funder.shortCode,
+				permission: Permission.EDIT,
+				createdBy: user.keycloakUserId,
+			});
+			const permission = await loadUserFunderPermission(
+				user.keycloakUserId,
+				funder.shortCode,
+				Permission.EDIT,
+			);
+			expect(permission).toEqual({
+				funderShortCode: funder.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+			await request(app)
+				.delete(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeader)
+				.send()
+				.expect(204);
+			await expect(
+				loadUserFunderPermission(
+					user.keycloakUserId,
+					funder.shortCode,
+					Permission.EDIT,
+				),
+			).rejects.toThrow(NotFoundError);
 		});
 	});
 });

--- a/src/__tests__/userFunderPermissions.int.test.ts
+++ b/src/__tests__/userFunderPermissions.int.test.ts
@@ -1,0 +1,166 @@
+import request from 'supertest';
+import { app } from '../app';
+import {
+	createOrUpdateFunder,
+	createOrUpdateUserFunderPermission,
+	loadSystemUser,
+} from '../database';
+import { expectTimestamp, loadTestUser } from '../test/utils';
+import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
+} from '../test/mockJwt';
+import { keycloakIdToString, Permission } from '../types';
+
+describe('/users/funders/:funderShortcode/permissions/:permission', () => {
+	describe('PUT /', () => {
+		it('returns 401 if the request lacks authentication', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 401 if the authenticated user lacks permission', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+
+			await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 400 if the userId is not a valid keycloak user ID', async () => {
+			await request(app)
+				.put(
+					`/users/notaguid/funders/ExampleInc/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the funder ID is not a valid shortcode', async () => {
+			const user = await loadTestUser();
+			await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/changemakers/this is not valid/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the permission is not a valid permission', async () => {
+			const user = await loadTestUser();
+			await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/ExampleInc/permissions/notAPermission`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('creates and returns the new user funder permission when user has administrative credentials', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+
+			const response = await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				funderShortCode: funder.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+		});
+
+		it('creates and returns the new user funder permission when user has permission to manage the funder', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await createOrUpdateUserFunderPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				funderShortCode: funder.shortCode,
+				permission: Permission.MANAGE,
+				createdBy: user.keycloakUserId,
+			});
+
+			const response = await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				funderShortCode: funder.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+		});
+
+		it('does not update `createdBy`, but returns the user funder permission when user has permission to manage the funder', async () => {
+			const user = await loadTestUser();
+			const systemUser = await loadSystemUser();
+			const funder = await createOrUpdateFunder({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await createOrUpdateUserFunderPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				funderShortCode: funder.shortCode,
+				permission: Permission.MANAGE,
+				createdBy: systemUser.keycloakUserId,
+			});
+
+			const response = await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				funderShortCode: funder.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: systemUser.keycloakUserId,
+				permission: Permission.MANAGE,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+		});
+	});
+});

--- a/src/database/operations/userChangemakerPermissions/loadUserChangemakerPermission.ts
+++ b/src/database/operations/userChangemakerPermissions/loadUserChangemakerPermission.ts
@@ -1,12 +1,12 @@
 import { db } from '../../db';
 import { NotFoundError } from '../../../errors';
-import {
-	keycloakIdToString,
-	type Id,
-	type JsonResultSet,
-	type KeycloakId,
-	type Permission,
-	type UserChangemakerPermission,
+import { keycloakIdToString } from '../../../types';
+import type {
+	Id,
+	JsonResultSet,
+	KeycloakId,
+	Permission,
+	UserChangemakerPermission,
 } from '../../../types';
 
 export const loadUserChangemakerPermission = async (
@@ -25,7 +25,7 @@ export const loadUserChangemakerPermission = async (
 	const object = result.rows[0]?.object;
 	if (object === undefined) {
 		throw new NotFoundError(`Entity not found`, {
-			entityType: 'UserchangemakerPermission',
+			entityType: 'UserChangemakerPermission',
 			entityPrimaryKey: {
 				userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
 				changemakerId,

--- a/src/database/operations/userFunderPermissions/assertUserFunderPermissionExists.ts
+++ b/src/database/operations/userFunderPermissions/assertUserFunderPermissionExists.ts
@@ -1,0 +1,37 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import type {
+	CheckResult,
+	KeycloakId,
+	Permission,
+	ShortCode,
+} from '../../../types';
+
+const assertUserFunderPermissionExists = async (
+	userKeycloakUserId: KeycloakId,
+	funderShortCode: ShortCode,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql<CheckResult>(
+		'userFunderPermissions.checkExistsByPrimaryKey',
+		{
+			userKeycloakUserId,
+			funderShortCode,
+			permission,
+		},
+	);
+
+	if (result.rows[0]?.result !== true) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'UserFunderPermission',
+			entityPrimaryKey: {
+				userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
+				funderShortCode,
+				permission,
+			},
+		});
+	}
+};
+
+export { assertUserFunderPermissionExists };

--- a/src/database/operations/userFunderPermissions/index.ts
+++ b/src/database/operations/userFunderPermissions/index.ts
@@ -1,1 +1,4 @@
+export * from './assertUserFunderPermissionExists';
 export * from './createOrUpdateUserFunderPermission';
+export * from './loadUserFunderPermission';
+export * from './removeUserFunderPermission';

--- a/src/database/operations/userFunderPermissions/loadUserFunderPermission.ts
+++ b/src/database/operations/userFunderPermissions/loadUserFunderPermission.ts
@@ -1,0 +1,37 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import type {
+	JsonResultSet,
+	KeycloakId,
+	Permission,
+	ShortCode,
+	UserFunderPermission,
+} from '../../../types';
+
+export const loadUserFunderPermission = async (
+	userKeycloakUserId: KeycloakId,
+	funderShortCode: ShortCode,
+	permission: Permission,
+): Promise<UserFunderPermission> => {
+	const result = await db.sql<JsonResultSet<UserFunderPermission>>(
+		'userFunderPermissions.selectByPrimaryKey',
+		{
+			userKeycloakUserId,
+			funderShortCode,
+			permission,
+		},
+	);
+	const object = result.rows[0]?.object;
+	if (object === undefined) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'UserFunderPermission',
+			entityPrimaryKey: {
+				userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
+				funderShortCode,
+				permission,
+			},
+		});
+	}
+	return object;
+};

--- a/src/database/operations/userFunderPermissions/removeUserFunderPermission.ts
+++ b/src/database/operations/userFunderPermissions/removeUserFunderPermission.ts
@@ -1,0 +1,32 @@
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import { db } from '../../db';
+import type { KeycloakId, Permission, ShortCode } from '../../../types';
+
+const removeUserFunderPermission = async (
+	userKeycloakUserId: KeycloakId,
+	funderShortCode: ShortCode,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql('userFunderPermissions.deleteOne', {
+		userKeycloakUserId,
+		funderShortCode,
+		permission,
+	});
+
+	if (result.row_count === 0) {
+		throw new NotFoundError(
+			'The item did not exist and could not be deleted.',
+			{
+				entityType: 'UserFunderPermission',
+				entityPrimaryKey: {
+					userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
+					funderShortCode,
+					permission,
+				},
+			},
+		);
+	}
+};
+
+export { removeUserFunderPermission };

--- a/src/database/queries/userFunderPermissions/checkExistsByPrimaryKey.sql
+++ b/src/database/queries/userFunderPermissions/checkExistsByPrimaryKey.sql
@@ -1,0 +1,9 @@
+SELECT exists(
+	SELECT 1
+	FROM user_funder_permissions
+	WHERE
+		user_keycloak_user_id = :userKeycloakUserId
+		AND funder_short_code = :funderShortCode
+		AND permission = :permission
+		AND NOT is_expired(not_after)
+) AS result;

--- a/src/database/queries/userFunderPermissions/deleteOne.sql
+++ b/src/database/queries/userFunderPermissions/deleteOne.sql
@@ -1,0 +1,7 @@
+UPDATE user_funder_permissions
+SET not_after = now()
+WHERE
+	user_keycloak_user_id = :userKeycloakUserId
+	AND permission = :permission::permission_t
+	AND funder_short_code = :funderShortCode
+	AND NOT is_expired(not_after);

--- a/src/database/queries/userFunderPermissions/selectByPrimaryKey.sql
+++ b/src/database/queries/userFunderPermissions/selectByPrimaryKey.sql
@@ -1,0 +1,10 @@
+SELECT
+	user_funder_permission_to_json(
+		user_funder_permissions.*
+	) AS object
+FROM user_funder_permissions
+WHERE
+	user_keycloak_user_id = :userKeycloakUserId
+	AND funder_short_code = :funderShortCode
+	AND permission = :permission
+	AND NOT is_expired(not_after);

--- a/src/handlers/userFunderPermissionsHandlers.ts
+++ b/src/handlers/userFunderPermissionsHandlers.ts
@@ -1,0 +1,89 @@
+import { createOrUpdateUserFunderPermission } from '../database';
+import {
+	isAuthContext,
+	isId,
+	isKeycloakId,
+	isPermission,
+	isShortCode,
+	isTinyPgErrorWithQueryContext,
+	isWritableUserFunderPermission,
+} from '../types';
+import {
+	DatabaseError,
+	FailedMiddlewareError,
+	InputValidationError,
+} from '../errors';
+import type { Request, Response, NextFunction } from 'express';
+
+const putUserFunderPermission = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
+
+	const { userKeycloakUserId, funderShortCode, permission } = req.params;
+	const createdBy = req.user.keycloakUserId;
+
+	if (!isKeycloakId(userKeycloakUserId)) {
+		next(
+			new InputValidationError(
+				'Invalid userKeycloakUserId parameter.',
+				isKeycloakId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isShortCode(funderShortCode)) {
+		next(
+			new InputValidationError(
+				'Invalid funderShortCode parameter.',
+				isId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isPermission(permission)) {
+		next(
+			new InputValidationError(
+				'Invalid permission parameter.',
+				isPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isWritableUserFunderPermission(req.body)) {
+		next(
+			new InputValidationError(
+				'Invalid request body.',
+				isWritableUserFunderPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+
+	(async () => {
+		const userFunderPermission = await createOrUpdateUserFunderPermission({
+			userKeycloakUserId,
+			funderShortCode,
+			permission,
+			createdBy,
+		});
+		res.status(201).contentType('application/json').send(userFunderPermission);
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error creating item.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const userFunderPermissionsHandlers = {
+	putUserFunderPermission,
+};
+
+export { userFunderPermissionsHandlers };

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -5,3 +5,4 @@ export * from './processJwt';
 export * from './requireAdministratorRole';
 export * from './requireAuthentication';
 export * from './requireChangemakerPermission';
+export * from './requireFunderPermission';

--- a/src/middleware/requireFunderPermission.ts
+++ b/src/middleware/requireFunderPermission.ts
@@ -1,0 +1,55 @@
+/**
+ * Middleware to require a specific funder permission for a request.
+ *
+ * @param {Permission} permission - The required permission to check for.
+ * @returns {Function} Middleware function to validate the funder permission.
+ *
+ * The middleware does the following:
+ * 1. Ensures the request contains an AuthContext.
+ * 2. Allows the request to proceed if the user is an administrator.
+ * 3. Validates the `funderShortCode` parameter in the request.
+ * 4. Checks if the authenticated user has the required permission for the specified funder.
+ *
+ * If any of the checks fail, the middleware will pass an appropriate error to the next middleware.
+ */
+import { Response, NextFunction } from 'express';
+import { InputValidationError, UnauthorizedError } from '../errors';
+import { isAuthContext, isShortCode } from '../types';
+import type { Permission } from '../types';
+import type { Request } from 'express';
+
+const requireFunderPermission =
+	(permission: Permission) =>
+	(req: Request, res: Response, next: NextFunction) => {
+		if (!isAuthContext(req)) {
+			next(new UnauthorizedError('The request lacks an AuthContext.'));
+			return;
+		}
+		if (req.role?.isAdministrator === true) {
+			next();
+			return;
+		}
+		const { funderShortCode } = req.params;
+		if (!isShortCode(funderShortCode)) {
+			next(
+				new InputValidationError(
+					'Invalid funderShortCode.',
+					isShortCode.errors ?? [],
+				),
+			);
+			return;
+		}
+		const { user } = req;
+		const permissions = user.permissions.funder[funderShortCode] ?? [];
+		if (!permissions.includes(permission)) {
+			next(
+				new UnauthorizedError(
+					'Authenticated user does not have permission to perform this action.',
+				),
+			);
+			return;
+		}
+		next();
+	};
+
+export { requireFunderPermission };

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1189,6 +1189,41 @@
 					}
 				},
 				"required": ["id", "", "createdAt"]
+			},
+			"UserFunderPermission": {
+				"type": "object",
+				"properties": {
+					"permission": {
+						"$ref": "#/components/schemas/Permission",
+						"readOnly": true
+					},
+					"funderShortcode": {
+						"$ref": "#/components/schemas/shortCode",
+						"readOnly": true
+					},
+					"userKeycloakUserId": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdBy": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"readOnly": true
+					}
+				},
+				"required": [
+					"permission",
+					"funderShortcode",
+					"userKeycloakUserId",
+					"createdBy",
+					"createdAt"
+				]
 			}
 		}
 	},
@@ -2825,6 +2860,61 @@
 				"responses": {
 					"204": {
 						"description": "Confirmation of successful deletion."
+					}
+				}
+			}
+		},
+		"/users/{userKeycloakUserId}/funders/{funderShortCode}/permissions/{permission}": {
+			"put": {
+				"operationId": "createOrUpdateUserFunderPermission",
+				"summary": "Creates or updates a user funder permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "userKeycloakUserId",
+						"description": "The keycloak user id of a user.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "funderShortCode",
+						"description": "The shortCode of a funder.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/shortCode"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be granted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "The resulting permission.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UserFunderPermission"
+								}
+							}
+						}
 					}
 				}
 			}

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -2917,6 +2917,52 @@
 						}
 					}
 				}
+			},
+			"delete": {
+				"operationId": "deleteUserFunderPermission",
+				"summary": "Deletes a user-funder permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "userKeycloakUserId",
+						"description": "The keycloak user id of a user.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "funderShortCode",
+						"description": "The shortCode of a funder.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/shortCode"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be deleted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Confirmation of successful deletion."
+					}
+				}
 			}
 		}
 	}

--- a/src/routers/usersRouter.ts
+++ b/src/routers/usersRouter.ts
@@ -27,5 +27,10 @@ usersRouter.put(
 	requireFunderPermission(Permission.MANAGE),
 	userFunderPermissionsHandlers.putUserFunderPermission,
 );
+usersRouter.delete(
+	'/:userKeycloakUserId/funders/:funderShortCode/permissions/:permission',
+	requireFunderPermission(Permission.MANAGE),
+	userFunderPermissionsHandlers.deleteUserFunderPermission,
+);
 
 export { usersRouter };

--- a/src/routers/usersRouter.ts
+++ b/src/routers/usersRouter.ts
@@ -4,8 +4,10 @@ import { usersHandlers } from '../handlers/usersHandlers';
 import {
 	requireAuthentication,
 	requireChangemakerPermission,
+	requireFunderPermission,
 } from '../middleware';
 import { Permission } from '../types';
+import { userFunderPermissionsHandlers } from '../handlers/userFunderPermissionsHandlers';
 
 const usersRouter = express.Router();
 
@@ -19,6 +21,11 @@ usersRouter.delete(
 	'/:userKeycloakUserId/changemakers/:changemakerId/permissions/:permission',
 	requireChangemakerPermission(Permission.MANAGE),
 	userChangemakerPermissionsHandlers.deleteUserChangemakerPermission,
+);
+usersRouter.put(
+	'/:userKeycloakUserId/funders/:funderShortCode/permissions/:permission',
+	requireFunderPermission(Permission.MANAGE),
+	userFunderPermissionsHandlers.putUserFunderPermission,
 );
 
 export { usersRouter };


### PR DESCRIPTION
This PR adds two new endpoints that make it possible to create and delete UserFunderPermissions in the PDC.

It uses the same patterns that were established for UserChangemakerPermissions

Related to #1250 