### PR TITLE
Add AuthContext to load query operations

### DIFF
--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -589,7 +589,7 @@ describe('/baseFields', () => {
 			const after = await loadTableMetrics('base_field_localizations');
 			const baseFieldLocalizations =
 				await loadBaseFieldLocalizationsBundleByBaseFieldId(
-					undefined,
+					null,
 					testBaseField.id,
 					NO_LIMIT,
 					NO_OFFSET,
@@ -631,7 +631,7 @@ describe('/baseFields', () => {
 			const after = await loadTableMetrics('base_field_localizations');
 			const baseFieldLocalizations =
 				await loadBaseFieldLocalizationsBundleByBaseFieldId(
-					undefined,
+					null,
 					testBaseField.id,
 					NO_LIMIT,
 					NO_OFFSET,

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -36,8 +36,8 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns bulk upload tasks associated with the requesting user', async () => {
-			const systemUser = await loadSystemUser();
-			const systemSource = await loadSystemSource();
+			const systemUser = await loadSystemUser(null);
+			const systemSource = await loadSystemSource(null);
 			const testUser = await loadTestUser();
 			const thirdUser = await createUser({
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
@@ -107,7 +107,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns all bulk uploads for administrative users', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			const testUser = await loadTestUser();
 			const anotherUser = await createUser({
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
@@ -163,7 +163,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns upload tasks for specified createdBy user', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			const testUser = await loadTestUser();
 			const anotherUser = await createUser({
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
@@ -210,7 +210,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns upload tasks for the admin user when createdBy is set to me as an admin', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			const testUser = await loadTestUser();
 			const anotherUser = await createUser({
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
@@ -255,7 +255,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('supports pagination', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			const testUser = await loadTestUser();
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
@@ -359,7 +359,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('creates exactly one bulk upload task', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			const before = await loadTableMetrics('bulk_upload_tasks');
 			const result = await request(app)
 				.post('/tasks/bulkUploads/')
@@ -390,7 +390,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when no file name is provided', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			const result = await request(app)
 				.post('/tasks/bulkUploads')
 				.type('application/json')
@@ -407,7 +407,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when an invalid file name is provided', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			const result = await request(app)
 				.post('/tasks/bulkUploads')
 				.type('application/json')

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -308,8 +308,8 @@ describe('/changemakers', () => {
 			let secondDataProviderSourceId: Id;
 
 			beforeEach(async () => {
-				systemSource = await loadSystemSource();
-				systemUser = await loadSystemUser();
+				systemSource = await loadSystemSource(null);
+				systemUser = await loadSystemUser(null);
 				baseFieldEmail = await createBaseField({
 					label: 'Fifty one fifty three',
 					shortCode: 'fifty_one_fifty_three',

--- a/src/__tests__/dataProviders.int.test.ts
+++ b/src/__tests__/dataProviders.int.test.ts
@@ -154,8 +154,10 @@ describe('/dataProviders', () => {
 					keycloakOrganizationId: '8b0163ac-bd91-11ef-8579-9fa8ab9f4b7d',
 				})
 				.expect(201);
-			const anotherDataProviderAfter =
-				await loadDataProvider('anotherFirework');
+			const anotherDataProviderAfter = await loadDataProvider(
+				null,
+				'anotherFirework',
+			);
 			const after = await loadTableMetrics('data_providers');
 			expect(result.body).toStrictEqual({
 				shortCode: 'firework',

--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -152,7 +152,7 @@ describe('/funders', () => {
 				.send({ name: '🎆' })
 				.expect(201);
 			const after = await loadTableMetrics('data_providers');
-			const anotherFunderAfter = await loadFunder('anotherFirework');
+			const anotherFunderAfter = await loadFunder(null, 'anotherFirework');
 			expect(result.body).toStrictEqual({
 				shortCode: 'firework',
 				name: '🎆',

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -41,7 +41,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('returns exactly one proposal version selected by id', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			const opportunity = await createOpportunity({ title: '🔥' });
 			const testUser = await loadTestUser();
 			const proposal = await createProposal({
@@ -102,7 +102,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('creates exactly one proposal version', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createOpportunity({ title: '🔥' });
 			const testUser = await loadTestUser();
 			await createProposal({
@@ -138,7 +138,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('creates exactly the number of provided field values', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createOpportunity({ title: '🔥' });
 			const testUser = await loadTestUser();
 			await createProposal({
@@ -268,7 +268,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('returns 409 Conflict when the provided proposal does not exist', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createOpportunity({ title: '🔥' });
 			const testUser = await loadTestUser();
 			await createProposal({
@@ -336,7 +336,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('Returns 409 Conflict if the provided application form does not exist', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createOpportunity({ title: '🔥' });
 			const testUser = await loadTestUser();
 			await createProposal({
@@ -376,7 +376,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('Returns 409 Conflict if the provided application form ID is not associated with the proposal opportunity', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createOpportunity({ title: '🔥' });
 			await createOpportunity({ title: '💧' });
 			const testUser = await loadTestUser();
@@ -422,7 +422,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('Returns 409 Conflict if a provided application form field ID does not exist', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createOpportunity({ title: '🔥' });
 			const testUser = await loadTestUser();
 			await createProposal({
@@ -469,7 +469,7 @@ describe('/proposalVersions', () => {
 		});
 
 		it('Returns 409 Conflict if a provided application form field ID is not associated with the supplied application form ID', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createOpportunity({ title: '🔥' });
 			const testUser = await loadTestUser();
 			await createProposal({

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -70,7 +70,7 @@ describe('/proposals', () => {
 			const secondUser = await createUser({
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createTestBaseFields();
 			await createProposal({
 				externalId: 'proposal-1',
@@ -250,7 +250,7 @@ describe('/proposals', () => {
 			});
 
 			const testUser = await loadTestUser();
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createTestBaseFields();
 			await createProposal({
 				externalId: 'proposal-1',
@@ -491,7 +491,7 @@ describe('/proposals', () => {
 				title: 'Grand opportunity',
 			});
 			const testUser = await loadTestUser();
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createTestBaseFields();
 			await createProposal({
 				externalId: 'proposal-4999',
@@ -788,7 +788,7 @@ describe('/proposals', () => {
 				label: 'Long summary or abstract',
 			});
 			const testUser = await loadTestUser();
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createProposal({
 				externalId: `proposal-2525-01-04T00Z`,
 				opportunityId: 1,
@@ -983,7 +983,7 @@ describe('/proposals', () => {
 
 		it('returns the proposal if an administrator requests a proposal they do not own', async () => {
 			const testUser = await loadTestUser();
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await createTestBaseFields();
 			await createOpportunity({
 				title: '🌎',

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -23,7 +23,7 @@ describe('/sources', () => {
 		});
 
 		it('returns the system source when no data has been added', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			await agent
 				.get('/sources')
 				.set(authHeader)
@@ -34,7 +34,7 @@ describe('/sources', () => {
 		});
 
 		it('returns all sources present in the database', async () => {
-			const systemSource = await loadSystemSource();
+			const systemSource = await loadSystemSource(null);
 			const changemaker = await createChangemaker({
 				taxId: '11-1111111',
 				name: 'Example Inc.',

--- a/src/__tests__/userChangemakerPermissions.int.test.ts
+++ b/src/__tests__/userChangemakerPermissions.int.test.ts
@@ -133,7 +133,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 
 		it('does not update `createdBy`, but returns the user changemaker permission when user has permission to manage the changemaker', async () => {
 			const user = await loadTestUser();
-			const systemUser = await loadSystemUser();
+			const systemUser = await loadSystemUser(null);
 			const changemaker = await createChangemaker({
 				taxId: '11-1111111',
 				name: 'Example Inc.',
@@ -283,6 +283,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserChangemakerPermission(
+				null,
 				user.keycloakUserId,
 				changemaker.id,
 				Permission.EDIT,
@@ -303,6 +304,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 				.expect(204);
 			await expect(
 				loadUserChangemakerPermission(
+					null,
 					user.keycloakUserId,
 					changemaker.id,
 					Permission.EDIT,
@@ -330,6 +332,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserChangemakerPermission(
+				null,
 				user.keycloakUserId,
 				changemaker.id,
 				Permission.EDIT,
@@ -350,6 +353,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 				.expect(204);
 			await expect(
 				loadUserChangemakerPermission(
+					null,
 					user.keycloakUserId,
 					changemaker.id,
 					Permission.EDIT,

--- a/src/__tests__/userDataProviderPermissions.int.test.ts
+++ b/src/__tests__/userDataProviderPermissions.int.test.ts
@@ -137,7 +137,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('does not update `createdBy`, but returns the user data provider permission when user has permission to manage the data provider', async () => {
 			const user = await loadTestUser();
-			const systemUser = await loadSystemUser();
+			const systemUser = await loadSystemUser(null);
 			const dataProvider = await createOrUpdateDataProvider({
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
@@ -288,6 +288,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserDataProviderPermission(
+				null,
 				user.keycloakUserId,
 				dataProvider.shortCode,
 				Permission.EDIT,
@@ -308,6 +309,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 				.expect(204);
 			await expect(
 				loadUserDataProviderPermission(
+					null,
 					user.keycloakUserId,
 					dataProvider.shortCode,
 					Permission.EDIT,
@@ -335,6 +337,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserDataProviderPermission(
+				null,
 				user.keycloakUserId,
 				dataProvider.shortCode,
 				Permission.EDIT,
@@ -355,6 +358,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 				.expect(204);
 			await expect(
 				loadUserDataProviderPermission(
+					null,
 					user.keycloakUserId,
 					dataProvider.shortCode,
 					Permission.EDIT,

--- a/src/__tests__/userFunderPermissions.int.test.ts
+++ b/src/__tests__/userFunderPermissions.int.test.ts
@@ -137,7 +137,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('does not update `createdBy`, but returns the user funder permission when user has permission to manage the funder', async () => {
 			const user = await loadTestUser();
-			const systemUser = await loadSystemUser();
+			const systemUser = await loadSystemUser(null);
 			const funder = await createOrUpdateFunder({
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
@@ -286,6 +286,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserFunderPermission(
+				null,
 				user.keycloakUserId,
 				funder.shortCode,
 				Permission.EDIT,
@@ -306,6 +307,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				.expect(204);
 			await expect(
 				loadUserFunderPermission(
+					null,
 					user.keycloakUserId,
 					funder.shortCode,
 					Permission.EDIT,
@@ -333,6 +335,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserFunderPermission(
+				null,
 				user.keycloakUserId,
 				funder.shortCode,
 				Permission.EDIT,
@@ -353,6 +356,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				.expect(204);
 			await expect(
 				loadUserFunderPermission(
+					null,
 					user.keycloakUserId,
 					funder.shortCode,
 					Permission.EDIT,

--- a/src/__tests__/users.int.test.ts
+++ b/src/__tests__/users.int.test.ts
@@ -57,7 +57,7 @@ describe('/users', () => {
 		});
 
 		it('returns the permissions associated with a user', async () => {
-			const systemUser = await loadSystemUser();
+			const systemUser = await loadSystemUser(null);
 			const testUser = await loadTestUser();
 			const dataProvider = await createOrUpdateDataProvider({
 				name: 'Test Provider',
@@ -121,7 +121,7 @@ describe('/users', () => {
 		});
 
 		it('does not return deleted permissions associated with a user', async () => {
-			const systemUser = await loadSystemUser();
+			const systemUser = await loadSystemUser(null);
 			const testUser = await loadTestUser();
 			const changemaker = await createChangemaker({
 				name: 'Test Changemaker',
@@ -162,7 +162,7 @@ describe('/users', () => {
 		});
 
 		it('returns all users when the user is an administrator', async () => {
-			const systemUser = await loadSystemUser();
+			const systemUser = await loadSystemUser(null);
 			const testUser = await loadTestUser();
 			const anotherUser = await createAdditionalTestUser();
 			const { count: userCount } = await loadTableMetrics('users');

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import type { User } from './types';
 let systemUser: User | null = null;
 
 export const loadConfig = async () => {
-	systemUser = await loadSystemUser();
+	systemUser = await loadSystemUser(null);
 };
 
 export const getSystemUser = (): User => {

--- a/src/database/operations/applicationFormFields/loadApplicationFormField.ts
+++ b/src/database/operations/applicationFormFields/loadApplicationFormField.ts
@@ -1,22 +1,11 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, ApplicationFormField } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { ApplicationFormField, Id } from '../../../types';
 
-export const loadApplicationFormField = async (
-	id: number,
-): Promise<ApplicationFormField> => {
-	const result = await db.sql<JsonResultSet<ApplicationFormField>>(
-		'applicationFormFields.selectById',
-		{
-			id,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'ApplicationFormField',
-			entityId: id,
-		});
-	}
-	return object;
-};
+const loadApplicationFormField = generateLoadItemOperation<
+	ApplicationFormField,
+	[applicationFormFieldId: Id]
+>('applicationFormFields.selectById', 'ApplicationFormField', [
+	'applicationFormFieldId',
+]);
+
+export { loadApplicationFormField };

--- a/src/database/operations/applicationForms/loadApplicationForm.ts
+++ b/src/database/operations/applicationForms/loadApplicationForm.ts
@@ -1,22 +1,9 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, ApplicationForm } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { ApplicationForm, Id } from '../../../types';
 
-export const loadApplicationForm = async (
-	id: number,
-): Promise<ApplicationForm> => {
-	const result = await db.sql<JsonResultSet<ApplicationForm>>(
-		'applicationForms.selectById',
-		{
-			id,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'ApplicationForm',
-			entityId: id,
-		});
-	}
-	return object;
-};
+const loadApplicationForm = generateLoadItemOperation<
+	ApplicationForm,
+	[applicationFormId: Id]
+>('applicationForms.selectById', 'ApplicationForm', ['applicationFormId']);
+
+export { loadApplicationForm };

--- a/src/database/operations/baseFields/loadBaseField.ts
+++ b/src/database/operations/baseFields/loadBaseField.ts
@@ -1,20 +1,10 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, BaseField } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { BaseField, Id } from '../../../types';
 
-export const loadBaseField = async (id: number): Promise<BaseField> => {
-	const result = await db.sql<JsonResultSet<BaseField>>(
-		'baseFields.selectById',
-		{
-			id,
-		},
-	);
-	const baseField = result.rows[0]?.object;
-	if (baseField === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'BaseField',
-			entityId: id,
-		});
-	}
-	return baseField;
-};
+const loadBaseField = generateLoadItemOperation<BaseField, [baseFieldId: Id]>(
+	'baseFields.selectById',
+	'BaseField',
+	['baseFieldId'],
+);
+
+export { loadBaseField };

--- a/src/database/operations/baseFieldsCopyTasks/loadBaseFieldsCopyTask.ts
+++ b/src/database/operations/baseFieldsCopyTasks/loadBaseFieldsCopyTask.ts
@@ -1,21 +1,11 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, BaseFieldsCopyTask } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { BaseFieldsCopyTask, Id } from '../../../types';
 
-export const loadBaseFieldsCopyTask = async (
-	id: number,
-): Promise<BaseFieldsCopyTask> => {
-	const baseFieldsCopyTaskQueryResult = await db.sql<
-		JsonResultSet<BaseFieldsCopyTask>
-	>('baseFieldsCopyTasks.selectById', {
-		id,
-	});
-	const { object } = baseFieldsCopyTaskQueryResult.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'BaseFieldsCopyTask',
-			entityId: id,
-		});
-	}
-	return object;
-};
+const loadBaseFieldsCopyTask = generateLoadItemOperation<
+	BaseFieldsCopyTask,
+	[baseFieldsCopyTaskId: Id]
+>('baseFieldsCopyTasks.selectById', 'BaseFieldsCopyTask', [
+	'baseFieldsCopyTaskId',
+]);
+
+export { loadBaseFieldsCopyTask };

--- a/src/database/operations/bulkUploadTasks/loadBulkUploadTask.ts
+++ b/src/database/operations/bulkUploadTasks/loadBulkUploadTask.ts
@@ -1,22 +1,7 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, BulkUploadTask } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { BulkUploadTask, Id } from '../../../types';
 
-export const loadBulkUploadTask = async (
-	id: number,
-): Promise<BulkUploadTask> => {
-	const bulkUploadsQueryResult = await db.sql<JsonResultSet<BulkUploadTask>>(
-		'bulkUploadTasks.selectById',
-		{
-			id,
-		},
-	);
-	const { object } = bulkUploadsQueryResult.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'BulkUploadTask',
-			entityId: id,
-		});
-	}
-	return object;
-};
+export const loadBulkUploadTask = generateLoadItemOperation<
+	BulkUploadTask,
+	[bulkUploadTaskId: Id]
+>('bulkUploadTasks.selectById', 'BulkUploadTask', ['bulkUploadTaskId']);

--- a/src/database/operations/changemakers/loadChangemaker.ts
+++ b/src/database/operations/changemakers/loadChangemaker.ts
@@ -1,32 +1,12 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import { getKeycloakUserIdFromAuthContext } from '../../../types';
-import type {
-	AuthContext,
-	Id,
-	JsonResultSet,
-	Changemaker,
-} from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { Changemaker, Id, KeycloakId } from '../../../types';
 
-export const loadChangemaker = async (
-	authContext: AuthContext | undefined,
-	id: Id,
-): Promise<Changemaker> => {
-	const authContextKeycloakUserId =
-		getKeycloakUserIdFromAuthContext(authContext);
-	const result = await db.sql<JsonResultSet<Changemaker>>(
-		'changemakers.selectById',
-		{
-			id,
-			authContextKeycloakUserId,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'Changemaker',
-			entityId: id,
-		});
-	}
-	return object;
-};
+const loadChangemaker = generateLoadItemOperation<
+	Changemaker,
+	[authContextKeycloakUserId: KeycloakId | undefined, changemakerId: Id]
+>('changemakers.selectById', 'Changemaker', [
+	'authContextKeycloakUserId',
+	'changemakerId',
+]);
+
+export { loadChangemaker };

--- a/src/database/operations/dataProviders/loadDataProvider.ts
+++ b/src/database/operations/dataProviders/loadDataProvider.ts
@@ -1,24 +1,9 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { DataProvider, JsonResultSet, ShortCode } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { DataProvider, ShortCode } from '../../../types';
 
-const loadDataProvider = async (
-	shortCode: ShortCode,
-): Promise<DataProvider> => {
-	const result = await db.sql<JsonResultSet<DataProvider>>(
-		'dataProviders.selectByShortCode',
-		{
-			shortCode,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'DataProvider',
-			entityShortCode: shortCode,
-		});
-	}
-	return object;
-};
+const loadDataProvider = generateLoadItemOperation<
+	DataProvider,
+	[dataProviderShortCode: ShortCode]
+>('dataProviders.selectByShortCode', 'DataProvider', ['dataProviderShortCode']);
 
 export { loadDataProvider };

--- a/src/database/operations/funders/loadFunder.ts
+++ b/src/database/operations/funders/loadFunder.ts
@@ -1,20 +1,9 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { Funder, JsonResultSet, ShortCode } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { Funder, ShortCode } from '../../../types';
 
-export const loadFunder = async (shortCode: ShortCode): Promise<Funder> => {
-	const result = await db.sql<JsonResultSet<Funder>>(
-		'funders.selectByShortCode',
-		{
-			shortCode,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'Funder',
-			entityShortCode: shortCode,
-		});
-	}
-	return object;
-};
+const loadFunder = generateLoadItemOperation<
+	Funder,
+	[funderShortCode: ShortCode]
+>('funders.selectByShortCode', 'Funder', ['funderShortCode']);
+
+export { loadFunder };

--- a/src/database/operations/generators/generateLoadBundleOperation.ts
+++ b/src/database/operations/generators/generateLoadBundleOperation.ts
@@ -25,7 +25,7 @@ const generateLoadBundleOperation = <T, P extends [...args: unknown[]]>(
 ) => {
 	const generatedParameterNames = [...parameterNames, 'limit', 'offset'];
 	return async (
-		authContext: AuthContext | undefined,
+		authContext: AuthContext | null,
 		...args: [...P, limit: number | undefined, offset: number | undefined]
 	): Promise<Bundle<T>> => {
 		const queryParameters = generatedParameterNames.reduce(

--- a/src/database/operations/generators/generateLoadBundleOperation.ts
+++ b/src/database/operations/generators/generateLoadBundleOperation.ts
@@ -1,3 +1,11 @@
+import { db } from '../../db';
+import { loadTableMetrics } from '../generic/loadTableMetrics';
+import {
+	getIsAdministratorFromAuthContext,
+	getKeycloakUserIdFromAuthContext,
+} from '../../../types';
+import type { AuthContext, Bundle, JsonResultSet } from '../../../types';
+
 /**
  * Generates a bundle loader function for a specific query and table.
  *
@@ -10,15 +18,6 @@
  *
  * @returns {Function} A function that takes query parameters, limit, and offset, and returns a promise that resolves to a bundle of entries and total count.
  */
-
-import { db } from '../../db';
-import { loadTableMetrics } from '../generic/loadTableMetrics';
-import {
-	getIsAdministratorFromAuthContext,
-	getKeycloakUserIdFromAuthContext,
-} from '../../../types';
-import type { AuthContext, Bundle, JsonResultSet } from '../../../types';
-
 const generateLoadBundleOperation = <T, P extends [...args: unknown[]]>(
 	queryName: string,
 	tableName: string,

--- a/src/database/operations/generators/generateLoadItemOperation.ts
+++ b/src/database/operations/generators/generateLoadItemOperation.ts
@@ -1,0 +1,43 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import type { JsonResultSet } from '../../../types';
+
+/**
+ * Generates an item loader function for a specific query and table.
+ *
+ * @template T - The type of the item being loaded.
+ * @template P - The type of the parameters for the query. Use labeled tuples so the generated function has a pretty type definition.
+ *
+ * @param {string} queryName - The name of the query to execute.
+ * @param {string} entityType - The name of entity type being loaded, for use in error messages.
+ * @param {Object} parameterNames - An object mapping parameter indices to their names within the query.
+ *
+ * @returns {Function} A function that takes query parameters, limit, and offset, and returns a promise that resolves to a bundle of entries and total count.
+ */
+ const generateLoadItemOperation = <T, P extends [...args: unknown[]]>(
+	queryName: string,
+	entityType: string,
+	parameterNames: { [K in keyof P]: string },
+) => {
+	return async (...args: [...P]): Promise<T> => {
+		const queryParameters = parameterNames.reduce(
+			(acc, parameterName, index) => ({
+				...acc,
+				[parameterName]: args[index],
+			}),
+			{},
+		);
+
+		const result = await db.sql<JsonResultSet<T>>(queryName, queryParameters);
+		const { object } = result.rows[0] ?? {};
+		if (object === undefined) {
+			throw new NotFoundError(`Entity not found`, {
+				entityType,
+				lookupValues: queryParameters,
+			});
+		}
+		return object;
+	};
+};
+
+export { generateLoadItemOperation };

--- a/src/database/operations/generators/index.ts
+++ b/src/database/operations/generators/index.ts
@@ -1,1 +1,2 @@
 export * from './generateLoadBundleOperation';
+export * from './generateLoadItemOperation';

--- a/src/database/operations/opportunities/loadOpportunity.ts
+++ b/src/database/operations/opportunities/loadOpportunity.ts
@@ -1,22 +1,9 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, Opportunity } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { Id, Opportunity } from '../../../types';
 
-const loadOpportunity = async (id: number): Promise<Opportunity> => {
-	const result = await db.sql<JsonResultSet<Opportunity>>(
-		'opportunities.selectById',
-		{
-			id,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'Opportunity',
-			entityId: id,
-		});
-	}
-	return object;
-};
+const loadOpportunity = generateLoadItemOperation<
+	Opportunity,
+	[opportunityId: Id]
+>('opportunities.selectById', 'Opportunity', ['opportunityId']);
 
 export { loadOpportunity };

--- a/src/database/operations/proposalVersions/loadProposalVersion.ts
+++ b/src/database/operations/proposalVersions/loadProposalVersion.ts
@@ -1,22 +1,9 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, ProposalVersion } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { Id, ProposalVersion } from '../../../types';
 
-export const loadProposalVersion = async (
-	id: number,
-): Promise<ProposalVersion> => {
-	const result = await db.sql<JsonResultSet<ProposalVersion>>(
-		'proposalVersions.selectById',
-		{
-			id,
-		},
-	);
-	const proposalVersion = result.rows[0]?.object;
-	if (proposalVersion === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'ProposalVersion',
-			entityId: id,
-		});
-	}
-	return proposalVersion;
-};
+const loadProposalVersion = generateLoadItemOperation<
+	ProposalVersion,
+	[proposalVersionId: Id]
+>('proposalVersions.selectById', 'ProposalVersion', ['proposalVersionId']);
+
+export { loadProposalVersion };

--- a/src/database/operations/proposals/loadProposal.ts
+++ b/src/database/operations/proposals/loadProposal.ts
@@ -1,17 +1,10 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, Proposal } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { Id, Proposal } from '../../../types';
 
-export const loadProposal = async (id: number): Promise<Proposal> => {
-	const result = await db.sql<JsonResultSet<Proposal>>('proposals.selectById', {
-		id,
-	});
-	const proposal = result.rows[0]?.object;
-	if (proposal === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'Proposal',
-			entityId: id,
-		});
-	}
-	return proposal;
-};
+const loadProposal = generateLoadItemOperation<Proposal, [proposalId: Id]>(
+	'proposals.selectById',
+	'Proposal',
+	['proposalId'],
+);
+
+export { loadProposal };

--- a/src/database/operations/sources/__test__/loadSystemSource.int.test.ts
+++ b/src/database/operations/sources/__test__/loadSystemSource.int.test.ts
@@ -3,7 +3,7 @@ import { expectTimestamp } from '../../../../test/utils';
 
 describe('loadSystemSource', () => {
 	it('loads the expected system source', async () => {
-		const systemSource = await loadSystemSource();
+		const systemSource = await loadSystemSource(null);
 		expect(systemSource).toMatchObject({
 			createdAt: expectTimestamp,
 			dataProvider: {

--- a/src/database/operations/sources/loadSource.ts
+++ b/src/database/operations/sources/loadSource.ts
@@ -1,17 +1,10 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, Source } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { Id, Source } from '../../../types';
 
-export const loadSource = async (id: number): Promise<Source> => {
-	const result = await db.sql<JsonResultSet<Source>>('sources.selectById', {
-		id,
-	});
-	const item = result.rows[0]?.object;
-	if (item === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'Source',
-			entityId: id,
-		});
-	}
-	return item;
-};
+const loadSource = generateLoadItemOperation<Source, [sourceId: Id]>(
+	'sources.selectById',
+	'Source',
+	['sourceId'],
+);
+
+export { loadSource };

--- a/src/database/operations/sources/loadSystemSource.ts
+++ b/src/database/operations/sources/loadSystemSource.ts
@@ -1,22 +1,10 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, Source } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { Source } from '../../../types';
 
-const loadSystemSource = async (): Promise<Source> => {
-	const result = await db.sql<JsonResultSet<Source>>(
-		'sources.selectSystemSource',
-		{},
-	);
-	const item = result.rows[0]?.object;
-	if (item === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'Source',
-			lookupValues: {
-				specialQuery: 'selectSystemSource',
-			},
-		});
-	}
-	return item;
-};
+const loadSystemSource = generateLoadItemOperation<Source, []>(
+	'sources.selectSystemSource',
+	'Source',
+	[],
+);
 
 export { loadSystemSource };

--- a/src/database/operations/userChangemakerPermissions/loadUserChangemakerPermission.ts
+++ b/src/database/operations/userChangemakerPermissions/loadUserChangemakerPermission.ts
@@ -1,37 +1,18 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import { keycloakIdToString } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
 import type {
 	Id,
-	JsonResultSet,
 	KeycloakId,
 	Permission,
 	UserChangemakerPermission,
 } from '../../../types';
 
-export const loadUserChangemakerPermission = async (
-	userKeycloakUserId: KeycloakId,
-	changemakerId: Id,
-	permission: Permission,
-): Promise<UserChangemakerPermission> => {
-	const result = await db.sql<JsonResultSet<UserChangemakerPermission>>(
-		'userChangemakerPermissions.selectByPrimaryKey',
-		{
-			userKeycloakUserId,
-			changemakerId,
-			permission,
-		},
-	);
-	const object = result.rows[0]?.object;
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'UserChangemakerPermission',
-			entityPrimaryKey: {
-				userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
-				changemakerId,
-				permission,
-			},
-		});
-	}
-	return object;
-};
+const loadUserChangemakerPermission = generateLoadItemOperation<
+	UserChangemakerPermission,
+	[userKeycloakUserId: KeycloakId, changemakerId: Id, permission: Permission]
+>(
+	'userChangemakerPermissions.selectByPrimaryKey',
+	'UserChangemakerPermission',
+	['userKeycloakUserId', 'changemakerId', 'permission'],
+);
+
+export { loadUserChangemakerPermission };

--- a/src/database/operations/userDataProviderPermissions/loadUserDataProviderPermission.ts
+++ b/src/database/operations/userDataProviderPermissions/loadUserDataProviderPermission.ts
@@ -1,39 +1,22 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import { keycloakIdToString } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
 import type {
-	JsonResultSet,
 	KeycloakId,
 	Permission,
 	ShortCode,
 	UserDataProviderPermission,
 } from '../../../types';
 
-const loadUserDataProviderPermission = async (
-	userKeycloakUserId: KeycloakId,
-	dataProviderShortCode: ShortCode,
-	permission: Permission,
-): Promise<UserDataProviderPermission> => {
-	const result = await db.sql<JsonResultSet<UserDataProviderPermission>>(
-		'userDataProviderPermissions.selectByPrimaryKey',
-		{
-			userKeycloakUserId,
-			dataProviderShortCode,
-			permission,
-		},
-	);
-	const object = result.rows[0]?.object;
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'UserDataProviderPermission',
-			entityPrimaryKey: {
-				userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
-				dataProviderShortCode,
-				permission,
-			},
-		});
-	}
-	return object;
-};
+const loadUserDataProviderPermission = generateLoadItemOperation<
+	UserDataProviderPermission,
+	[
+		userKeycloakUserId: KeycloakId,
+		dataProviderShortCode: ShortCode,
+		permission: Permission,
+	]
+>(
+	'userDataProviderPermissions.selectByPrimaryKey',
+	'UserDataProviderPermission',
+	['userKeycloakUserId', 'dataProviderShortCode', 'permission'],
+);
 
 export { loadUserDataProviderPermission };

--- a/src/database/operations/userFunderPermissions/loadUserFunderPermission.ts
+++ b/src/database/operations/userFunderPermissions/loadUserFunderPermission.ts
@@ -1,37 +1,22 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import { keycloakIdToString } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
 import type {
-	JsonResultSet,
 	KeycloakId,
 	Permission,
 	ShortCode,
 	UserFunderPermission,
 } from '../../../types';
 
-export const loadUserFunderPermission = async (
-	userKeycloakUserId: KeycloakId,
-	funderShortCode: ShortCode,
-	permission: Permission,
-): Promise<UserFunderPermission> => {
-	const result = await db.sql<JsonResultSet<UserFunderPermission>>(
-		'userFunderPermissions.selectByPrimaryKey',
-		{
-			userKeycloakUserId,
-			funderShortCode,
-			permission,
-		},
-	);
-	const object = result.rows[0]?.object;
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'UserFunderPermission',
-			entityPrimaryKey: {
-				userKeycloakUserId: keycloakIdToString(userKeycloakUserId),
-				funderShortCode,
-				permission,
-			},
-		});
-	}
-	return object;
-};
+const loadUserFunderPermission = generateLoadItemOperation<
+	UserFunderPermission,
+	[
+		userKeycloakUserId: KeycloakId,
+		funderShortCode: ShortCode,
+		permission: Permission,
+	]
+>('userFunderPermissions.selectByPrimaryKey', 'UserFunderPermission', [
+	'userKeycloakUserId',
+	'funderShortCode',
+	'permission',
+]);
+
+export { loadUserFunderPermission };

--- a/src/database/operations/users/__tests__/loadSystemUser.unit.test.ts
+++ b/src/database/operations/users/__tests__/loadSystemUser.unit.test.ts
@@ -14,6 +14,6 @@ describe('loadSystemUser', () => {
 				}) as Result<object>,
 		);
 
-		await expect(loadSystemUser()).rejects.toThrow(NotFoundError);
+		await expect(loadSystemUser(null)).rejects.toThrow(NotFoundError);
 	});
 });

--- a/src/database/operations/users/loadSystemUser.ts
+++ b/src/database/operations/users/loadSystemUser.ts
@@ -1,22 +1,10 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type { JsonResultSet, User } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { User } from '../../../types';
 
-const loadSystemUser = async (): Promise<User> => {
-	const result = await db.sql<JsonResultSet<User>>(
-		'users.selectSystemUser',
-		{},
-	);
-	const item = result.rows[0]?.object;
-	if (item === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'User',
-			lookupValues: {
-				specialQuery: 'selectSystemUser',
-			},
-		});
-	}
-	return item;
-};
+const loadSystemUser = generateLoadItemOperation<User, []>(
+	'users.selectSystemUser',
+	'User',
+	[],
+);
 
 export { loadSystemUser };

--- a/src/database/operations/users/loadUserByKeycloakUserId.ts
+++ b/src/database/operations/users/loadUserByKeycloakUserId.ts
@@ -1,23 +1,9 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import { keycloakIdToString } from '../../../types';
-import type { JsonResultSet, KeycloakId, User } from '../../../types';
+import { generateLoadItemOperation } from '../generators';
+import type { KeycloakId, User } from '../../../types';
 
-export const loadUserByKeycloakUserId = async (
-	keycloakUserId: KeycloakId,
-): Promise<User> => {
-	const userQueryResult = await db.sql<JsonResultSet<User>>(
-		'users.selectByKeycloakUserId',
-		{
-			keycloakUserId,
-		},
-	);
-	const { object } = userQueryResult.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'User',
-			lookupValues: { keycloakUserId: keycloakIdToString(keycloakUserId) },
-		});
-	}
-	return object;
-};
+const loadUserByKeycloakUserId = generateLoadItemOperation<
+	User,
+	[keycloakUserId: KeycloakId]
+>('users.selectByKeycloakUserId', 'User', ['keycloakUserId']);
+
+export { loadUserByKeycloakUserId };

--- a/src/database/queries/applicationFormFields/selectById.sql
+++ b/src/database/queries/applicationFormFields/selectById.sql
@@ -1,3 +1,3 @@
 SELECT application_form_field_to_json(application_form_fields) AS object
 FROM application_form_fields
-WHERE id = :id;
+WHERE id = :applicationFormFieldId;

--- a/src/database/queries/applicationForms/selectById.sql
+++ b/src/database/queries/applicationForms/selectById.sql
@@ -1,3 +1,3 @@
 SELECT application_form_to_json(application_forms) AS object
 FROM application_forms
-WHERE id = :id;
+WHERE id = :applicationFormId;

--- a/src/database/queries/baseFields/selectById.sql
+++ b/src/database/queries/baseFields/selectById.sql
@@ -1,3 +1,3 @@
 SELECT base_field_to_json(base_fields.*) AS object
 FROM base_fields
-WHERE id = :id;
+WHERE id = :baseFieldId;

--- a/src/database/queries/baseFieldsCopyTasks/selectById.sql
+++ b/src/database/queries/baseFieldsCopyTasks/selectById.sql
@@ -1,3 +1,3 @@
 SELECT base_fields_copy_task_to_json(base_fields_copy_tasks.*) AS object
 FROM base_fields_copy_tasks
-WHERE id = :id;
+WHERE id = :baseFieldsCopyTaskId;

--- a/src/database/queries/bulkUploadTasks/selectById.sql
+++ b/src/database/queries/bulkUploadTasks/selectById.sql
@@ -1,3 +1,3 @@
 SELECT bulk_upload_task_to_json(bulk_upload_tasks.*) AS object
 FROM bulk_upload_tasks
-WHERE id = :id;
+WHERE id = :bulkUploadTaskId;

--- a/src/database/queries/changemakers/selectById.sql
+++ b/src/database/queries/changemakers/selectById.sql
@@ -1,3 +1,3 @@
 SELECT changemaker_to_json(changemakers.*, :authContextKeycloakUserId) AS object
 FROM changemakers
-WHERE id = :id;
+WHERE id = :changemakerId;

--- a/src/database/queries/dataProviders/selectByShortCode.sql
+++ b/src/database/queries/dataProviders/selectByShortCode.sql
@@ -1,3 +1,3 @@
 SELECT data_provider_to_json(data_providers.*) AS object
 FROM data_providers
-WHERE short_code = :shortCode;
+WHERE short_code = :dataProviderShortCode;

--- a/src/database/queries/funders/selectByShortCode.sql
+++ b/src/database/queries/funders/selectByShortCode.sql
@@ -1,3 +1,3 @@
 SELECT funder_to_json(funders.*) AS object
 FROM funders
-WHERE short_code = :shortCode;
+WHERE short_code = :funderShortCode;

--- a/src/database/queries/opportunities/selectById.sql
+++ b/src/database/queries/opportunities/selectById.sql
@@ -1,3 +1,3 @@
 SELECT opportunity_to_json(opportunities) AS object
 FROM opportunities
-WHERE id = :id;
+WHERE id = :opportunityId;

--- a/src/database/queries/proposalVersions/selectById.sql
+++ b/src/database/queries/proposalVersions/selectById.sql
@@ -1,3 +1,3 @@
 SELECT proposal_version_to_json(proposal_versions.*) AS object
 FROM proposal_versions
-WHERE id = :id;
+WHERE id = :proposalVersionId;

--- a/src/database/queries/proposals/selectById.sql
+++ b/src/database/queries/proposals/selectById.sql
@@ -1,3 +1,3 @@
 SELECT proposal_to_json(proposals.*) AS object
 FROM proposals
-WHERE id = :id;
+WHERE id = :proposalId;

--- a/src/database/queries/sources/selectById.sql
+++ b/src/database/queries/sources/selectById.sql
@@ -1,3 +1,3 @@
 SELECT source_to_json(sources.*) AS object
 FROM sources
-WHERE id = :id;
+WHERE id = :sourceId;

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -15,7 +15,7 @@ interface NotFoundErrorDetailsWithComplexPrimaryKey {
 
 interface NotFoundErrorDetailsWithLookupValues {
 	entityType: string;
-	lookupValues: Record<string, number | string>;
+	lookupValues: Record<string, unknown>;
 }
 
 type NotFoundErrorDetails =

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -44,7 +44,7 @@ const getApplicationForm = (
 		next(new InputValidationError('Invalid request.', isId.errors ?? []));
 		return;
 	}
-	loadApplicationForm(applicationFormId)
+	loadApplicationForm(null, applicationFormId)
 		.then((applicationForm) => {
 			res.status(200).contentType('application/json').send(applicationForm);
 		})

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -21,7 +21,7 @@ const getApplicationForms = (
 ): void => {
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
-	loadApplicationFormBundle(undefined, limit, offset)
+	loadApplicationFormBundle(null, limit, offset)
 		.then((applicationForms) => {
 			res.status(200).contentType('application/json').send(applicationForms);
 		})

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -117,7 +117,7 @@ const getBaseFieldLocalizationsByBaseFieldId = (
 	assertBaseFieldExists(baseFieldId)
 		.then(() => {
 			loadBaseFieldLocalizationsBundleByBaseFieldId(
-				undefined,
+				null,
 				baseFieldId,
 				limit,
 				offset,

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -19,7 +19,7 @@ import {
 import type { Request, Response, NextFunction } from 'express';
 
 const assertBaseFieldExists = async (baseFieldId: number): Promise<void> => {
-	await loadBaseField(baseFieldId);
+	await loadBaseField(null, baseFieldId);
 };
 
 const getBaseFields = (

--- a/src/handlers/changemakerProposalsHandlers.ts
+++ b/src/handlers/changemakerProposalsHandlers.ts
@@ -27,7 +27,7 @@ const getChangemakerProposals = (
 
 	(async () => {
 		const changemakerProposalBundle = await loadChangemakerProposalBundle(
-			undefined,
+			null,
 			changemakerId,
 			proposalId,
 			limit,

--- a/src/handlers/changemakersHandlers.ts
+++ b/src/handlers/changemakersHandlers.ts
@@ -78,7 +78,11 @@ const getChangemaker = (
 		return;
 	}
 	const authContext = isAuthContext(req) ? req : undefined;
-	loadChangemaker(getKeycloakUserIdFromAuthContext(authContext), changemakerId)
+	loadChangemaker(
+		null,
+		getKeycloakUserIdFromAuthContext(authContext),
+		changemakerId,
+	)
 		.then((changemaker) => {
 			res.status(200).contentType('application/json').send(changemaker);
 		})

--- a/src/handlers/changemakersHandlers.ts
+++ b/src/handlers/changemakersHandlers.ts
@@ -9,6 +9,7 @@ import {
 	isWritableChangemaker,
 	isTinyPgErrorWithQueryContext,
 	isAuthContext,
+	getKeycloakUserIdFromAuthContext,
 } from '../types';
 import { DatabaseError, InputValidationError } from '../errors';
 import {
@@ -77,7 +78,7 @@ const getChangemaker = (
 		return;
 	}
 	const authContext = isAuthContext(req) ? req : undefined;
-	loadChangemaker(authContext, changemakerId)
+	loadChangemaker(getKeycloakUserIdFromAuthContext(authContext), changemakerId)
 		.then((changemaker) => {
 			res.status(200).contentType('application/json').send(changemaker);
 		})

--- a/src/handlers/changemakersHandlers.ts
+++ b/src/handlers/changemakersHandlers.ts
@@ -53,7 +53,7 @@ const getChangemakers = (
 	const paginationParameters = extractPaginationParameters(req);
 	const { limit, offset } = getLimitValues(paginationParameters);
 	const { proposalId } = extractProposalParameters(req);
-	const authContext = isAuthContext(req) ? req : undefined;
+	const authContext = isAuthContext(req) ? req : null;
 	loadChangemakerBundle(authContext, proposalId, limit, offset)
 		.then((changemakerBundle) => {
 			res.status(200).contentType('application/json').send(changemakerBundle);

--- a/src/handlers/dataProvidersHandlers.ts
+++ b/src/handlers/dataProvidersHandlers.ts
@@ -54,7 +54,7 @@ const getDataProvider = (
 		);
 		return;
 	}
-	loadDataProvider(dataProviderShortCode)
+	loadDataProvider(null, dataProviderShortCode)
 		.then((item) => {
 			res.status(200).contentType('application/json').send(item);
 		})

--- a/src/handlers/fundersHandlers.ts
+++ b/src/handlers/fundersHandlers.ts
@@ -46,7 +46,7 @@ const getFunder = (req: Request, res: Response, next: NextFunction): void => {
 		);
 		return;
 	}
-	loadFunder(funderShortCode)
+	loadFunder(null, funderShortCode)
 		.then((funder) => {
 			res.status(200).contentType('application/json').send(funder);
 		})

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -20,7 +20,7 @@ const getOpportunities = (
 ): void => {
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
-	loadOpportunityBundle(undefined, limit, offset)
+	loadOpportunityBundle(null, limit, offset)
 		.then((opportunityBundle) => {
 			res.status(200).contentType('application/json').send(opportunityBundle);
 		})

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -43,7 +43,7 @@ const getOpportunity = (
 		next(new InputValidationError('Invalid id parameter.', isId.errors ?? []));
 		return;
 	}
-	loadOpportunity(opportunityId)
+	loadOpportunity(null, opportunityId)
 		.then((opportunity) => {
 			res.status(200).contentType('application/json').send(opportunity);
 		})

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -35,7 +35,7 @@ const assertApplicationFormExistsForProposal = async (
 ): Promise<void> => {
 	let applicationForm: ApplicationForm;
 	try {
-		applicationForm = await loadApplicationForm(applicationFormId);
+		applicationForm = await loadApplicationForm(null, applicationFormId);
 	} catch {
 		throw new InputConflictError('The Application Form does not exist.', {
 			entityType: 'ApplicationForm',
@@ -45,7 +45,7 @@ const assertApplicationFormExistsForProposal = async (
 
 	let proposal: Proposal;
 	try {
-		proposal = await loadProposal(proposalId);
+		proposal = await loadProposal(null, proposalId);
 	} catch (err) {
 		if (err instanceof NotFoundError) {
 			throw new InputConflictError(
@@ -83,6 +83,7 @@ const assertProposalFieldValuesMapToApplicationForm = async (
 			const { applicationFormFieldId } = proposalFieldValue;
 			try {
 				const applicationFormField = await loadApplicationFormField(
+					null,
 					proposalFieldValue.applicationFormFieldId,
 				);
 				if (applicationFormField.applicationFormId !== applicationFormId) {
@@ -156,6 +157,7 @@ const postProposalVersion = (
 					fieldValues.map(async (fieldValue) => {
 						const { value, applicationFormFieldId } = fieldValue;
 						const applicationFormField = await loadApplicationFormField(
+							null,
 							applicationFormFieldId,
 						);
 						const isValid = fieldValueIsValid(
@@ -226,7 +228,7 @@ const getProposalVersion = (
 		);
 		return;
 	}
-	loadProposalVersion(proposalVersionId)
+	loadProposalVersion(null, proposalVersionId)
 		.then((item) => {
 			res.status(200).contentType('application/json').send(item);
 		})

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -71,7 +71,7 @@ const getProposal = (req: Request, res: Response, next: NextFunction): void => {
 	}
 	(async () => {
 		await assertProposalAuthorization(proposalId, req);
-		const proposal = await loadProposal(proposalId);
+		const proposal = await loadProposal(null, proposalId);
 		res.status(200).contentType('application/json').send(proposal);
 	})().catch((error: unknown) => {
 		if (isTinyPgErrorWithQueryContext(error)) {

--- a/src/handlers/sourcesHandlers.ts
+++ b/src/handlers/sourcesHandlers.ts
@@ -75,7 +75,7 @@ const getSource = (req: Request, res: Response, next: NextFunction): void => {
 		next(new InputValidationError('Invalid request body.', isId.errors ?? []));
 		return;
 	}
-	loadSource(sourceId)
+	loadSource(null, sourceId)
 		.then((item) => {
 			res.status(200).contentType('application/json').send(item);
 		})

--- a/src/middleware/__tests__/addUserContext.int.test.ts
+++ b/src/middleware/__tests__/addUserContext.int.test.ts
@@ -42,6 +42,7 @@ describe('addUserContext', () => {
 					expect(err).toBe(undefined);
 					const { count: userCount } = await loadTableMetrics('users');
 					const user = await loadUserByKeycloakUserId(
+						null,
 						stringToKeycloakId('123e4567-e89b-12d3-a456-426614174000'),
 					);
 					expect(mockRequest.user).toEqual(user);

--- a/src/middleware/addUserContext.ts
+++ b/src/middleware/addUserContext.ts
@@ -12,7 +12,7 @@ import type { AuthenticatedRequest, KeycloakId } from '../types';
 
 const selectOrCreateUser = async (keycloakUserId: KeycloakId) => {
 	try {
-		return await loadUserByKeycloakUserId(keycloakUserId);
+		return await loadUserByKeycloakUserId(null, keycloakUserId);
 	} catch {
 		const user = await createUser({ keycloakUserId });
 		return user;

--- a/src/tasks/__tests__/copyBaseFields.int.test.ts
+++ b/src/tasks/__tests__/copyBaseFields.int.test.ts
@@ -24,7 +24,7 @@ const MOCK_API_URL = 'https://example.com';
 const createTestBaseFieldsCopyTask = async (
 	overrideValues?: Partial<InternallyWritableBaseFieldsCopyTask>,
 ): Promise<BaseFieldsCopyTask> => {
-	const systemUser = await loadSystemUser();
+	const systemUser = await loadSystemUser(null);
 	const defaultValues = {
 		pdcApiUrl: MOCK_API_URL,
 		status: TaskStatus.PENDING,
@@ -182,6 +182,7 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 
@@ -203,6 +204,7 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 
@@ -231,6 +233,7 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 
@@ -252,6 +255,7 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 		const after = await loadTableMetrics('base_fields');
@@ -279,6 +283,7 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 		const after = await loadTableMetrics('base_fields');
@@ -286,7 +291,7 @@ describe('copyBaseFields', () => {
 		expect(before.count).toEqual(0);
 		expect(after.count).toEqual(1);
 
-		const insertedRemoteBaseField = await loadBaseField(1);
+		const insertedRemoteBaseField = await loadBaseField(null, 1);
 
 		expect(insertedRemoteBaseField).toEqual({
 			id: 1,
@@ -342,6 +347,7 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 		const after = await loadTableMetrics('base_fields');
@@ -349,7 +355,10 @@ describe('copyBaseFields', () => {
 		expect(before.count).toEqual(1);
 		expect(after.count).toEqual(3);
 
-		const localBaseFieldAfterInsertion = await loadBaseField(localBaseField.id);
+		const localBaseFieldAfterInsertion = await loadBaseField(
+			null,
+			localBaseField.id,
+		);
 
 		expect(localBaseFieldAfterInsertion).toEqual(localBaseField);
 
@@ -392,12 +401,13 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 
 		const after = await loadTableMetrics('base_fields');
 
-		const updatedBaseField = await loadBaseField(localBaseField.id);
+		const updatedBaseField = await loadBaseField(null, localBaseField.id);
 
 		expect(before.count).toEqual(1);
 		expect(after.count).toEqual(1);
@@ -452,12 +462,13 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 
 		const after = await loadTableMetrics('base_fields');
 
-		const updatedBaseField = await loadBaseField(localBaseField.id);
+		const updatedBaseField = await loadBaseField(null, localBaseField.id);
 
 		expect(before.count).toEqual(1);
 		expect(after.count).toEqual(2);
@@ -473,7 +484,7 @@ describe('copyBaseFields', () => {
 			localizations: {},
 		});
 
-		const insertedRemoteBaseField = await loadBaseField(3);
+		const insertedRemoteBaseField = await loadBaseField(null, 3);
 
 		expect(insertedRemoteBaseField).toEqual({
 			id: 3,
@@ -535,10 +546,11 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 
-		const updatedBaseField = await loadBaseField(localBaseField.id);
+		const updatedBaseField = await loadBaseField(null, localBaseField.id);
 
 		expect(updatedBaseField).toEqual({
 			id: localBaseField.id,
@@ -593,10 +605,11 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 
-		const updatedBaseField = await loadBaseField(localBaseField.id);
+		const updatedBaseField = await loadBaseField(null, localBaseField.id);
 
 		expect(updatedBaseField).toEqual({
 			id: localBaseField.id,
@@ -651,6 +664,7 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 		const after = await loadTableMetrics('base_fields');
@@ -686,12 +700,13 @@ describe('copyBaseFields', () => {
 		);
 
 		const updatedBaseFieldsCopyTask = await loadBaseFieldsCopyTask(
+			null,
 			baseFieldsCopyTask.id,
 		);
 
 		const after = await loadTableMetrics('base_fields');
 
-		const updatedBaseField = await loadBaseField(baseField.id);
+		const updatedBaseField = await loadBaseField(null, baseField.id);
 
 		expect(before.count).toEqual(1);
 		expect(after.count).toEqual(1);

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -51,8 +51,8 @@ const getS3KeyPath = (key: string) => `${getS3Path()}/${key}`;
 const createTestBulkUploadTask = async (
 	overrideValues?: Partial<InternallyWritableBulkUploadTask>,
 ): Promise<BulkUploadTask> => {
-	const systemUser = await loadSystemUser();
-	const systemSource = await loadSystemSource();
+	const systemUser = await loadSystemUser(null);
+	const systemSource = await loadSystemSource(null);
 	const defaultValues = {
 		fileName: 'bar.csv',
 		sourceId: systemSource.id,
@@ -197,7 +197,10 @@ describe('processBulkUploadTask', () => {
 			getMockJobHelpers(),
 		);
 
-		const updatedBulkUploadTask = await loadBulkUploadTask(bulkUploadTask.id);
+		const updatedBulkUploadTask = await loadBulkUploadTask(
+			null,
+			bulkUploadTask.id,
+		);
 		expect(updatedBulkUploadTask).toMatchObject({
 			status: TaskStatus.FAILED,
 			fileSize: null,
@@ -218,7 +221,7 @@ describe('processBulkUploadTask', () => {
 			getMockJobHelpers(),
 		);
 
-		const updatedBulkUpload = await loadBulkUploadTask(bulkUploadTask.id);
+		const updatedBulkUpload = await loadBulkUploadTask(null, bulkUploadTask.id);
 		expect(updatedBulkUpload).toMatchObject({
 			status: TaskStatus.FAILED,
 			fileSize: null,
@@ -242,7 +245,7 @@ describe('processBulkUploadTask', () => {
 			getMockJobHelpers(),
 		);
 
-		const updatedBulkUpload = await loadBulkUploadTask(bulkUploadTask.id);
+		const updatedBulkUpload = await loadBulkUploadTask(null, bulkUploadTask.id);
 		expect(updatedBulkUpload.status).toEqual(TaskStatus.IN_PROGRESS);
 		expect(requests.getRequest.isDone()).toEqual(false);
 	});
@@ -261,7 +264,10 @@ describe('processBulkUploadTask', () => {
 			},
 			getMockJobHelpers(),
 		);
-		const updatedBulkUploadTask = await loadBulkUploadTask(bulkUploadTask.id);
+		const updatedBulkUploadTask = await loadBulkUploadTask(
+			null,
+			bulkUploadTask.id,
+		);
 		expect(updatedBulkUploadTask).toMatchObject({
 			status: TaskStatus.FAILED,
 			fileSize: 97,
@@ -301,7 +307,7 @@ describe('processBulkUploadTask', () => {
 			},
 			getMockJobHelpers(),
 		);
-		const updatedBulkUpload = await loadBulkUploadTask(bulkUploadTask.id);
+		const updatedBulkUpload = await loadBulkUploadTask(null, bulkUploadTask.id);
 		expect(updatedBulkUpload).toMatchObject({
 			status: TaskStatus.FAILED,
 			fileSize: 0,
@@ -324,7 +330,10 @@ describe('processBulkUploadTask', () => {
 			},
 			getMockJobHelpers(),
 		);
-		const updatedBulkUploadTask = await loadBulkUploadTask(bulkUploadTask.id);
+		const updatedBulkUploadTask = await loadBulkUploadTask(
+			null,
+			bulkUploadTask.id,
+		);
 		expect(updatedBulkUploadTask).toMatchObject({
 			fileSize: 93,
 		});
@@ -332,8 +341,8 @@ describe('processBulkUploadTask', () => {
 
 	it('should download, process, and resolve the bulk upload if the sourceKey is accessible and contains a valid CSV bulk upload', async () => {
 		await createTestBaseFields();
-		const systemSource = await loadSystemSource();
-		const systemUser = await loadSystemUser();
+		const systemSource = await loadSystemSource(null);
+		const systemUser = await loadSystemUser(null);
 		const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
 		const bulkUploadTask = await createTestBulkUploadTask({
 			sourceKey,
@@ -350,7 +359,10 @@ describe('processBulkUploadTask', () => {
 			},
 			getMockJobHelpers(),
 		);
-		const updatedBulkUploadTask = await loadBulkUploadTask(bulkUploadTask.id);
+		const updatedBulkUploadTask = await loadBulkUploadTask(
+			null,
+			bulkUploadTask.id,
+		);
 
 		const {
 			entries: [opportunity],

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -366,14 +366,14 @@ describe('processBulkUploadTask', () => {
 
 		const {
 			entries: [opportunity],
-		} = await loadOpportunityBundle(undefined, NO_LIMIT, NO_OFFSET);
+		} = await loadOpportunityBundle(null, NO_LIMIT, NO_OFFSET);
 		if (opportunity === undefined) {
 			throw new Error('The opportunity was not created');
 		}
 
 		const {
 			entries: [applicationForm],
-		} = await loadApplicationFormBundle(undefined, NO_LIMIT, NO_OFFSET);
+		} = await loadApplicationFormBundle(null, NO_LIMIT, NO_OFFSET);
 		if (applicationForm === undefined) {
 			fail('The application form was not created');
 		}
@@ -384,7 +384,7 @@ describe('processBulkUploadTask', () => {
 		});
 
 		const proposalBundle = await loadProposalBundle(
-			undefined,
+			null,
 			undefined,
 			undefined,
 			undefined,
@@ -550,7 +550,7 @@ describe('processBulkUploadTask', () => {
 		});
 
 		const changemakerBundle = await loadChangemakerBundle(
-			undefined,
+			null,
 			undefined,
 			NO_LIMIT,
 			NO_OFFSET,
@@ -561,7 +561,7 @@ describe('processBulkUploadTask', () => {
 		});
 
 		const changemakerProposalBundle = await loadChangemakerProposalBundle(
-			undefined,
+			null,
 			undefined,
 			undefined,
 			NO_LIMIT,
@@ -595,14 +595,14 @@ describe('processBulkUploadTask', () => {
 		);
 
 		const changemakerBundle = await loadChangemakerBundle(
-			undefined,
+			null,
 			undefined,
 			NO_LIMIT,
 			NO_OFFSET,
 		);
 
 		const changemakerProposalBundle = await loadChangemakerProposalBundle(
-			undefined,
+			null,
 			undefined,
 			undefined,
 			NO_LIMIT,

--- a/src/tasks/copyBaseFields.ts
+++ b/src/tasks/copyBaseFields.ts
@@ -90,6 +90,7 @@ export const copyBaseFields = async (
 		`Started BasefieldsCopy Job for BaseFieldsCopyTask ID ${payload.baseFieldsCopyTaskId}`,
 	);
 	const baseFieldsCopyTask = await loadBaseFieldsCopyTask(
+		null,
 		payload.baseFieldsCopyTaskId,
 	);
 

--- a/src/tasks/processBulkUploadTask.ts
+++ b/src/tasks/processBulkUploadTask.ts
@@ -226,7 +226,7 @@ export const processBulkUploadTask = async (
 	helpers.logger.debug(
 		`Started processBulkUpload Job for Bulk Upload ID ${payload.bulkUploadId}`,
 	);
-	const bulkUploadTask = await loadBulkUploadTask(payload.bulkUploadId);
+	const bulkUploadTask = await loadBulkUploadTask(null, payload.bulkUploadId);
 	if (bulkUploadTask.status !== TaskStatus.PENDING) {
 		helpers.logger.warn(
 			'Bulk upload cannot be processed because it is not in a PENDING state',

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -31,7 +31,7 @@ export const createTestUser = async () =>
 	});
 
 export const loadTestUser = async () =>
-	loadUserByKeycloakUserId(getTestUserKeycloakUserId());
+	loadUserByKeycloakUserId(null, getTestUserKeycloakUserId());
 
 export const NO_OFFSET = 0;
 

--- a/src/types/AuthContext.ts
+++ b/src/types/AuthContext.ts
@@ -31,14 +31,14 @@ const authContextSchema: JSONSchemaType<AuthContext> = {
 const isAuthContext = ajv.compile(authContextSchema);
 
 const getKeycloakUserIdFromAuthContext = (
-	req: AuthContext | undefined,
+	req: AuthContext | undefined | null,
 ): KeycloakId | undefined => {
 	const keycloakUserId = req?.user?.keycloakUserId;
 	return keycloakUserId;
 };
 
 const getIsAdministratorFromAuthContext = (
-	req: AuthContext | undefined,
+	req: AuthContext | undefined | null,
 ): boolean | undefined => req?.role?.isAdministrator;
 
 export {


### PR DESCRIPTION
This PR continues the work of DRYing out our DB operators by using a generator for load operations; it also adds in the auth context for load operations via that generator.

Related to #1407 