### PR TITLE
Try adding `python3-venv` to an Aptfile

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,1 @@
+python3-venv


### PR DESCRIPTION
Try adding `python3-venv` to an Aptfile

The goal is to restore the Digital Ocean (DO) deployment pipeline
while keeping the existing `lint` command that now includes `sqlfluff`
calls. The assumption is that an Ubuntu Jammy image is being built and
that when an Aptfile is present, DO will use it before or during a build.

The specific error we're getting at deploy time is this:

> postinstall
> > [ ! -d "venv" ] && python3 -m venv venv; ./venv/bin/pip install -r sqlfluff/requirements.txt
> The virtual environment was not created successfully because ensurepip is not
> available.  On Debian/Ubuntu systems, you need to install the python3-venv
> package...

See https://docs.digitalocean.com/products/app-platform/reference/buildpacks/aptfile/

Hat tip to Daniel Schultz for finding that documentation.

Issue #1410
