### PR TITLE
Add python3 to build

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,3 @@
+python3
 python3-venv
 python3-pip


### PR DESCRIPTION
We're trying to get python to work as expected in the build process in Digital Ocean Apps.  I'm not sure it's actually been installed, so fixing that here.