### PR TITLE
Resurrect the docker image build/push to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build and push docker image
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: philanthropydatacommons/service
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build-and-push-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - run: echo VERSION="$(git log -1 --date=unix --pretty=format:'%cd' | date --utc '+%Y%m%d')"-"$(git log -1 --pretty=format:'%h')" >> "$GITHUB_ENV"
+      - name: Build with node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - run: npm ci
+      - run: npm run build
+      - run: npm prune --omit=dev
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/Aptfile
+++ b/Aptfile
@@ -1,3 +1,0 @@
-python3
-python3-venv
-python3-pip


### PR DESCRIPTION
Prior to this commit, the Digital Ocean deployment pipeline would pull the new source code, re-run lint, re-run tests, build a docker image, and then deploy. The problem with this approach is that it includes too much, does too much, and is entirely outside our CI/CD steps at the canonical source forge (GH). The problem is revealed when running the `lint` step at Digital Ocean: no Python environment. But then an attempt to add Python to the environment both fails and does not make much sense. There doesn't need to be a Python environment, nor any development environment for that matter, present in the production deployment image. Only the already-linted, already-compiled, and already-tested code should go into production. Instead of trying to remove steps from the DO pipeline, this commit restores a docker image build and push when a merge to main occurs. Note that a controversial token is not used in this step and the inter-repository trigger that previously used such a token not restored.

The approach here is to build an artifact out of components that have already been linted, compiled, and tested, and do not include any development tools along the way. See the `npm prune --omit=dev` command. Note that this does not perfectly meet the objective but further improvements can be done in later commits, for example, making this step contingent on previous workflow steps and declaring `uses` the exact same deployment image in the lint and test workflows.

On the DO App Platform side, there is an option to run a docker image rather than compiling and building one from source. Other benefits come from this approach. The version of node used by DO was not clear until looking deep into logs or running a shell on the production runtime. The version of node was not able to controlled, either. With the approach of running an existing docker image, the full runtime, including node version, is known and controlled. A further benefit is when an issue occurs in production that cannot be easily reproduced with source code, the exact image running in production can be run on a local development environment by pulling from the image repository.

With this commit, the ability to use the option of running a GHCR image on the DO App Platform is present because the image is publicly available.

Issue #1410
https://github.com/PhilanthropyDataCommons/deploy/issues/118 PR #1236