### PR TITLE
Add `PUT` and `DELETE` endpoints for UserDataProviderPermissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ### Added
 
 - Manage user-funder permissions using `PUT`, and `DELETE` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
+- Manage user-data-provider permissions using `PUT` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+
+- Manage user-funder permissions using `PUT`, and `DELETE` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Manage user-funder permissions using `PUT`, and `DELETE` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
-- Manage user-data-provider permissions using `PUT` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
+- Manage user-data-provider permissions using `PUT`, and `DELETE` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
 
 ### Added
 

--- a/src/__tests__/userDataProviderPermissions.int.test.ts
+++ b/src/__tests__/userDataProviderPermissions.int.test.ts
@@ -1,0 +1,166 @@
+import request from 'supertest';
+import { app } from '../app';
+import {
+	createOrUpdateDataProvider,
+	createOrUpdateUserDataProviderPermission,
+	loadSystemUser,
+} from '../database';
+import { expectTimestamp, loadTestUser } from '../test/utils';
+import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
+} from '../test/mockJwt';
+import { keycloakIdToString, Permission } from '../types';
+
+describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', () => {
+	describe('PUT /', () => {
+		it('returns 401 if the request lacks authentication', async () => {
+			const user = await loadTestUser();
+			const dataProvider = await createOrUpdateDataProvider({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 401 if the authenticated user lacks permission', async () => {
+			const user = await loadTestUser();
+			const dataProvider = await createOrUpdateDataProvider({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+
+			await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 400 if the userId is not a valid keycloak user ID', async () => {
+			await request(app)
+				.put(
+					`/users/notaguid/dataProviders/ExampleInc/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the data provider ID is not a valid short code', async () => {
+			const user = await loadTestUser();
+			await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/dataProviders/this is not valid/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the permission is not a valid permission', async () => {
+			const user = await loadTestUser();
+			await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/dataProviders/ExampleInc/permissions/notAPermission`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('creates and returns the new user data provider permission when user has administrative credentials', async () => {
+			const user = await loadTestUser();
+			const dataProvider = await createOrUpdateDataProvider({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+
+			const response = await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				dataProviderShortCode: dataProvider.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+		});
+
+		it('creates and returns the new user data provider permission when user has permission to manage the data provider', async () => {
+			const user = await loadTestUser();
+			const dataProvider = await createOrUpdateDataProvider({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await createOrUpdateUserDataProviderPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				dataProviderShortCode: dataProvider.shortCode,
+				permission: Permission.MANAGE,
+				createdBy: user.keycloakUserId,
+			});
+
+			const response = await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				dataProviderShortCode: dataProvider.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+		});
+
+		it('does not update `createdBy`, but returns the user data provider permission when user has permission to manage the data provider', async () => {
+			const user = await loadTestUser();
+			const systemUser = await loadSystemUser();
+			const dataProvider = await createOrUpdateDataProvider({
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await createOrUpdateUserDataProviderPermission({
+				userKeycloakUserId: user.keycloakUserId,
+				dataProviderShortCode: dataProvider.shortCode,
+				permission: Permission.MANAGE,
+				createdBy: systemUser.keycloakUserId,
+			});
+
+			const response = await request(app)
+				.put(
+					`/users/${keycloakIdToString(user.keycloakUserId)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				dataProviderShortCode: dataProvider.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: systemUser.keycloakUserId,
+				permission: Permission.MANAGE,
+				userKeycloakUserId: user.keycloakUserId,
+			});
+		});
+	});
+});

--- a/src/database/operations/userDataProviderPermissions/assertUserDataProviderPermissionExists.ts
+++ b/src/database/operations/userDataProviderPermissions/assertUserDataProviderPermissionExists.ts
@@ -1,0 +1,37 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import type {
+	CheckResult,
+	KeycloakId,
+	Permission,
+	ShortCode,
+} from '../../../types';
+
+const assertUserDataProviderPermissionExists = async (
+	userKeycloakUserId: KeycloakId,
+	dataProviderShortCode: ShortCode,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql<CheckResult>(
+		'userDataProviderPermissions.checkExistsByPrimaryKey',
+		{
+			userKeycloakUserId,
+			dataProviderShortCode,
+			permission,
+		},
+	);
+
+	if (result.rows[0]?.result !== true) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'UserDataProviderPermission',
+			entityPrimaryKey: {
+				userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
+				dataProviderShortCode,
+				permission,
+			},
+		});
+	}
+};
+
+export { assertUserDataProviderPermissionExists };

--- a/src/database/operations/userDataProviderPermissions/index.ts
+++ b/src/database/operations/userDataProviderPermissions/index.ts
@@ -1,1 +1,4 @@
+export * from './assertUserDataProviderPermissionExists';
 export * from './createOrUpdateUserDataProviderPermission';
+export * from './loadUserDataProviderPermission';
+export * from './removeUserDataProviderPermission';

--- a/src/database/operations/userDataProviderPermissions/loadUserDataProviderPermission.ts
+++ b/src/database/operations/userDataProviderPermissions/loadUserDataProviderPermission.ts
@@ -1,0 +1,39 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import type {
+	JsonResultSet,
+	KeycloakId,
+	Permission,
+	ShortCode,
+	UserDataProviderPermission,
+} from '../../../types';
+
+const loadUserDataProviderPermission = async (
+	userKeycloakUserId: KeycloakId,
+	dataProviderShortCode: ShortCode,
+	permission: Permission,
+): Promise<UserDataProviderPermission> => {
+	const result = await db.sql<JsonResultSet<UserDataProviderPermission>>(
+		'userDataProviderPermissions.selectByPrimaryKey',
+		{
+			userKeycloakUserId,
+			dataProviderShortCode,
+			permission,
+		},
+	);
+	const object = result.rows[0]?.object;
+	if (object === undefined) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'UserDataProviderPermission',
+			entityPrimaryKey: {
+				userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
+				dataProviderShortCode,
+				permission,
+			},
+		});
+	}
+	return object;
+};
+
+export { loadUserDataProviderPermission };

--- a/src/database/operations/userDataProviderPermissions/removeUserDataProviderPermission.ts
+++ b/src/database/operations/userDataProviderPermissions/removeUserDataProviderPermission.ts
@@ -1,0 +1,32 @@
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import { db } from '../../db';
+import type { KeycloakId, Permission, ShortCode } from '../../../types';
+
+const removeUserDataProviderPermission = async (
+	userKeycloakUserId: KeycloakId,
+	dataProviderShortCode: ShortCode,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql('userDataProviderPermissions.deleteOne', {
+		userKeycloakUserId,
+		dataProviderShortCode,
+		permission,
+	});
+
+	if (result.row_count === 0) {
+		throw new NotFoundError(
+			'The item did not exist and could not be deleted.',
+			{
+				entityType: 'UserDataProviderPermission',
+				entityPrimaryKey: {
+					userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
+					dataProviderShortCode,
+					permission,
+				},
+			},
+		);
+	}
+};
+
+export { removeUserDataProviderPermission };

--- a/src/database/queries/userDataProviderPermissions/checkExistsByPrimaryKey.sql
+++ b/src/database/queries/userDataProviderPermissions/checkExistsByPrimaryKey.sql
@@ -1,0 +1,9 @@
+SELECT exists(
+	SELECT 1
+	FROM user_data_provider_permissions
+	WHERE
+		user_keycloak_user_id = :userKeycloakUserId
+		AND data_provider_short_code = :dataProviderShortCode
+		AND permission = :permission
+		AND NOT is_expired(not_after)
+) AS result;

--- a/src/database/queries/userDataProviderPermissions/deleteOne.sql
+++ b/src/database/queries/userDataProviderPermissions/deleteOne.sql
@@ -1,0 +1,7 @@
+UPDATE user_data_provider_permissions
+SET not_after = now()
+WHERE
+	user_keycloak_user_id = :userKeycloakUserId
+	AND permission = :permission::permission_t
+	AND data_provider_short_code = :dataProviderShortCode
+	AND NOT is_expired(not_after);

--- a/src/database/queries/userDataProviderPermissions/selectByPrimaryKey.sql
+++ b/src/database/queries/userDataProviderPermissions/selectByPrimaryKey.sql
@@ -1,0 +1,10 @@
+SELECT
+	user_data_provider_permission_to_json(
+		user_data_provider_permissions.*
+	) AS object
+FROM user_data_provider_permissions
+WHERE
+	user_keycloak_user_id = :userKeycloakUserId
+	AND data_provider_short_code = :dataProviderShortCode
+	AND permission = :permission
+	AND NOT is_expired(not_after);

--- a/src/handlers/userDataProviderPermissionsHandlers.ts
+++ b/src/handlers/userDataProviderPermissionsHandlers.ts
@@ -1,0 +1,91 @@
+import { createOrUpdateUserDataProviderPermission } from '../database';
+import {
+	isAuthContext,
+	isId,
+	isKeycloakId,
+	isPermission,
+	isShortCode,
+	isTinyPgErrorWithQueryContext,
+	isWritableUserFunderPermission,
+} from '../types';
+import {
+	DatabaseError,
+	FailedMiddlewareError,
+	InputValidationError,
+} from '../errors';
+import type { Request, Response, NextFunction } from 'express';
+
+const putUserDataProviderPermission = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
+
+	const { userKeycloakUserId, dataProviderShortCode, permission } = req.params;
+	const createdBy = req.user.keycloakUserId;
+
+	if (!isKeycloakId(userKeycloakUserId)) {
+		next(
+			new InputValidationError(
+				'Invalid userKeycloakUserId parameter.',
+				isKeycloakId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isShortCode(dataProviderShortCode)) {
+		next(
+			new InputValidationError(
+				'Invalid dataProviderShortCode parameter.',
+				isId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isPermission(permission)) {
+		next(
+			new InputValidationError(
+				'Invalid permission parameter.',
+				isPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isWritableUserFunderPermission(req.body)) {
+		next(
+			new InputValidationError(
+				'Invalid request body.',
+				isWritableUserFunderPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+
+	(async () => {
+		const userFunderPermission = await createOrUpdateUserDataProviderPermission(
+			{
+				userKeycloakUserId,
+				dataProviderShortCode,
+				permission,
+				createdBy,
+			},
+		);
+		res.status(201).contentType('application/json').send(userFunderPermission);
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error creating item.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const userDataProviderPermissionsHandlers = {
+	putUserDataProviderPermission,
+};
+
+export { userDataProviderPermissionsHandlers };

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -5,4 +5,5 @@ export * from './processJwt';
 export * from './requireAdministratorRole';
 export * from './requireAuthentication';
 export * from './requireChangemakerPermission';
+export * from './requireDataProviderPermission';
 export * from './requireFunderPermission';

--- a/src/middleware/requireDataProviderPermission.ts
+++ b/src/middleware/requireDataProviderPermission.ts
@@ -1,0 +1,56 @@
+/**
+ * Middleware to require a specific data provider permission for a request.
+ *
+ * @param {Permission} permission - The required permission to check for.
+ * @returns {Function} Middleware function to validate the data provider permission.
+ *
+ * The middleware does the following:
+ * 1. Ensures the request contains an AuthContext.
+ * 2. Allows the request to proceed if the user is an administrator.
+ * 3. Validates the `dataProviderShortCode` parameter in the request.
+ * 4. Checks if the authenticated user has the required permission for the specified data provider.
+ *
+ * If any of the checks fail, the middleware will pass an appropriate error to the next middleware.
+ */
+import { Response, NextFunction } from 'express';
+import { InputValidationError, UnauthorizedError } from '../errors';
+import { isAuthContext, isShortCode } from '../types';
+import type { Permission } from '../types';
+import type { Request } from 'express';
+
+const requireDataProviderPermission =
+	(permission: Permission) =>
+	(req: Request, res: Response, next: NextFunction) => {
+		if (!isAuthContext(req)) {
+			next(new UnauthorizedError('The request lacks an AuthContext.'));
+			return;
+		}
+		if (req.role?.isAdministrator === true) {
+			next();
+			return;
+		}
+		const { dataProviderShortCode } = req.params;
+		if (!isShortCode(dataProviderShortCode)) {
+			next(
+				new InputValidationError(
+					'Invalid dataProviderShortCode.',
+					isShortCode.errors ?? [],
+				),
+			);
+			return;
+		}
+		const { user } = req;
+		const permissions =
+			user.permissions.dataProvider[dataProviderShortCode] ?? [];
+		if (!permissions.includes(permission)) {
+			next(
+				new UnauthorizedError(
+					'Authenticated user does not have permission to perform this action.',
+				),
+			);
+			return;
+		}
+		next();
+	};
+
+export { requireDataProviderPermission };

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1224,6 +1224,41 @@
 					"createdBy",
 					"createdAt"
 				]
+			},
+			"UserDataProviderPermission": {
+				"type": "object",
+				"properties": {
+					"permission": {
+						"$ref": "#/components/schemas/Permission",
+						"readOnly": true
+					},
+					"dataProviderShortcode": {
+						"$ref": "#/components/schemas/shortCode",
+						"readOnly": true
+					},
+					"userKeycloakUserId": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdBy": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"readOnly": true
+					}
+				},
+				"required": [
+					"id",
+					"dataProviderShortcode",
+					"userKeycloakUserId",
+					"createdBy",
+					"createdAt"
+				]
 			}
 		}
 	},
@@ -2961,6 +2996,61 @@
 				"responses": {
 					"204": {
 						"description": "Confirmation of successful deletion."
+					}
+				}
+			}
+		},
+		"/users/{userKeycloakUserId}/dataProviders/{dataProviderShortCode}/permissions/{permission}": {
+			"put": {
+				"operationId": "createOrUpdateUserDataProviderPermission",
+				"summary": "Creates or updates a user data provider permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "userKeycloakUserId",
+						"description": "The keycloak user id of a user.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "dataProviderShortCode",
+						"description": "The shortCode of a funder.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/shortCode"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be granted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "The resulting permission.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UserDataProviderPermission"
+								}
+							}
+						}
 					}
 				}
 			}

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3053,6 +3053,52 @@
 						}
 					}
 				}
+			},
+			"delete": {
+				"operationId": "deleteUserDataProviderPermission",
+				"summary": "Deletes a user-data-provider permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "userKeycloakUserId",
+						"description": "The keycloak user id of a user.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "dataProviderShortCode",
+						"description": "The shortCode of a funder.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/shortCode"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be deleted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Confirmation of successful deletion."
+					}
+				}
 			}
 		}
 	}

--- a/src/routers/usersRouter.ts
+++ b/src/routers/usersRouter.ts
@@ -4,10 +4,12 @@ import { usersHandlers } from '../handlers/usersHandlers';
 import {
 	requireAuthentication,
 	requireChangemakerPermission,
+	requireDataProviderPermission,
 	requireFunderPermission,
 } from '../middleware';
 import { Permission } from '../types';
 import { userFunderPermissionsHandlers } from '../handlers/userFunderPermissionsHandlers';
+import { userDataProviderPermissionsHandlers } from '../handlers/userDataProviderPermissionsHandlers';
 
 const usersRouter = express.Router();
 
@@ -21,6 +23,11 @@ usersRouter.delete(
 	'/:userKeycloakUserId/changemakers/:changemakerId/permissions/:permission',
 	requireChangemakerPermission(Permission.MANAGE),
 	userChangemakerPermissionsHandlers.deleteUserChangemakerPermission,
+);
+usersRouter.put(
+	'/:userKeycloakUserId/dataProviders/:dataProviderShortCode/permissions/:permission',
+	requireDataProviderPermission(Permission.MANAGE),
+	userDataProviderPermissionsHandlers.putUserDataProviderPermission,
 );
 usersRouter.put(
 	'/:userKeycloakUserId/funders/:funderShortCode/permissions/:permission',

--- a/src/routers/usersRouter.ts
+++ b/src/routers/usersRouter.ts
@@ -29,6 +29,11 @@ usersRouter.put(
 	requireDataProviderPermission(Permission.MANAGE),
 	userDataProviderPermissionsHandlers.putUserDataProviderPermission,
 );
+usersRouter.delete(
+	'/:userKeycloakUserId/dataProviders/:dataProviderShortCode/permissions/:permission',
+	requireDataProviderPermission(Permission.MANAGE),
+	userDataProviderPermissionsHandlers.deleteUserDataProviderPermission,
+);
 usersRouter.put(
 	'/:userKeycloakUserId/funders/:funderShortCode/permissions/:permission',
 	requireFunderPermission(Permission.MANAGE),


### PR DESCRIPTION
This PR adds the final set of permission endpoints for our three organizational entity types.

Resolves #1250 
Resolves #1351