### PR TITLE
Try adding `python3-pip` to `Aptfile`

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,2 @@
 python3-venv
+python3-pip


### PR DESCRIPTION
The previous attempt did not resolve a Digital Ocean deployment failure, `pip` is still not found. It appears the package from `Aptfile` was in fact installed so explicitly install `pip` too.

Issue #1410