### PR TITLE
Add AuthContext to create / update operations

### DIFF
--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -16,14 +16,14 @@ import { mockJwt as authHeader } from '../test/mockJwt';
 const logger = getLogger(__filename);
 
 const createTestBaseFields = async () => {
-	await createBaseField({
+	await createBaseField(null, {
 		label: 'Organization Name',
 		description: 'The organizational name of the applicant',
 		shortCode: 'organizationName',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.ORGANIZATION,
 	});
-	await createBaseField({
+	await createBaseField(null, {
 		label: 'Years of work',
 		description: 'The number of years the project will take to complete',
 		shortCode: 'yearsOfWork',
@@ -50,19 +50,19 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns all application forms present in the database', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Tremendous opportunity 👌',
 			});
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Good opportunity',
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 2,
 			});
 			const response = await request(app)
@@ -95,41 +95,41 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns an application form with its fields', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Holiday opportunity 🎄',
 			});
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Another holiday opportunity 🕎',
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 2,
 			});
 			await createTestBaseFields();
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 3,
 				baseFieldId: 2,
 				position: 1,
 				label: 'Anni Worki',
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 3,
 				baseFieldId: 1,
 				position: 2,
 				label: 'Org Nomen',
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 2,
 				baseFieldId: 1,
 				position: 2,
 				label: 'Name of Organization',
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 2,
 				baseFieldId: 2,
 				position: 1,
@@ -213,7 +213,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('creates exactly one application form', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Tremendous opportunity 👌',
 			});
 			const before = await loadTableMetrics('application_forms');
@@ -239,7 +239,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('creates exactly the number of provided fields', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Tremendous opportunity 👌',
 			});
 			await createTestBaseFields();
@@ -282,13 +282,13 @@ describe('/applicationForms', () => {
 		});
 
 		it('increments version when creating a second form for an opportunity', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Tremendous opportunity 👌',
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
 			const result = await request(app)
@@ -371,7 +371,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns 500 UnknownError if a generic Error is thrown when inserting the field', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Tremendous opportunity 👌',
 			});
 			await createTestBaseFields();

--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../test/mockJwt';
 
 const createTestBaseField = async () =>
-	createBaseField({
+	createBaseField(null, {
 		label: 'Summary',
 		description: 'A summary of the proposal',
 		shortCode: 'summary',
@@ -24,14 +24,14 @@ const createTestBaseField = async () =>
 	});
 
 const createTestBaseFieldWithLocalization = async () => {
-	const baseField = await createBaseField({
+	const baseField = await createBaseField(null, {
 		label: 'Summary',
 		description: 'A summary of the proposal',
 		shortCode: 'summary',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.PROPOSAL,
 	});
-	await createOrUpdateBaseFieldLocalization({
+	await createOrUpdateBaseFieldLocalization(null, {
 		baseFieldId: baseField.id,
 		label: 'Le Resume',
 		description: 'Le Resume de la Applicant',
@@ -50,14 +50,14 @@ describe('/baseFields', () => {
 		});
 
 		it('returns all base fields present in the database', async () => {
-			const baseFieldOne = await createBaseField({
+			const baseFieldOne = await createBaseField(null, {
 				label: 'First Name',
 				description: 'The first name of the applicant',
 				shortCode: 'firstName',
 				dataType: BaseFieldDataType.STRING,
 				scope: BaseFieldScope.PROPOSAL,
 			});
-			const baseFieldTwo = await createBaseField({
+			const baseFieldTwo = await createBaseField(null, {
 				label: 'Last Name',
 				description: 'The last name of the applicant',
 				shortCode: 'lastName',
@@ -65,14 +65,14 @@ describe('/baseFields', () => {
 				scope: BaseFieldScope.PROPOSAL,
 			});
 
-			await createOrUpdateBaseFieldLocalization({
+			await createOrUpdateBaseFieldLocalization(null, {
 				baseFieldId: baseFieldOne.id,
 				language: 'fr',
 				label: 'prenom',
 				description: 'le prenom',
 			});
 
-			await createOrUpdateBaseFieldLocalization({
+			await createOrUpdateBaseFieldLocalization(null, {
 				baseFieldId: baseFieldTwo.id,
 				language: 'fr',
 				label: 'postnom',
@@ -288,7 +288,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 409 conflict when a duplicate short name is submitted', async () => {
-			await createBaseField({
+			await createBaseField(null, {
 				label: 'First Name',
 				description: 'The first name of the applicant',
 				shortCode: 'firstName',
@@ -331,7 +331,7 @@ describe('/baseFields', () => {
 			// Not using the helper here because observing a change in values is explicitly
 			// the point of the test, so having full explicit control of the original value
 			// seems important.  Some day when we add better test tooling we can have it all.
-			await createBaseField({
+			await createBaseField(null, {
 				label: 'Summary',
 				description: 'A summary of the proposal',
 				shortCode: 'summary',
@@ -502,7 +502,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns all base field localizations related to the given baseFieldId', async () => {
-			await createBaseField({
+			await createBaseField(null, {
 				label: 'First Name',
 				description: 'The first name of the applicant',
 				shortCode: 'firstName',
@@ -510,14 +510,14 @@ describe('/baseFields', () => {
 				scope: BaseFieldScope.PROPOSAL,
 			});
 
-			await createOrUpdateBaseFieldLocalization({
+			await createOrUpdateBaseFieldLocalization(null, {
 				baseFieldId: 1,
 				language: 'fr',
 				label: 'prenom',
 				description: 'le prenom',
 			});
 
-			await createOrUpdateBaseFieldLocalization({
+			await createOrUpdateBaseFieldLocalization(null, {
 				baseFieldId: 1,
 				language: 'en',
 				label: 'First Name',
@@ -606,13 +606,13 @@ describe('/baseFields', () => {
 
 		it('updates only the specified base field if it does exist', async () => {
 			const testBaseField = await createTestBaseField();
-			await createOrUpdateBaseFieldLocalization({
+			await createOrUpdateBaseFieldLocalization(null, {
 				baseFieldId: 1,
 				language: 'fr',
 				label: 'Résume',
 				description: 'Le Résume de proposal',
 			});
-			await createOrUpdateBaseFieldLocalization({
+			await createOrUpdateBaseFieldLocalization(null, {
 				baseFieldId: 1,
 				language: 'en',
 				label: 'Summary',

--- a/src/__tests__/baseFieldsCopyTasks.int.test.ts
+++ b/src/__tests__/baseFieldsCopyTasks.int.test.ts
@@ -37,17 +37,17 @@ describe('/tasks/baseFieldsCopy', () => {
 
 		it('returns all BaseFieldsCopy Tasks for administrative users', async () => {
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser({
+			const anotherUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
 
-			await createBaseFieldsCopyTask({
+			await createBaseFieldsCopyTask(null, {
 				pdcApiUrl: MOCK_API_URL,
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
 
-			await createBaseFieldsCopyTask({
+			await createBaseFieldsCopyTask(null, {
 				pdcApiUrl: MOCK_API_URL,
 				status: TaskStatus.COMPLETED,
 				createdBy: anotherUser.keycloakUserId,
@@ -86,7 +86,7 @@ describe('/tasks/baseFieldsCopy', () => {
 			const testUser = await loadTestUser();
 			await Array.from(Array(20)).reduce(async (p) => {
 				await p;
-				await createBaseFieldsCopyTask({
+				await createBaseFieldsCopyTask(null, {
 					pdcApiUrl: MOCK_API_URL,
 					status: TaskStatus.COMPLETED,
 					createdBy: testUser.keycloakUserId,

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -39,31 +39,31 @@ describe('/tasks/bulkUploads', () => {
 			const systemUser = await loadSystemUser(null);
 			const systemSource = await loadSystemSource(null);
 			const testUser = await loadTestUser();
-			const thirdUser = await createUser({
+			const thirdUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: TaskStatus.COMPLETED,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'baz.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-baz',
 				status: TaskStatus.COMPLETED,
 				createdBy: systemUser.keycloakUserId,
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'boop.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-boop',
@@ -109,17 +109,17 @@ describe('/tasks/bulkUploads', () => {
 		it('returns all bulk uploads for administrative users', async () => {
 			const systemSource = await loadSystemSource(null);
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser({
+			const anotherUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -165,17 +165,17 @@ describe('/tasks/bulkUploads', () => {
 		it('returns upload tasks for specified createdBy user', async () => {
 			const systemSource = await loadSystemSource(null);
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser({
+			const anotherUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -212,17 +212,17 @@ describe('/tasks/bulkUploads', () => {
 		it('returns upload tasks for the admin user when createdBy is set to me as an admin', async () => {
 			const systemSource = await loadSystemSource(null);
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser({
+			const anotherUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask({
+			await createBulkUploadTask(null, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -259,7 +259,7 @@ describe('/tasks/bulkUploads', () => {
 			const testUser = await loadTestUser();
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
-				await createBulkUploadTask({
+				await createBulkUploadTask(null, {
 					sourceId: systemSource.id,
 					fileName: `bar-${i + 1}.csv`,
 					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',

--- a/src/__tests__/changemakerProposals.int.test.ts
+++ b/src/__tests__/changemakerProposals.int.test.ts
@@ -11,12 +11,12 @@ import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 
 const insertTestChangemakers = async () => {
-	await createChangemaker({
+	await createChangemaker(null, {
 		taxId: '11-1111111',
 		name: 'Example Inc.',
 		keycloakOrganizationId: null,
 	});
-	await createChangemaker({
+	await createChangemaker(null, {
 		taxId: '22-2222222',
 		name: 'Another Inc.',
 		keycloakOrganizationId: '402b1208-be48-11ef-8af9-b767e5e8e4ee',
@@ -30,26 +30,26 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns the ChangemakerProposals for the specified changemaker', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal({
+			await createProposal(null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				opportunityId: 1,
 				externalId: '2',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemakerProposal({
+			await createChangemakerProposal(null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});
-			await createChangemakerProposal({
+			await createChangemakerProposal(null, {
 				changemakerId: 1,
 				proposalId: 2,
 			});
@@ -109,26 +109,26 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns the ProposalChangemakers for the specified proposal', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal({
+			await createProposal(null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				opportunityId: 1,
 				externalId: '2',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemakerProposal({
+			await createChangemakerProposal(null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});
-			await createChangemakerProposal({
+			await createChangemakerProposal(null, {
 				changemakerId: 2,
 				proposalId: 2,
 			});
@@ -180,12 +180,12 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('creates exactly one ChangemakerProposal', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			await insertTestChangemakers();
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
@@ -228,12 +228,12 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 400 bad request when no proposalId is sent', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal({
+			await createProposal(null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
@@ -253,12 +253,12 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 400 bad request when no changemakerId is sent', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal({
+			await createProposal(null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
@@ -278,7 +278,7 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 422 Conflict when a non-existent proposal is sent', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			await insertTestChangemakers();
@@ -297,11 +297,11 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 422 Conflict when a non-existent changemaker is sent', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
@@ -321,17 +321,17 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 409 Conflict when attempting to create a duplicate ChangemakerProposal', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal({
+			await createProposal(null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemakerProposal({
+			await createChangemakerProposal(null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -34,12 +34,12 @@ import {
 } from '../types';
 
 const insertTestChangemakers = async () => {
-	await createChangemaker({
+	await createChangemaker(null, {
 		taxId: '11-1111111',
 		name: 'Example Inc.',
 		keycloakOrganizationId: null,
 	});
-	await createChangemaker({
+	await createChangemaker(null, {
 		taxId: '22-2222222',
 		name: 'Another Inc.',
 		keycloakOrganizationId: '57ceaca8-be48-11ef-8c91-5732d98a77e1',
@@ -93,7 +93,7 @@ describe('/changemakers', () => {
 		it('returns according to pagination parameters', async () => {
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
-				await createChangemaker({
+				await createChangemaker(null, {
 					taxId: '11-1111111',
 					name: `Changemaker ${i + 1}`,
 					keycloakOrganizationId: null,
@@ -157,26 +157,26 @@ describe('/changemakers', () => {
 		});
 
 		it('returns a subset of changemakers present in the database when a proposal filter is provided', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemaker({
+			await createChangemaker(null, {
 				taxId: '123-123-123',
 				name: 'Canadian Company',
 				keycloakOrganizationId: null,
 			});
-			await createChangemaker({
+			await createChangemaker(null, {
 				taxId: '123-123-123',
 				name: 'Another Canadian Company',
 				keycloakOrganizationId: null,
 			});
-			await createChangemakerProposal({
+			await createChangemakerProposal(null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});
@@ -200,30 +200,30 @@ describe('/changemakers', () => {
 		});
 
 		it('does not return duplicate changemakers when a changemaker has multiple proposals', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemaker({
+			await createChangemaker(null, {
 				taxId: '123-123-123',
 				name: 'Canadian Company',
 				keycloakOrganizationId: null,
 			});
-			await createChangemakerProposal({
+			await createChangemakerProposal(null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});
-			await createChangemakerProposal({
+			await createChangemakerProposal(null, {
 				changemakerId: 1,
 				proposalId: 2,
 			});
@@ -310,75 +310,75 @@ describe('/changemakers', () => {
 			beforeEach(async () => {
 				systemSource = await loadSystemSource(null);
 				systemUser = await loadSystemUser(null);
-				baseFieldEmail = await createBaseField({
+				baseFieldEmail = await createBaseField(null, {
 					label: 'Fifty one fifty three',
 					shortCode: 'fifty_one_fifty_three',
 					description: 'Five thousand one hundred fifty three.',
 					dataType: BaseFieldDataType.EMAIL,
 					scope: BaseFieldScope.ORGANIZATION,
 				});
-				baseFieldPhone = await createBaseField({
+				baseFieldPhone = await createBaseField(null, {
 					label: 'Fifty three ninety nine',
 					shortCode: 'fifty_three_ninety_nine',
 					description: 'Five thousand three hundred ninety nine.',
 					dataType: BaseFieldDataType.PHONE_NUMBER,
 					scope: BaseFieldScope.ORGANIZATION,
 				});
-				baseFieldWebsite = await createBaseField({
+				baseFieldWebsite = await createBaseField(null, {
 					label: 'Fifty four seventy one 5471',
 					shortCode: 'fifty_four_seventy_one',
 					description: 'Five thousand four hundred seventy one.',
 					dataType: BaseFieldDataType.URL,
 					scope: BaseFieldScope.ORGANIZATION,
 				});
-				firstChangemaker = await createChangemaker({
+				firstChangemaker = await createChangemaker(null, {
 					name: 'Five thousand one hundred forty seven reasons',
 					taxId: '05119',
 					keycloakOrganizationId: null,
 				});
-				secondChangemaker = await createChangemaker({
+				secondChangemaker = await createChangemaker(null, {
 					taxId: '5387',
 					name: 'Changemaker 5387',
 					keycloakOrganizationId: '8b15d276-be48-11ef-a061-5b4a50e82d50',
 				});
 				secondChangemakerSourceId = (
-					await createSource({
+					await createSource(null, {
 						changemakerId: secondChangemaker.id,
 						label: `${secondChangemaker.name} source`,
 					})
 				).id;
-				firstFunder = await createOrUpdateFunder({
+				firstFunder = await createOrUpdateFunder(null, {
 					shortCode: 'funder_5393',
 					name: 'Funder 5393',
 					keycloakOrganizationId: null,
 				});
-				firstFunderOpportunity = await createOpportunity({
+				firstFunderOpportunity = await createOpportunity(null, {
 					title: `${firstFunder.name} opportunity`,
 				});
 				firstFunderSourceId = (
-					await createSource({
+					await createSource(null, {
 						funderShortCode: firstFunder.shortCode,
 						label: `${firstFunder.name} source`,
 					})
 				).id;
-				firstDataProvider = await createOrUpdateDataProvider({
+				firstDataProvider = await createOrUpdateDataProvider(null, {
 					shortCode: 'data_provider_5431',
 					name: 'Data Platform Provider 5431',
 					keycloakOrganizationId: null,
 				});
-				secondDataProvider = await createOrUpdateDataProvider({
+				secondDataProvider = await createOrUpdateDataProvider(null, {
 					shortCode: 'data_provider_5477',
 					name: 'Data Platform Provider 5477',
 					keycloakOrganizationId: null,
 				});
 				firstDataProviderSourceId = (
-					await createSource({
+					await createSource(null, {
 						dataProviderShortCode: firstDataProvider.shortCode,
 						label: `${firstDataProvider.name} source`,
 					})
 				).id;
 				secondDataProviderSourceId = (
-					await createSource({
+					await createSource(null, {
 						dataProviderShortCode: secondDataProvider.shortCode,
 						label: `${secondDataProvider.name} source`,
 					})
@@ -391,26 +391,26 @@ describe('/changemakers', () => {
 				const changemakerId = firstChangemaker.id;
 				const opportunityId = firstFunderOpportunity.id;
 				const proposalId = (
-					await createProposal({
+					await createProposal(null, {
 						opportunityId,
 						externalId: 'Proposal',
 						createdBy: systemUser.keycloakUserId,
 					})
 				).id;
-				await createChangemakerProposal({
+				await createChangemakerProposal(null, {
 					changemakerId,
 					proposalId,
 				});
 				// I need 3 application form fields here. May as well make them use distinct forms too.
 				const applicationFormIdEarliest = (
-					await createApplicationForm({
+					await createApplicationForm(null, {
 						opportunityId,
 					})
 				).id;
 				// Older field that is valid
-				await createProposalFieldValue({
+				await createProposalFieldValue(null, {
 					proposalVersionId: (
-						await createProposalVersion({
+						await createProposalVersion(null, {
 							proposalId,
 							applicationFormId: applicationFormIdEarliest,
 							sourceId: systemSource.id,
@@ -418,7 +418,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField({
+						await createApplicationFormField(null, {
 							label: 'Org email',
 							applicationFormId: applicationFormIdEarliest,
 							baseFieldId,
@@ -430,13 +430,13 @@ describe('/changemakers', () => {
 					isValid: true,
 				});
 				const applicationFormIdLatestValid = (
-					await createApplicationForm({
+					await createApplicationForm(null, {
 						opportunityId,
 					})
 				).id;
-				const latestValidValue = await createProposalFieldValue({
+				const latestValidValue = await createProposalFieldValue(null, {
 					proposalVersionId: (
-						await createProposalVersion({
+						await createProposalVersion(null, {
 							proposalId,
 							applicationFormId: applicationFormIdLatestValid,
 							sourceId: systemSource.id,
@@ -444,7 +444,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField({
+						await createApplicationFormField(null, {
 							label: 'Email contact',
 							applicationFormId: applicationFormIdLatestValid,
 							baseFieldId,
@@ -456,14 +456,14 @@ describe('/changemakers', () => {
 					isValid: true,
 				});
 				const applicationFormIdLatest = (
-					await createApplicationForm({
+					await createApplicationForm(null, {
 						opportunityId,
 					})
 				).id;
 				// Latest value but invalid
-				await createProposalFieldValue({
+				await createProposalFieldValue(null, {
 					proposalVersionId: (
-						await createProposalVersion({
+						await createProposalVersion(null, {
 							proposalId,
 							applicationFormId: applicationFormIdLatest,
 							sourceId: systemSource.id,
@@ -471,7 +471,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField({
+						await createApplicationFormField(null, {
 							label: 'Contact email address',
 							applicationFormId: applicationFormIdLatest,
 							baseFieldId,
@@ -507,25 +507,25 @@ describe('/changemakers', () => {
 				const baseFieldId = baseFieldPhone.id;
 				const opportunity = firstFunderOpportunity;
 				const proposalId = (
-					await createProposal({
+					await createProposal(null, {
 						opportunityId: opportunity.id,
 						externalId: `Proposal to ${opportunity.title}`,
 						createdBy: systemUser.keycloakUserId,
 					})
 				).id;
-				await createChangemakerProposal({
+				await createChangemakerProposal(null, {
 					changemakerId: changemaker.id,
 					proposalId,
 				});
 				const applicationFormIdChangemakerEarliest = (
-					await createApplicationForm({
+					await createApplicationForm(null, {
 						opportunityId: opportunity.id,
 					})
 				).id;
 				// Set up older field value that is from the changemaker. We'll expect this to be returned.
-				const changemakerEarliestValue = await createProposalFieldValue({
+				const changemakerEarliestValue = await createProposalFieldValue(null, {
 					proposalVersionId: (
-						await createProposalVersion({
+						await createProposalVersion(null, {
 							proposalId,
 							applicationFormId: applicationFormIdChangemakerEarliest,
 							sourceId: changemakerSourceId,
@@ -533,7 +533,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField({
+						await createApplicationFormField(null, {
 							label: 'Org phone',
 							applicationFormId: applicationFormIdChangemakerEarliest,
 							baseFieldId,
@@ -545,14 +545,14 @@ describe('/changemakers', () => {
 					isValid: true,
 				});
 				const applicationFormIdFunderLatest = (
-					await createApplicationForm({
+					await createApplicationForm(null, {
 						opportunityId: opportunity.id,
 					})
 				).id;
 				// Set up newer field value that is from the funder.
-				await createProposalFieldValue({
+				await createProposalFieldValue(null, {
 					proposalVersionId: (
-						await createProposalVersion({
+						await createProposalVersion(null, {
 							proposalId,
 							applicationFormId: applicationFormIdFunderLatest,
 							sourceId: funderSourceId,
@@ -560,7 +560,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField({
+						await createApplicationFormField(null, {
 							label: 'Phone contact',
 							applicationFormId: applicationFormIdFunderLatest,
 							baseFieldId,
@@ -593,25 +593,25 @@ describe('/changemakers', () => {
 				const baseFieldId = baseFieldPhone.id;
 				const opportunity = firstFunderOpportunity;
 				const proposalId = (
-					await createProposal({
+					await createProposal(null, {
 						opportunityId: opportunity.id,
 						externalId: `Another proposal to ${opportunity.title}`,
 						createdBy: systemUser.keycloakUserId,
 					})
 				).id;
-				await createChangemakerProposal({
+				await createChangemakerProposal(null, {
 					changemakerId: changemaker.id,
 					proposalId,
 				});
 				const applicationFormIdFunderEarliest = (
-					await createApplicationForm({
+					await createApplicationForm(null, {
 						opportunityId: opportunity.id,
 					})
 				).id;
 				// Set up older field value that is from the funder. We'll expect this to be returned.
-				const funderEarliestValue = await createProposalFieldValue({
+				const funderEarliestValue = await createProposalFieldValue(null, {
 					proposalVersionId: (
-						await createProposalVersion({
+						await createProposalVersion(null, {
 							proposalId,
 							applicationFormId: applicationFormIdFunderEarliest,
 							sourceId: funderSourceId,
@@ -619,7 +619,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField({
+						await createApplicationFormField(null, {
 							label: 'Organization phone 5437',
 							applicationFormId: applicationFormIdFunderEarliest,
 							baseFieldId,
@@ -631,14 +631,14 @@ describe('/changemakers', () => {
 					isValid: true,
 				});
 				const applicationFormIdDataProviderLatest = (
-					await createApplicationForm({
+					await createApplicationForm(null, {
 						opportunityId: opportunity.id,
 					})
 				).id;
 				// Set up newer field value that is from the data platform provider.
-				await createProposalFieldValue({
+				await createProposalFieldValue(null, {
 					proposalVersionId: (
-						await createProposalVersion({
+						await createProposalVersion(null, {
 							proposalId,
 							applicationFormId: applicationFormIdDataProviderLatest,
 							sourceId: dataProviderSourceId,
@@ -646,7 +646,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField({
+						await createApplicationFormField(null, {
 							label: 'Phone contact',
 							applicationFormId: applicationFormIdDataProviderLatest,
 							baseFieldId,
@@ -675,25 +675,25 @@ describe('/changemakers', () => {
 				// Set up data platform provider sources.
 				// Associate one opportunity, one changemaker, and two responses with a base field.
 				const proposalId = (
-					await createProposal({
+					await createProposal(null, {
 						opportunityId: firstFunderOpportunity.id,
 						externalId: `Yet another proposal to ${firstFunderOpportunity.title}`,
 						createdBy: systemUser.keycloakUserId,
 					})
 				).id;
-				await createChangemakerProposal({
+				await createChangemakerProposal(null, {
 					changemakerId: changemaker.id,
 					proposalId,
 				});
 				const applicationFormIdDataProviderEarliest = (
-					await createApplicationForm({
+					await createApplicationForm(null, {
 						opportunityId: firstFunderOpportunity.id,
 					})
 				).id;
 				// Set up older field value.
-				await createProposalFieldValue({
+				await createProposalFieldValue(null, {
 					proposalVersionId: (
-						await createProposalVersion({
+						await createProposalVersion(null, {
 							proposalId,
 							applicationFormId: applicationFormIdDataProviderEarliest,
 							sourceId: firstDataProviderSourceId,
@@ -701,7 +701,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField({
+						await createApplicationFormField(null, {
 							label: 'Organization website 5479',
 							applicationFormId: applicationFormIdDataProviderEarliest,
 							baseFieldId: baseFieldWebsite.id,
@@ -713,14 +713,14 @@ describe('/changemakers', () => {
 					isValid: true,
 				});
 				const applicationFormIdDataProviderLatest = (
-					await createApplicationForm({
+					await createApplicationForm(null, {
 						opportunityId: firstFunderOpportunity.id,
 					})
 				).id;
 				// Set up newer field value.
-				const dataProviderNewestValue = await createProposalFieldValue({
+				const dataProviderNewestValue = await createProposalFieldValue(null, {
 					proposalVersionId: (
-						await createProposalVersion({
+						await createProposalVersion(null, {
 							proposalId,
 							applicationFormId: applicationFormIdDataProviderLatest,
 							sourceId: secondDataProviderSourceId,
@@ -728,7 +728,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField({
+						await createApplicationFormField(null, {
 							label: 'Phone contact',
 							applicationFormId: applicationFormIdDataProviderLatest,
 							baseFieldId: baseFieldWebsite.id,
@@ -815,7 +815,7 @@ describe('/changemakers', () => {
 		});
 
 		it('returns 409 conflict when an existing EIN + name combination is submitted', async () => {
-			await createChangemaker({
+			await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,

--- a/src/__tests__/dataProviders.int.test.ts
+++ b/src/__tests__/dataProviders.int.test.ts
@@ -22,12 +22,12 @@ describe('/dataProviders', () => {
 
 		it('returns all data providers present in the database', async () => {
 			const systemDataProvider = await loadSystemDataProvider();
-			await createOrUpdateDataProvider({
+			await createOrUpdateDataProvider(null, {
 				shortCode: 'dataRUs',
 				name: 'Data R Us',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateDataProvider({
+			await createOrUpdateDataProvider(null, {
 				shortCode: 'nonProfitWarehouse',
 				name: 'Nonprofit Warehouse',
 				keycloakOrganizationId: null,
@@ -64,12 +64,12 @@ describe('/dataProviders', () => {
 		});
 
 		it('returns exactly one data provider selected by short code', async () => {
-			await createOrUpdateDataProvider({
+			await createOrUpdateDataProvider(null, {
 				shortCode: 'dataRUs',
 				name: 'Data R Us',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateDataProvider({
+			await createOrUpdateDataProvider(null, {
 				shortCode: 'nonProfitWarehouse',
 				name: 'Nonprofit Warehouse',
 				keycloakOrganizationId: null,
@@ -88,7 +88,7 @@ describe('/dataProviders', () => {
 		});
 
 		it('returns 404 when short code is not found', async () => {
-			await createOrUpdateDataProvider({
+			await createOrUpdateDataProvider(null, {
 				shortCode: 'dataRUs',
 				name: 'Data R Us',
 				keycloakOrganizationId: null,
@@ -134,12 +134,12 @@ describe('/dataProviders', () => {
 		});
 
 		it('updates an existing data provider and no others', async () => {
-			await createOrUpdateDataProvider({
+			await createOrUpdateDataProvider(null, {
 				shortCode: 'firework',
 				name: 'boring text base firework',
 				keycloakOrganizationId: null,
 			});
-			const anotherDataProviderBefore = await createOrUpdateDataProvider({
+			const anotherDataProviderBefore = await createOrUpdateDataProvider(null, {
 				shortCode: 'anotherFirework',
 				name: 'another boring text base firework',
 				keycloakOrganizationId: null,

--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -27,12 +27,12 @@ describe('/funders', () => {
 		});
 
 		it('returns all funders present in the database', async () => {
-			await createOrUpdateFunder({
+			await createOrUpdateFunder(null, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateFunder({
+			await createOrUpdateFunder(null, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: null,
@@ -65,12 +65,12 @@ describe('/funders', () => {
 		});
 
 		it('returns exactly one funder selected by short code', async () => {
-			await createOrUpdateFunder({
+			await createOrUpdateFunder(null, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateFunder({
+			await createOrUpdateFunder(null, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: '0de87edc-be40-11ef-8249-0312f1b87538',
@@ -89,7 +89,7 @@ describe('/funders', () => {
 		});
 
 		it('returns 404 when short code is not found', async () => {
-			await createOrUpdateFunder({
+			await createOrUpdateFunder(null, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: null,
@@ -134,12 +134,12 @@ describe('/funders', () => {
 		});
 
 		it('updates an existing funder and no others', async () => {
-			await createOrUpdateFunder({
+			await createOrUpdateFunder(null, {
 				shortCode: 'firework',
 				name: 'boring text-based firework',
 				keycloakOrganizationId: null,
 			});
-			const anotherFunderBefore = await createOrUpdateFunder({
+			const anotherFunderBefore = await createOrUpdateFunder(null, {
 				shortCode: 'anotherFirework',
 				name: 'another boring text based firework',
 				keycloakOrganizationId: null,

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -18,10 +18,10 @@ describe('/opportunities', () => {
 		});
 
 		it('returns all opportunities present in the database', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Tremendous opportunity 👌',
 			});
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Terrific opportunity 👐',
 			});
 			const response = await request(app)
@@ -52,9 +52,9 @@ describe('/opportunities', () => {
 		});
 
 		it('returns exactly one opportunity selected by id', async () => {
-			await createOpportunity({ title: '🔥' });
-			await createOpportunity({ title: '✨' });
-			await createOpportunity({ title: '🚀' });
+			await createOpportunity(null, { title: '🔥' });
+			await createOpportunity(null, { title: '✨' });
+			await createOpportunity(null, { title: '🚀' });
 
 			const response = await request(app)
 				.get(`/opportunities/2`)
@@ -90,7 +90,7 @@ describe('/opportunities', () => {
 		});
 
 		it('returns 404 when id is not found', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'This definitely should not be returned',
 			});
 			await request(app).get('/opportunities/9001').set(authHeader).expect(404);

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -18,14 +18,14 @@ import { mockJwt as authHeader } from '../test/mockJwt';
 const logger = getLogger(__filename);
 
 const createTestBaseFields = async () => {
-	await createBaseField({
+	await createBaseField(null, {
 		label: 'First Name',
 		description: 'The first name of the applicant',
 		shortCode: 'firstName',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.PROPOSAL,
 	});
-	await createBaseField({
+	await createBaseField(null, {
 		label: 'Last Name',
 		description: 'The last name of the applicant',
 		shortCode: 'lastName',
@@ -42,17 +42,17 @@ describe('/proposalVersions', () => {
 
 		it('returns exactly one proposal version selected by id', async () => {
 			const systemSource = await loadSystemSource(null);
-			const opportunity = await createOpportunity({ title: '🔥' });
+			const opportunity = await createOpportunity(null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			const proposal = await createProposal({
+			const proposal = await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			const applicationForm = await createApplicationForm({
+			const applicationForm = await createApplicationForm(null, {
 				opportunityId: opportunity.id,
 			});
-			const proposalVersion = await createProposalVersion({
+			const proposalVersion = await createProposalVersion(null, {
 				proposalId: proposal.id,
 				applicationFormId: applicationForm.id,
 				sourceId: systemSource.id,
@@ -103,14 +103,14 @@ describe('/proposalVersions', () => {
 
 		it('creates exactly one proposal version', async () => {
 			const systemSource = await loadSystemSource(null);
-			await createOpportunity({ title: '🔥' });
+			await createOpportunity(null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
 			const before = await loadTableMetrics('proposal_versions');
@@ -139,24 +139,24 @@ describe('/proposalVersions', () => {
 
 		it('creates exactly the number of provided field values', async () => {
 			const systemSource = await loadSystemSource(null);
-			await createOpportunity({ title: '🔥' });
+			await createOpportunity(null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
 			await createTestBaseFields();
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'First Name',
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 2,
 				position: 2,
@@ -269,14 +269,14 @@ describe('/proposalVersions', () => {
 
 		it('returns 409 Conflict when the provided proposal does not exist', async () => {
 			const systemSource = await loadSystemSource(null);
-			await createOpportunity({ title: '🔥' });
+			await createOpportunity(null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
 			const result = await request(app)
@@ -303,14 +303,14 @@ describe('/proposalVersions', () => {
 		});
 
 		it('returns 409 conflict when the provided source does not exist', async () => {
-			await createOpportunity({ title: '🔥' });
+			await createOpportunity(null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
 			const result = await request(app)
@@ -337,14 +337,14 @@ describe('/proposalVersions', () => {
 
 		it('Returns 409 Conflict if the provided application form does not exist', async () => {
 			const systemSource = await loadSystemSource(null);
-			await createOpportunity({ title: '🔥' });
+			await createOpportunity(null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
 			const before = await loadTableMetrics('proposal_field_values');
@@ -377,18 +377,18 @@ describe('/proposalVersions', () => {
 
 		it('Returns 409 Conflict if the provided application form ID is not associated with the proposal opportunity', async () => {
 			const systemSource = await loadSystemSource(null);
-			await createOpportunity({ title: '🔥' });
-			await createOpportunity({ title: '💧' });
+			await createOpportunity(null, { title: '🔥' });
+			await createOpportunity(null, { title: '💧' });
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 2,
 			});
 			const before = await loadTableMetrics('proposal_field_values');
@@ -423,14 +423,14 @@ describe('/proposalVersions', () => {
 
 		it('Returns 409 Conflict if a provided application form field ID does not exist', async () => {
 			const systemSource = await loadSystemSource(null);
-			await createOpportunity({ title: '🔥' });
+			await createOpportunity(null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
 			const before = await loadTableMetrics('proposal_field_values');
@@ -470,27 +470,27 @@ describe('/proposalVersions', () => {
 
 		it('Returns 409 Conflict if a provided application form field ID is not associated with the supplied application form ID', async () => {
 			const systemSource = await loadSystemSource(null);
-			await createOpportunity({ title: '🔥' });
+			await createOpportunity(null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
 			await createTestBaseFields();
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'First Name',
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 2,
 				position: 2,

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -29,14 +29,14 @@ import {
 } from '../types';
 
 const createTestBaseFields = async () => {
-	await createBaseField({
+	await createBaseField(null, {
 		label: 'Summary',
 		description: 'A summary of the proposal',
 		shortCode: 'summary',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.PROPOSAL,
 	});
-	await createBaseField({
+	await createBaseField(null, {
 		label: 'Title',
 		description: 'The title of the proposal',
 		shortCode: 'title',
@@ -63,46 +63,46 @@ describe('/proposals', () => {
 		});
 
 		it('returns proposals associated with the requesting user', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
-			const secondUser = await createUser({
+			const secondUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
 			const systemSource = await loadSystemSource(null);
 			await createTestBaseFields();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-3',
 				opportunityId: 1,
 				createdBy: secondUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createProposalVersion({
+			await createProposalVersion(null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'Short summary',
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
@@ -178,28 +178,28 @@ describe('/proposals', () => {
 		});
 
 		it('returns a subset of proposals present in the database when a changemaker filter is provided', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
 			await createTestBaseFields();
-			const proposal = await createProposal({
+			const proposal = await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '123-123-123',
 				name: 'Canadian Company',
 				keycloakOrganizationId: null,
 			});
-			await createChangemakerProposal({
+			await createChangemakerProposal(null, {
 				changemakerId: changemaker.id,
 				proposalId: proposal.id,
 			});
@@ -245,52 +245,52 @@ describe('/proposals', () => {
 		});
 
 		it('returns a subset of proposals present in the database when search is provided', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
 			const systemSource = await loadSystemSource(null);
 			await createTestBaseFields();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createProposalVersion({
+			await createProposalVersion(null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion({
+			await createProposalVersion(null, {
 				proposalId: 2,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'Short summary',
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'This is a summary',
 				isValid: true,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 1,
 				position: 1,
@@ -357,21 +357,21 @@ describe('/proposals', () => {
 		});
 
 		it('returns all proposals present in the database regardless of createdBy value when loading as an administrator', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser({
+			const anotherUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
 			await createTestBaseFields();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: anotherUser.keycloakUserId,
@@ -404,21 +404,21 @@ describe('/proposals', () => {
 		});
 
 		it('returns a correct subset of proposals when createdBy is provided as an administrator', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser({
+			const anotherUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
 			await createTestBaseFields();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: anotherUser.keycloakUserId,
@@ -445,21 +445,21 @@ describe('/proposals', () => {
 		});
 
 		it("returns just the administrator's proposals when createdBy is set to `me` as an administrator", async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser({
+			const anotherUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
 			await createTestBaseFields();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: anotherUser.keycloakUserId,
@@ -487,51 +487,51 @@ describe('/proposals', () => {
 			// This should pass even if the default text search config is 'simple'.
 			// See https://github.com/PhilanthropyDataCommons/service/issues/336
 			await db.query("set default_text_search_config = 'simple';");
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: 'Grand opportunity',
 			});
 			const testUser = await loadTestUser();
 			const systemSource = await loadSystemSource(null);
 			await createTestBaseFields();
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-4999',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: 'proposal-5003',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createProposalVersion({
+			await createProposalVersion(null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion({
+			await createProposalVersion(null, {
 				proposalId: 2,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'Concise summary',
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'This is a summary',
 				isValid: true,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 1,
 				position: 1,
@@ -598,14 +598,14 @@ describe('/proposals', () => {
 		});
 
 		it('returns according to pagination parameters', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
-				await createProposal({
+				await createProposal(null, {
 					externalId: `proposal-${i + 1}`,
 					opportunityId: 1,
 					createdBy: testUser.keycloakUserId,
@@ -693,13 +693,13 @@ describe('/proposals', () => {
 		});
 
 		it('returns 404 when given id is not owned by the current user', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '⛰️',
 			});
-			const anotherUser = await createUser({
+			const anotherUser = await createUser(null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: `proposal-1`,
 				opportunityId: 1,
 				createdBy: anotherUser.keycloakUserId,
@@ -737,17 +737,17 @@ describe('/proposals', () => {
 		});
 
 		it('returns the one proposal asked for', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '⛰️',
 			});
 
 			const testUser = await loadTestUser();
-			await createProposal({
+			await createProposal(null, {
 				externalId: `proposal-1`,
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: `proposal-2`,
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
@@ -768,20 +768,20 @@ describe('/proposals', () => {
 		});
 
 		it('returns one proposal with deep fields', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🌎',
 			});
 			await createTestBaseFields();
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 2,
 				position: 1,
 				label: 'Short summary or title',
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 2,
@@ -789,45 +789,45 @@ describe('/proposals', () => {
 			});
 			const testUser = await loadTestUser();
 			const systemSource = await loadSystemSource(null);
-			await createProposal({
+			await createProposal(null, {
 				externalId: `proposal-2525-01-04T00Z`,
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion({
+			await createProposalVersion(null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion({
+			await createProposalVersion(null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'Title for version 1 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 2,
 				position: 2,
 				value: 'Abstract for version 1 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'Title for version 2 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 2,
 				position: 2,
@@ -985,63 +985,63 @@ describe('/proposals', () => {
 			const testUser = await loadTestUser();
 			const systemSource = await loadSystemSource(null);
 			await createTestBaseFields();
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🌎',
 			});
-			await createApplicationForm({
+			await createApplicationForm(null, {
 				opportunityId: 1,
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 2,
 				position: 1,
 				label: 'Short summary or title',
 			});
-			await createApplicationFormField({
+			await createApplicationFormField(null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 2,
 				label: 'Long summary or abstract',
 			});
-			await createProposal({
+			await createProposal(null, {
 				externalId: `proposal-2525-01-04T00Z`,
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion({
+			await createProposalVersion(null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion({
+			await createProposalVersion(null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'Title for version 1 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 2,
 				position: 2,
 				value: 'Abstract for version 1 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'Title for version 2 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue({
+			await createProposalFieldValue(null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 2,
 				position: 2,
@@ -1209,7 +1209,7 @@ describe('/proposals', () => {
 		});
 
 		it('creates exactly one proposal', async () => {
-			await createOpportunity({
+			await createOpportunity(null, {
 				title: '🔥',
 			});
 			const before = await loadTableMetrics('proposals');

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -35,12 +35,12 @@ describe('/sources', () => {
 
 		it('returns all sources present in the database', async () => {
 			const systemSource = await loadSystemSource(null);
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			const source = await createSource({
+			const source = await createSource(null, {
 				label: 'Example Inc.',
 				changemakerId: changemaker.id,
 			});
@@ -58,12 +58,12 @@ describe('/sources', () => {
 		});
 
 		it('returns exactly one source selected by id', async () => {
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			const source = await createSource({
+			const source = await createSource(null, {
 				label: 'Example Inc.',
 				changemakerId: changemaker.id,
 			});
@@ -95,12 +95,12 @@ describe('/sources', () => {
 		});
 
 		it('returns 404 when id is not found', async () => {
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createSource({
+			await createSource(null, {
 				label: 'not to be returned',
 				changemakerId: changemaker.id,
 			});
@@ -118,7 +118,7 @@ describe('/sources', () => {
 		});
 
 		it('creates and returns exactly one changemaker source', async () => {
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -146,7 +146,7 @@ describe('/sources', () => {
 		});
 
 		it('creates and returns exactly one funder source', async () => {
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'foo',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -174,7 +174,7 @@ describe('/sources', () => {
 		});
 
 		it('creates and returns exactly one data provider source', async () => {
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'foo',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -202,7 +202,7 @@ describe('/sources', () => {
 		});
 
 		it('returns 400 bad request when no label sent', async () => {
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,

--- a/src/__tests__/userChangemakerPermissions.int.test.ts
+++ b/src/__tests__/userChangemakerPermissions.int.test.ts
@@ -19,7 +19,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 	describe('PUT /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -34,7 +34,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -80,7 +80,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 
 		it('creates and returns the new user changemaker permission when user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -104,12 +104,12 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 
 		it('creates and returns the new user changemaker permission when user has permission to manage the changemaker', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserChangemakerPermission({
+			await createOrUpdateUserChangemakerPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				changemakerId: changemaker.id,
 				permission: Permission.MANAGE,
@@ -134,12 +134,12 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 		it('does not update `createdBy`, but returns the user changemaker permission when user has permission to manage the changemaker', async () => {
 			const user = await loadTestUser();
 			const systemUser = await loadSystemUser(null);
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserChangemakerPermission({
+			await createOrUpdateUserChangemakerPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				changemakerId: changemaker.id,
 				permission: Permission.MANAGE,
@@ -165,7 +165,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 	describe('DELETE /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -180,7 +180,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -228,7 +228,7 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 
 		it('returns 404 if the permission does not exist', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -244,12 +244,12 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 
 		it('returns 404 if the permission had existed and previously been deleted', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserChangemakerPermission({
+			await createOrUpdateUserChangemakerPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				changemakerId: changemaker.id,
 				permission: Permission.EDIT,
@@ -271,12 +271,12 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 
 		it('deletes the user changemaker permission when the user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserChangemakerPermission({
+			await createOrUpdateUserChangemakerPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				changemakerId: changemaker.id,
 				permission: Permission.EDIT,
@@ -314,18 +314,18 @@ describe('/users/changemakers/:changemakerId/permissions/:permission', () => {
 
 		it('deletes the user changemaker permission when the user has permission to manage the changemaker', async () => {
 			const user = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserChangemakerPermission({
+			await createOrUpdateUserChangemakerPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				changemakerId: changemaker.id,
 				permission: Permission.MANAGE,
 				createdBy: user.keycloakUserId,
 			});
-			await createOrUpdateUserChangemakerPermission({
+			await createOrUpdateUserChangemakerPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				changemakerId: changemaker.id,
 				permission: Permission.EDIT,

--- a/src/__tests__/userDataProviderPermissions.int.test.ts
+++ b/src/__tests__/userDataProviderPermissions.int.test.ts
@@ -19,7 +19,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 	describe('PUT /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -34,7 +34,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -83,7 +83,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('creates and returns the new user data provider permission when user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -107,12 +107,12 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('creates and returns the new user data provider permission when user has permission to manage the data provider', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission({
+			await createOrUpdateUserDataProviderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.MANAGE,
@@ -138,12 +138,12 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 		it('does not update `createdBy`, but returns the user data provider permission when user has permission to manage the data provider', async () => {
 			const user = await loadTestUser();
 			const systemUser = await loadSystemUser(null);
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission({
+			await createOrUpdateUserDataProviderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.MANAGE,
@@ -170,7 +170,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 	describe('DELETE /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -185,7 +185,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -233,7 +233,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('returns 404 if the permission does not exist', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -249,12 +249,12 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('returns 404 if the permission had existed and previously been deleted', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission({
+			await createOrUpdateUserDataProviderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.EDIT,
@@ -276,12 +276,12 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('deletes the user data provider permission when the user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission({
+			await createOrUpdateUserDataProviderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.EDIT,
@@ -319,18 +319,18 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('deletes the user data provider permission when the user has permission to manage the data provider', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission({
+			await createOrUpdateUserDataProviderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.MANAGE,
 				createdBy: user.keycloakUserId,
 			});
-			await createOrUpdateUserDataProviderPermission({
+			await createOrUpdateUserDataProviderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.EDIT,

--- a/src/__tests__/userFunderPermissions.int.test.ts
+++ b/src/__tests__/userFunderPermissions.int.test.ts
@@ -19,7 +19,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 	describe('PUT /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -34,7 +34,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -83,7 +83,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('creates and returns the new user funder permission when user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -107,12 +107,12 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('creates and returns the new user funder permission when user has permission to manage the funder', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission({
+			await createOrUpdateUserFunderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.MANAGE,
@@ -138,12 +138,12 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 		it('does not update `createdBy`, but returns the user funder permission when user has permission to manage the funder', async () => {
 			const user = await loadTestUser();
 			const systemUser = await loadSystemUser(null);
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission({
+			await createOrUpdateUserFunderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.MANAGE,
@@ -170,7 +170,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 	describe('DELETE /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -185,7 +185,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -231,7 +231,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('returns 404 if the permission does not exist', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -247,12 +247,12 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('returns 404 if the permission had existed and previously been deleted', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission({
+			await createOrUpdateUserFunderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.EDIT,
@@ -274,12 +274,12 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('deletes the user funder permission when the user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission({
+			await createOrUpdateUserFunderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.EDIT,
@@ -317,18 +317,18 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('deletes the user funder permission when the user has permission to manage the funder', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission({
+			await createOrUpdateUserFunderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.MANAGE,
 				createdBy: user.keycloakUserId,
 			});
-			await createOrUpdateUserFunderPermission({
+			await createOrUpdateUserFunderPermission(null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.EDIT,

--- a/src/__tests__/users.int.test.ts
+++ b/src/__tests__/users.int.test.ts
@@ -21,7 +21,7 @@ import {
 import { keycloakIdToString, stringToKeycloakId, Permission } from '../types';
 
 const createAdditionalTestUser = async () =>
-	createUser({
+	createUser(null, {
 		keycloakUserId: stringToKeycloakId('123e4567-e89b-12d3-a456-426614174000'),
 	});
 
@@ -59,34 +59,34 @@ describe('/users', () => {
 		it('returns the permissions associated with a user', async () => {
 			const systemUser = await loadSystemUser(null);
 			const testUser = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider({
+			const dataProvider = await createOrUpdateDataProvider(null, {
 				name: 'Test Provider',
 				shortCode: 'testProvider',
 				keycloakOrganizationId: null,
 			});
-			const funder = await createOrUpdateFunder({
+			const funder = await createOrUpdateFunder(null, {
 				name: 'Test Funder',
 				shortCode: 'testFunder',
 				keycloakOrganizationId: null,
 			});
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				name: 'Test Changemaker',
 				taxId: '12-3456789',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission({
+			await createOrUpdateUserDataProviderPermission(null, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				permission: Permission.MANAGE,
 				dataProviderShortCode: dataProvider.shortCode,
 				createdBy: systemUser.keycloakUserId,
 			});
-			await createOrUpdateUserFunderPermission({
+			await createOrUpdateUserFunderPermission(null, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				permission: Permission.EDIT,
 				funderShortCode: funder.shortCode,
 				createdBy: systemUser.keycloakUserId,
 			});
-			await createOrUpdateUserChangemakerPermission({
+			await createOrUpdateUserChangemakerPermission(null, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				permission: Permission.VIEW,
 				changemakerId: changemaker.id,
@@ -123,12 +123,12 @@ describe('/users', () => {
 		it('does not return deleted permissions associated with a user', async () => {
 			const systemUser = await loadSystemUser(null);
 			const testUser = await loadTestUser();
-			const changemaker = await createChangemaker({
+			const changemaker = await createChangemaker(null, {
 				name: 'Test Changemaker',
 				taxId: '12-3456789',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserChangemakerPermission({
+			await createOrUpdateUserChangemakerPermission(null, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				permission: Permission.VIEW,
 				changemakerId: changemaker.id,
@@ -204,7 +204,7 @@ describe('/users', () => {
 			const uuids = Array.from(Array(20)).map(() => uuidv4());
 			await uuids.reduce(async (p, uuid) => {
 				await p;
-				await createUser({
+				await createUser(null, {
 					keycloakUserId: uuid,
 				});
 			}, Promise.resolve());

--- a/src/database/operations/applicationFormFields/createApplicationFormField.ts
+++ b/src/database/operations/applicationFormFields/createApplicationFormField.ts
@@ -1,30 +1,17 @@
-import { db } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
-	JsonResultSet,
 	ApplicationFormField,
 	WritableApplicationFormField,
 } from '../../../types';
 
-const createApplicationFormField = async (
-	createValues: WritableApplicationFormField,
-): Promise<ApplicationFormField> => {
-	const { applicationFormId, baseFieldId, position, label } = createValues;
-	const result = await db.sql<JsonResultSet<ApplicationFormField>>(
-		'applicationFormFields.insertOne',
-		{
-			applicationFormId,
-			baseFieldId,
-			position,
-			label,
-		},
-	);
-	const applicationFormField = result.rows[0]?.object;
-	if (applicationFormField === undefined) {
-		throw new Error(
-			'The application form field creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return applicationFormField;
-};
+const createApplicationFormField = generateCreateOrUpdateItemOperation<
+	ApplicationFormField,
+	WritableApplicationFormField
+>('applicationFormFields.insertOne', [
+	'applicationFormId',
+	'baseFieldId',
+	'position',
+	'label',
+]);
 
 export { createApplicationFormField };

--- a/src/database/operations/applicationForms/createApplicationForm.ts
+++ b/src/database/operations/applicationForms/createApplicationForm.ts
@@ -1,25 +1,9 @@
-import { db } from '../../db';
-import type {
-	JsonResultSet,
-	ApplicationForm,
-	WritableApplicationForm,
-} from '../../../types';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { ApplicationForm, WritableApplicationForm } from '../../../types';
 
-export const createApplicationForm = async (
-	createValues: WritableApplicationForm,
-): Promise<ApplicationForm> => {
-	const { opportunityId } = createValues;
-	const result = await db.sql<JsonResultSet<ApplicationForm>>(
-		'applicationForms.insertOne',
-		{
-			opportunityId,
-		},
-	);
-	const applicationForm = result.rows[0]?.object;
-	if (applicationForm === undefined) {
-		throw new Error(
-			'The application form creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return applicationForm;
-};
+const createApplicationForm = generateCreateOrUpdateItemOperation<
+	ApplicationForm,
+	WritableApplicationForm
+>('applicationForms.insertOne', ['opportunityId']);
+
+export { createApplicationForm };

--- a/src/database/operations/baseFieldLocalization/createOrUpdateBaseFieldLocalizations.ts
+++ b/src/database/operations/baseFieldLocalization/createOrUpdateBaseFieldLocalizations.ts
@@ -1,33 +1,17 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
 	BaseFieldLocalization,
 	InternallyWritableBaseFieldLocalization,
-	JsonResultSet,
 } from '../../../types';
 
-export const createOrUpdateBaseFieldLocalization = async (
-	updateValues: InternallyWritableBaseFieldLocalization,
-): Promise<BaseFieldLocalization> => {
-	const { baseFieldId, language, label, description } = updateValues;
-	const result = await db.sql<JsonResultSet<BaseFieldLocalization>>(
-		'baseFieldLocalizations.createOrUpdateByPrimaryKey',
-		{
-			baseFieldId,
-			language,
-			label,
-			description,
-		},
-	);
-	const baseFieldLocalization = result.rows[0]?.object;
-	if (baseFieldLocalization === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'BaseFieldLocalization',
-			entityPrimaryKey: {
-				baseFieldId,
-				language,
-			},
-		});
-	}
-	return baseFieldLocalization;
-};
+const createOrUpdateBaseFieldLocalization = generateCreateOrUpdateItemOperation<
+	BaseFieldLocalization,
+	InternallyWritableBaseFieldLocalization
+>('baseFieldLocalizations.createOrUpdateByPrimaryKey', [
+	'baseFieldId',
+	'language',
+	'label',
+	'description',
+]);
+
+export { createOrUpdateBaseFieldLocalization };

--- a/src/database/operations/baseFields/createBaseField.ts
+++ b/src/database/operations/baseFields/createBaseField.ts
@@ -1,30 +1,15 @@
-import { db as defaultDb } from '../../db';
-import type {
-	BaseField,
-	JsonResultSet,
-	WritableBaseField,
-} from '../../../types';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { BaseField, WritableBaseField } from '../../../types';
 
-export const createBaseField = async (
-	createValues: WritableBaseField,
-	db = defaultDb,
-): Promise<BaseField> => {
-	const { label, description, shortCode, dataType, scope } = createValues;
-	const result = await db.sql<JsonResultSet<BaseField>>(
-		'baseFields.insertOne',
-		{
-			label,
-			description,
-			shortCode,
-			dataType,
-			scope,
-		},
-	);
-	const baseField = result.rows[0]?.object;
-	if (baseField === undefined) {
-		throw new Error(
-			'The base field creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return baseField;
-};
+const createBaseField = generateCreateOrUpdateItemOperation<
+	BaseField,
+	WritableBaseField
+>('baseFields.insertOne', [
+	'scope',
+	'dataType',
+	'shortCode',
+	'label',
+	'description',
+]);
+
+export { createBaseField };

--- a/src/database/operations/baseFields/createOrUpdateBaseField.ts
+++ b/src/database/operations/baseFields/createOrUpdateBaseField.ts
@@ -1,33 +1,15 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type {
-	BaseField,
-	WritableBaseField,
-	JsonResultSet,
-} from '../../../types';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { BaseField, WritableBaseField } from '../../../types';
 
-export const createOrUpdateBaseField = async (
-	updateValues: WritableBaseField,
-): Promise<BaseField> => {
-	const { scope, dataType, shortCode, label, description } = updateValues;
-	const result = await db.sql<JsonResultSet<BaseField>>(
-		'baseFields.createOrUpdateByShortcode',
-		{
-			scope,
-			dataType,
-			shortCode,
-			label,
-			description,
-		},
-	);
-	const baseField = result.rows[0]?.object;
-	if (baseField === undefined) {
-		throw new NotFoundError('BaseField could not be created or updated', {
-			entityType: 'BaseField',
-			lookupValues: {
-				shortCode,
-			},
-		});
-	}
-	return baseField;
-};
+const createOrUpdateBaseField = generateCreateOrUpdateItemOperation<
+	BaseField,
+	WritableBaseField
+>('baseFields.createOrUpdateByShortcode', [
+	'scope',
+	'dataType',
+	'shortCode',
+	'label',
+	'description',
+]);
+
+export { createOrUpdateBaseField };

--- a/src/database/operations/baseFieldsCopyTasks/createBaseFieldsCopyTask.ts
+++ b/src/database/operations/baseFieldsCopyTasks/createBaseFieldsCopyTask.ts
@@ -1,28 +1,12 @@
-import { db } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
-	JsonResultSet,
 	BaseFieldsCopyTask,
 	InternallyWritableBaseFieldsCopyTask,
 } from '../../../types';
 
-export const createBaseFieldsCopyTask = async (
-	createValues: InternallyWritableBaseFieldsCopyTask,
-): Promise<BaseFieldsCopyTask> => {
-	const { pdcApiUrl, status, createdBy } = createValues;
+const createBaseFieldsCopyTask = generateCreateOrUpdateItemOperation<
+	BaseFieldsCopyTask,
+	InternallyWritableBaseFieldsCopyTask
+>('baseFieldsCopyTasks.insertOne', ['status', 'pdcApiUrl', 'createdBy']);
 
-	const result = await db.sql<JsonResultSet<BaseFieldsCopyTask>>(
-		'baseFieldsCopyTasks.insertOne',
-		{
-			status,
-			pdcApiUrl,
-			createdBy,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+export { createBaseFieldsCopyTask };

--- a/src/database/operations/bulkUploadTasks/createBulkUploadTask.ts
+++ b/src/database/operations/bulkUploadTasks/createBulkUploadTask.ts
@@ -1,30 +1,18 @@
-import { db } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
-	JsonResultSet,
 	BulkUploadTask,
 	InternallyWritableBulkUploadTask,
 } from '../../../types';
 
-export const createBulkUploadTask = async (
-	createValues: InternallyWritableBulkUploadTask,
-): Promise<BulkUploadTask> => {
-	const { sourceId, fileName, sourceKey, status, createdBy } = createValues;
+const createBulkUploadTask = generateCreateOrUpdateItemOperation<
+	BulkUploadTask,
+	InternallyWritableBulkUploadTask
+>('bulkUploadTasks.insertOne', [
+	'sourceId',
+	'fileName',
+	'sourceKey',
+	'status',
+	'createdBy',
+]);
 
-	const result = await db.sql<JsonResultSet<BulkUploadTask>>(
-		'bulkUploadTasks.insertOne',
-		{
-			sourceId,
-			fileName,
-			sourceKey,
-			status,
-			createdBy,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+export { createBulkUploadTask };

--- a/src/database/operations/changemakerProposals/createChangemakerProposal.ts
+++ b/src/database/operations/changemakerProposals/createChangemakerProposal.ts
@@ -1,26 +1,12 @@
-import { db } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import {
-	JsonResultSet,
 	type ChangemakerProposal,
 	type WritableChangemakerProposal,
 } from '../../../types';
 
-export const createChangemakerProposal = async (
-	createValues: WritableChangemakerProposal,
-): Promise<ChangemakerProposal> => {
-	const { changemakerId, proposalId } = createValues;
-	const result = await db.sql<JsonResultSet<ChangemakerProposal>>(
-		'changemakersProposals.insertOne',
-		{
-			changemakerId,
-			proposalId,
-		},
-	);
-	const changemakerProposal = result.rows[0]?.object;
-	if (changemakerProposal === undefined) {
-		throw new Error(
-			'The changemaker-proposal creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return changemakerProposal;
-};
+const createChangemakerProposal = generateCreateOrUpdateItemOperation<
+	ChangemakerProposal,
+	WritableChangemakerProposal
+>('changemakersProposals.insertOne', ['changemakerId', 'proposalId']);
+
+export { createChangemakerProposal };

--- a/src/database/operations/changemakers/createChangemaker.ts
+++ b/src/database/operations/changemakers/createChangemaker.ts
@@ -1,27 +1,9 @@
-import { db } from '../../db';
-import type {
-	JsonResultSet,
-	Changemaker,
-	WritableChangemaker,
-} from '../../../types';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { Changemaker, WritableChangemaker } from '../../../types';
 
-export const createChangemaker = async (
-	createValues: WritableChangemaker,
-): Promise<Changemaker> => {
-	const { taxId, name, keycloakOrganizationId } = createValues;
-	const result = await db.sql<JsonResultSet<Changemaker>>(
-		'changemakers.insertOne',
-		{
-			taxId,
-			name,
-			keycloakOrganizationId,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+const createChangemaker = generateCreateOrUpdateItemOperation<
+	Changemaker,
+	WritableChangemaker
+>('changemakers.insertOne', ['taxId', 'name', 'keycloakOrganizationId']);
+
+export { createChangemaker };

--- a/src/database/operations/dataProviders/createOrUpdateDataProvider.ts
+++ b/src/database/operations/dataProviders/createOrUpdateDataProvider.ts
@@ -1,29 +1,16 @@
-import { db } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
-	JsonResultSet,
 	DataProvider,
 	InternallyWritableDataProvider,
 } from '../../../types';
 
-const createOrUpdateDataProvider = async (
-	createValues: InternallyWritableDataProvider,
-): Promise<DataProvider> => {
-	const { shortCode, name, keycloakOrganizationId } = createValues;
-	const result = await db.sql<JsonResultSet<DataProvider>>(
-		'dataProviders.insertOrUpdateOne',
-		{
-			shortCode,
-			name,
-			keycloakOrganizationId,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+const createOrUpdateDataProvider = generateCreateOrUpdateItemOperation<
+	DataProvider,
+	InternallyWritableDataProvider
+>('dataProviders.insertOrUpdateOne', [
+	'shortCode',
+	'name',
+	'keycloakOrganizationId',
+]);
 
 export { createOrUpdateDataProvider };

--- a/src/database/operations/funders/createOrUpdateFunder.ts
+++ b/src/database/operations/funders/createOrUpdateFunder.ts
@@ -1,29 +1,9 @@
-import { db } from '../../db';
-import type {
-	JsonResultSet,
-	Funder,
-	InternallyWritableFunder,
-} from '../../../types';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { Funder, InternallyWritableFunder } from '../../../types';
 
-const createOrUpdateFunder = async (
-	createValues: InternallyWritableFunder,
-): Promise<Funder> => {
-	const { shortCode, name, keycloakOrganizationId } = createValues;
-	const result = await db.sql<JsonResultSet<Funder>>(
-		'funders.insertOrUpdateOne',
-		{
-			shortCode,
-			name,
-			keycloakOrganizationId,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+const createOrUpdateFunder = generateCreateOrUpdateItemOperation<
+	Funder,
+	InternallyWritableFunder
+>('funders.insertOrUpdateOne', ['shortCode', 'name', 'keycloakOrganizationId']);
 
 export { createOrUpdateFunder };

--- a/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
+++ b/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
@@ -1,0 +1,41 @@
+import { db as defaultDb } from '../../db';
+import type { JsonResultSet } from '../../../types';
+
+// This may seem silly but it is necessary to get all keys of all
+// possible types in the event the type is a Union (e.g. A | B | C)
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+
+/**
+ * Generates a function that will invoke a specific query for data insertion
+ *
+ * @template T - The type of the item being created.
+ * @template I - The type of object to be passed for data insertion.
+ *
+ * @param {string} queryName - The name of the query to execute.
+ * @param {Object} savedAttributes - A list of the attribute names which should be converted to query parameters.
+ *
+ * @returns {Function} A function that takes query parameters, limit, and offset, and returns a promise that resolves to a bundle of entries and total count.
+ */
+ const generateCreateOrUpdateItemOperation =
+	<T, P extends Record<string, unknown>>(
+		queryName: string,
+		savedAttributes: KeysOfUnion<P>[],
+	) =>
+	async (createValues: P, db = defaultDb): Promise<T> => {
+		const queryParameters = savedAttributes.reduce(
+			(acc, attribute) => ({
+				...acc,
+				[attribute]: createValues[attribute],
+			}),
+			{},
+		);
+
+		const result = await db.sql<JsonResultSet<T>>(queryName, queryParameters);
+		const { object } = result.rows[0] ?? {};
+		if (object === undefined) {
+			throw new Error('The database did not return a query result.');
+		}
+		return object;
+	};
+
+export { generateCreateOrUpdateItemOperation };

--- a/src/database/operations/generators/index.ts
+++ b/src/database/operations/generators/index.ts
@@ -1,2 +1,3 @@
+export * from './generateCreateOrUpdateItemOperation';
 export * from './generateLoadBundleOperation';
 export * from './generateLoadItemOperation';

--- a/src/database/operations/opportunities/createOpportunity.ts
+++ b/src/database/operations/opportunities/createOpportunity.ts
@@ -1,26 +1,9 @@
-import { db } from '../../db';
-import type {
-	JsonResultSet,
-	WritableOpportunity,
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { WritableOpportunity, Opportunity } from '../../../types';
+
+const createOpportunity = generateCreateOrUpdateItemOperation<
 	Opportunity,
-} from '../../../types';
+	WritableOpportunity
+>('opportunities.insertOne', ['title']);
 
-export const createOpportunity = async (
-	createValues: WritableOpportunity,
-): Promise<Opportunity> => {
-	const { title } = createValues;
-
-	const result = await db.sql<JsonResultSet<Opportunity>>(
-		'opportunities.insertOne',
-		{
-			title,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+export { createOpportunity };

--- a/src/database/operations/proposalFieldValues/createProposalFieldValue.ts
+++ b/src/database/operations/proposalFieldValues/createProposalFieldValue.ts
@@ -1,38 +1,18 @@
-import { db as defaultDb } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
 	ProposalFieldValue,
 	InternallyWritableProposalFieldValue,
-	JsonResultSet,
 } from '../../../types';
 
-const createProposalFieldValue = async (
-	createValues: InternallyWritableProposalFieldValue,
-	db = defaultDb,
-): Promise<ProposalFieldValue> => {
-	const {
-		proposalVersionId,
-		applicationFormFieldId,
-		position,
-		value,
-		isValid,
-	} = createValues;
-	const result = await db.sql<JsonResultSet<ProposalFieldValue>>(
-		'proposalFieldValues.insertOne',
-		{
-			proposalVersionId,
-			applicationFormFieldId,
-			position,
-			value,
-			isValid,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+const createProposalFieldValue = generateCreateOrUpdateItemOperation<
+	ProposalFieldValue,
+	InternallyWritableProposalFieldValue
+>('proposalFieldValues.insertOne', [
+	'proposalVersionId',
+	'applicationFormFieldId',
+	'position',
+	'value',
+	'isValid',
+]);
 
 export { createProposalFieldValue };

--- a/src/database/operations/proposalVersions/createProposalVersion.ts
+++ b/src/database/operations/proposalVersions/createProposalVersion.ts
@@ -1,31 +1,17 @@
-import { db as defaultDb } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
-	JsonResultSet,
 	ProposalVersion,
 	InternallyWritableProposalVersion,
 } from '../../../types';
 
-const createProposalVersion = async (
-	createValues: InternallyWritableProposalVersion,
-	db = defaultDb,
-): Promise<ProposalVersion> => {
-	const { proposalId, applicationFormId, sourceId, createdBy } = createValues;
-	const result = await db.sql<JsonResultSet<ProposalVersion>>(
-		'proposalVersions.insertOne',
-		{
-			proposalId,
-			applicationFormId,
-			sourceId,
-			createdBy,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+const createProposalVersion = generateCreateOrUpdateItemOperation<
+	ProposalVersion,
+	InternallyWritableProposalVersion
+>('proposalVersions.insertOne', [
+	'proposalId',
+	'applicationFormId',
+	'sourceId',
+	'createdBy',
+]);
 
 export { createProposalVersion };

--- a/src/database/operations/proposals/createProposal.ts
+++ b/src/database/operations/proposals/createProposal.ts
@@ -1,24 +1,9 @@
-import { db } from '../../db';
-import type {
-	Proposal,
-	JsonResultSet,
-	InternallyWritableProposal,
-} from '../../../types';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { Proposal, InternallyWritableProposal } from '../../../types';
 
-export const createProposal = async (
-	createValues: InternallyWritableProposal,
-): Promise<Proposal> => {
-	const { opportunityId, externalId, createdBy } = createValues;
-	const result = await db.sql<JsonResultSet<Proposal>>('proposals.insertOne', {
-		opportunityId,
-		externalId,
-		createdBy,
-	});
-	const proposal = result.rows[0]?.object;
-	if (proposal === undefined) {
-		throw new Error(
-			'The proposal creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return proposal;
-};
+const createProposal = generateCreateOrUpdateItemOperation<
+	Proposal,
+	InternallyWritableProposal
+>('proposals.insertOne', ['opportunityId', 'externalId', 'createdBy']);
+
+export { createProposal };

--- a/src/database/operations/sources/createSource.ts
+++ b/src/database/operations/sources/createSource.ts
@@ -1,33 +1,14 @@
-import { db } from '../../db';
-import type { Source, JsonResultSet, WritableSource } from '../../../types';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { Source, WritableSource } from '../../../types';
 
-export const createSource = async (
-	createValues: WritableSource,
-): Promise<Source> => {
-	const { label } = createValues;
-	const dataProviderShortCode =
-		'dataProviderShortCode' in createValues
-			? createValues.dataProviderShortCode
-			: undefined;
-	const funderShortCode =
-		'funderShortCode' in createValues
-			? createValues.funderShortCode
-			: undefined;
-	const changemakerId =
-		'changemakerId' in createValues ? createValues.changemakerId : undefined;
+const createSource = generateCreateOrUpdateItemOperation<
+	Source,
+	WritableSource
+>('sources.insertOne', [
+	'label',
+	'dataProviderShortCode',
+	'funderShortCode',
+	'changemakerId',
+]);
 
-	const result = await db.sql<JsonResultSet<Source>>('sources.insertOne', {
-		label,
-		dataProviderShortCode,
-		funderShortCode,
-		changemakerId,
-	});
-
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+export { createSource };

--- a/src/database/operations/userChangemakerPermissions/createOrUpdateUserChangemakerPermission.ts
+++ b/src/database/operations/userChangemakerPermissions/createOrUpdateUserChangemakerPermission.ts
@@ -1,32 +1,18 @@
-import { db } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
 	InternallyWritableUserChangemakerPermission,
-	JsonResultSet,
 	UserChangemakerPermission,
 } from '../../../types';
 
-const createOrUpdateUserChangemakerPermission = async (
-	createValues: InternallyWritableUserChangemakerPermission,
-): Promise<UserChangemakerPermission> => {
-	const { userKeycloakUserId, changemakerId, permission, createdBy } =
-		createValues;
-	const result = await db.sql<JsonResultSet<UserChangemakerPermission>>(
-		'userChangemakerPermissions.insertOrUpdateOne',
-		{
-			userKeycloakUserId,
-			permission,
-			changemakerId,
-			createdBy,
-		},
-	);
-
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+const createOrUpdateUserChangemakerPermission =
+	generateCreateOrUpdateItemOperation<
+		UserChangemakerPermission,
+		InternallyWritableUserChangemakerPermission
+	>('userChangemakerPermissions.insertOrUpdateOne', [
+		'userKeycloakUserId',
+		'permission',
+		'changemakerId',
+		'createdBy',
+	]);
 
 export { createOrUpdateUserChangemakerPermission };

--- a/src/database/operations/userDataProviderPermissions/createOrUpdateUserDataProviderPermission.ts
+++ b/src/database/operations/userDataProviderPermissions/createOrUpdateUserDataProviderPermission.ts
@@ -1,32 +1,18 @@
-import { db } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
 	UserDataProviderPermission,
 	InternallyWritableUserDataProviderPermission,
-	JsonResultSet,
 } from '../../../types';
 
-const createOrUpdateUserDataProviderPermission = async (
-	createValues: InternallyWritableUserDataProviderPermission,
-): Promise<UserDataProviderPermission> => {
-	const { userKeycloakUserId, dataProviderShortCode, permission, createdBy } =
-		createValues;
-	const result = await db.sql<JsonResultSet<UserDataProviderPermission>>(
-		'userDataProviderPermissions.insertOrUpdateOne',
-		{
-			userKeycloakUserId,
-			permission,
-			dataProviderShortCode,
-			createdBy,
-		},
-	);
-
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+const createOrUpdateUserDataProviderPermission =
+	generateCreateOrUpdateItemOperation<
+		UserDataProviderPermission,
+		InternallyWritableUserDataProviderPermission
+	>('userDataProviderPermissions.insertOrUpdateOne', [
+		'userKeycloakUserId',
+		'permission',
+		'dataProviderShortCode',
+		'createdBy',
+	]);
 
 export { createOrUpdateUserDataProviderPermission };

--- a/src/database/operations/userFunderPermissions/createOrUpdateUserFunderPermission.ts
+++ b/src/database/operations/userFunderPermissions/createOrUpdateUserFunderPermission.ts
@@ -1,32 +1,17 @@
-import { db } from '../../db';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
 	UserFunderPermission,
 	InternallyWritableUserFunderPermission,
-	JsonResultSet,
 } from '../../../types';
 
-const createOrUpdateUserFunderPermission = async (
-	createValues: InternallyWritableUserFunderPermission,
-): Promise<UserFunderPermission> => {
-	const { userKeycloakUserId, funderShortCode, permission, createdBy } =
-		createValues;
-	const result = await db.sql<JsonResultSet<UserFunderPermission>>(
-		'userFunderPermissions.insertOrUpdateOne',
-		{
-			userKeycloakUserId,
-			permission,
-			funderShortCode,
-			createdBy,
-		},
-	);
-
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+const createOrUpdateUserFunderPermission = generateCreateOrUpdateItemOperation<
+	UserFunderPermission,
+	InternallyWritableUserFunderPermission
+>('userFunderPermissions.insertOrUpdateOne', [
+	'userKeycloakUserId',
+	'permission',
+	'funderShortCode',
+	'createdBy',
+]);
 
 export { createOrUpdateUserFunderPermission };

--- a/src/database/operations/users/createUser.ts
+++ b/src/database/operations/users/createUser.ts
@@ -1,16 +1,9 @@
-import { db } from '../../db';
-import type { User, JsonResultSet, WritableUser } from '../../../types';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { User, WritableUser } from '../../../types';
 
-export const createUser = async (createValues: WritableUser): Promise<User> => {
-	const { keycloakUserId } = createValues;
-	const result = await db.sql<JsonResultSet<User>>('users.insertOne', {
-		keycloakUserId,
-	});
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new Error(
-			'The entity creation did not appear to fail, but no data was returned by the operation.',
-		);
-	}
-	return object;
-};
+const createUser = generateCreateOrUpdateItemOperation<User, WritableUser>(
+	'users.insertOne',
+	['keycloakUserId'],
+);
+
+export { createUser };

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -73,10 +73,10 @@ const postApplicationForms = (
 	}
 	const { fields } = req.body;
 
-	createApplicationForm(req.body)
+	createApplicationForm(null, req.body)
 		.then((applicationForm) => {
 			const queries = fields.map(async (field) =>
-				createApplicationFormField({
+				createApplicationFormField(null, {
 					...field,
 					applicationFormId: applicationForm.id,
 				}),

--- a/src/handlers/baseFieldsCopyTasksHandlers.ts
+++ b/src/handlers/baseFieldsCopyTasksHandlers.ts
@@ -41,7 +41,7 @@ const postBaseFieldsCopyTask = (
 	const { pdcApiUrl } = req.body;
 	const createdBy = req.user.keycloakUserId;
 	(async () => {
-		const baseFieldsCopyTask = await createBaseFieldsCopyTask({
+		const baseFieldsCopyTask = await createBaseFieldsCopyTask(null, {
 			pdcApiUrl,
 			status: TaskStatus.PENDING,
 			createdBy,

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -55,7 +55,7 @@ const postBaseField = (
 		return;
 	}
 
-	createBaseField(req.body)
+	createBaseField(null, req.body)
 		.then((baseField) => {
 			res.status(201).contentType('application/json').send(baseField);
 		})
@@ -183,7 +183,7 @@ const putBaseFieldLocalization = (
 	const { label, description } = req.body;
 	assertBaseFieldExists(baseFieldId)
 		.then(() => {
-			createOrUpdateBaseFieldLocalization({
+			createOrUpdateBaseFieldLocalization(null, {
 				label,
 				description,
 				baseFieldId,

--- a/src/handlers/bulkUploadTasksHandlers.ts
+++ b/src/handlers/bulkUploadTasksHandlers.ts
@@ -56,7 +56,7 @@ const postBulkUploadTask = (
 
 	assertSourceExists(sourceId)
 		.then(async () => {
-			const bulkUploadTask = await createBulkUploadTask({
+			const bulkUploadTask = await createBulkUploadTask(null, {
 				sourceId,
 				fileName,
 				sourceKey,

--- a/src/handlers/changemakerProposalsHandlers.ts
+++ b/src/handlers/changemakerProposalsHandlers.ts
@@ -61,7 +61,7 @@ const postChangemakerProposal = (
 		return;
 	}
 
-	createChangemakerProposal(req.body)
+	createChangemakerProposal(null, req.body)
 		.then((changemakerProposal) => {
 			res.status(201).contentType('application/json').send(changemakerProposal);
 		})

--- a/src/handlers/changemakersHandlers.ts
+++ b/src/handlers/changemakersHandlers.ts
@@ -32,7 +32,7 @@ const postChangemaker = (
 		);
 		return;
 	}
-	createChangemaker(req.body)
+	createChangemaker(null, req.body)
 		.then((changemaker) => {
 			res.status(201).contentType('application/json').send(changemaker);
 		})

--- a/src/handlers/dataProvidersHandlers.ts
+++ b/src/handlers/dataProvidersHandlers.ts
@@ -94,7 +94,7 @@ const putDataProvider = (
 	}
 	const { name, keycloakOrganizationId } = req.body;
 	(async () => {
-		const dataProvider = await createOrUpdateDataProvider({
+		const dataProvider = await createOrUpdateDataProvider(null, {
 			shortCode,
 			name,
 			keycloakOrganizationId,

--- a/src/handlers/fundersHandlers.ts
+++ b/src/handlers/fundersHandlers.ts
@@ -83,7 +83,7 @@ const putFunder = (req: Request, res: Response, next: NextFunction): void => {
 	const { name, keycloakOrganizationId } = req.body;
 
 	(async () => {
-		const funder = await createOrUpdateFunder({
+		const funder = await createOrUpdateFunder(null, {
 			shortCode,
 			name,
 			keycloakOrganizationId,

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -70,7 +70,7 @@ const postOpportunity = (
 		);
 		return;
 	}
-	createOpportunity(req.body)
+	createOpportunity(null, req.body)
 		.then((opportunity) => {
 			res.status(201).contentType('application/json').send(opportunity);
 		})

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -150,6 +150,7 @@ const postProposalVersion = (
 		.then(() => {
 			db.transaction(async (transactionDb) => {
 				const proposalVersion = await createProposalVersion(
+					null,
 					{ proposalId, applicationFormId, sourceId, createdBy },
 					transactionDb,
 				);
@@ -165,6 +166,7 @@ const postProposalVersion = (
 							applicationFormField.baseField.dataType,
 						);
 						const proposalFieldValue = await createProposalFieldValue(
+							null,
 							{
 								...fieldValue,
 								proposalVersionId: proposalVersion.id,

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -104,7 +104,7 @@ const postProposal = (
 	const { externalId, opportunityId } = req.body;
 	const createdBy = req.user.keycloakUserId;
 
-	createProposal({
+	createProposal(null, {
 		opportunityId,
 		externalId,
 		createdBy,

--- a/src/handlers/sourcesHandlers.ts
+++ b/src/handlers/sourcesHandlers.ts
@@ -36,7 +36,7 @@ const postSource = (req: Request, res: Response, next: NextFunction): void => {
 	// Normally we try to avoid passing the body directly vs extracting the values and passing them.
 	// Because because writableSource is a union type it is hard to extract the values directly without
 	// losing type context that the union provided.
-	createSource(req.body)
+	createSource(null, req.body)
 		.then((item) => {
 			res.status(201).contentType('application/json').send(item);
 		})

--- a/src/handlers/userChangemakerPermissionsHandlers.ts
+++ b/src/handlers/userChangemakerPermissionsHandlers.ts
@@ -125,7 +125,7 @@ const putUserChangemakerPermission = (
 
 	(async () => {
 		const userChangemakerPermission =
-			await createOrUpdateUserChangemakerPermission({
+			await createOrUpdateUserChangemakerPermission(null, {
 				userKeycloakUserId,
 				changemakerId,
 				permission,

--- a/src/handlers/userDataProviderPermissionsHandlers.ts
+++ b/src/handlers/userDataProviderPermissionsHandlers.ts
@@ -126,6 +126,7 @@ const putUserDataProviderPermission = (
 
 	(async () => {
 		const userFunderPermission = await createOrUpdateUserDataProviderPermission(
+			null,
 			{
 				userKeycloakUserId,
 				dataProviderShortCode,

--- a/src/handlers/userFunderPermissionsHandlers.ts
+++ b/src/handlers/userFunderPermissionsHandlers.ts
@@ -125,12 +125,15 @@ const putUserFunderPermission = (
 	}
 
 	(async () => {
-		const userFunderPermission = await createOrUpdateUserFunderPermission({
-			userKeycloakUserId,
-			funderShortCode,
-			permission,
-			createdBy,
-		});
+		const userFunderPermission = await createOrUpdateUserFunderPermission(
+			null,
+			{
+				userKeycloakUserId,
+				funderShortCode,
+				permission,
+				createdBy,
+			},
+		);
 		res.status(201).contentType('application/json').send(userFunderPermission);
 	})().catch((error: unknown) => {
 		if (isTinyPgErrorWithQueryContext(error)) {

--- a/src/middleware/addUserContext.ts
+++ b/src/middleware/addUserContext.ts
@@ -14,7 +14,7 @@ const selectOrCreateUser = async (keycloakUserId: KeycloakId) => {
 	try {
 		return await loadUserByKeycloakUserId(null, keycloakUserId);
 	} catch {
-		const user = await createUser({ keycloakUserId });
+		const user = await createUser(null, { keycloakUserId });
 		return user;
 	}
 };

--- a/src/tasks/__tests__/copyBaseFields.int.test.ts
+++ b/src/tasks/__tests__/copyBaseFields.int.test.ts
@@ -31,7 +31,7 @@ const createTestBaseFieldsCopyTask = async (
 		statusUpdatedAt: new Date(Date.now()).toISOString(),
 		createdBy: systemUser.keycloakUserId,
 	};
-	return createBaseFieldsCopyTask({
+	return createBaseFieldsCopyTask(null, {
 		...defaultValues,
 		...overrideValues,
 	});
@@ -324,7 +324,7 @@ describe('copyBaseFields', () => {
 	});
 
 	it('should insert all remote basefields, without updating any local basefields, assuming there is no overlap on shortcode', async () => {
-		const localBaseField = await createOrUpdateBaseField({
+		const localBaseField = await createOrUpdateBaseField(null, {
 			label: 'Local BaseField',
 			description: 'This basefield should not be updated on basefield copy',
 			shortCode: 'local',
@@ -367,7 +367,7 @@ describe('copyBaseFields', () => {
 	});
 
 	it('should update local basefields when they match on remote basefield shortcodes, even if the basefields have identical data', async () => {
-		const localBaseField = await createOrUpdateBaseField({
+		const localBaseField = await createOrUpdateBaseField(null, {
 			label: 'Local Data',
 			description: 'This is local data',
 			shortCode: 'ld',
@@ -428,7 +428,7 @@ describe('copyBaseFields', () => {
 	});
 
 	it('should update local basefields when they match on remote basefield shortcodes, and insert all other remote basefields', async () => {
-		const localBaseField = await createOrUpdateBaseField({
+		const localBaseField = await createOrUpdateBaseField(null, {
 			label: 'Local Data',
 			description: 'This is local data',
 			shortCode: 'ld',
@@ -517,7 +517,7 @@ describe('copyBaseFields', () => {
 	});
 
 	it('should preserve localizations for a local basefield with localizations, when there is a remote basefield with no localizations that matches on shortcode', async () => {
-		const localBaseField = await createOrUpdateBaseField({
+		const localBaseField = await createOrUpdateBaseField(null, {
 			label: 'Update me',
 			description: 'This is a field to be updated',
 			shortCode: mockFirstNameBaseField.shortCode,
@@ -525,7 +525,7 @@ describe('copyBaseFields', () => {
 			scope: BaseFieldScope.PROPOSAL,
 		});
 
-		await createOrUpdateBaseFieldLocalization({
+		await createOrUpdateBaseFieldLocalization(null, {
 			baseFieldId: localBaseField.id,
 			label: 'Le Prenom',
 			description: 'Le Prenom de la Applicant',
@@ -576,7 +576,7 @@ describe('copyBaseFields', () => {
 	});
 
 	it('should add localizations to a local basefield from a remote basefield with matching shortcode', async () => {
-		const localBaseField = await createOrUpdateBaseField({
+		const localBaseField = await createOrUpdateBaseField(null, {
 			label: 'Update me',
 			description: 'This is a field to be updated',
 			shortCode: mockFirstNameBaseField.shortCode,
@@ -584,7 +584,7 @@ describe('copyBaseFields', () => {
 			scope: BaseFieldScope.PROPOSAL,
 		});
 
-		await createOrUpdateBaseFieldLocalization({
+		await createOrUpdateBaseFieldLocalization(null, {
 			baseFieldId: localBaseField.id,
 			label: 'Nombre de Pila',
 			description: 'Nombre de Pila',
@@ -677,7 +677,7 @@ describe('copyBaseFields', () => {
 	});
 
 	it('should update any existing local basefields that match on shortcode, and have status set as completed', async () => {
-		const baseField = await createOrUpdateBaseField({
+		const baseField = await createOrUpdateBaseField(null, {
 			label: 'Old First Name',
 			description: 'This should be replaced',
 			shortCode: mockFirstNameBaseField.shortCode,

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -60,28 +60,28 @@ const createTestBulkUploadTask = async (
 		status: TaskStatus.PENDING,
 		createdBy: systemUser.keycloakUserId,
 	};
-	return createBulkUploadTask({
+	return createBulkUploadTask(null, {
 		...defaultValues,
 		...overrideValues,
 	});
 };
 
 const createTestBaseFields = async (): Promise<void> => {
-	await createBaseField({
+	await createBaseField(null, {
 		label: 'Proposal Submitter Email',
 		description: 'The email address of the person who submitted the proposal.',
 		shortCode: 'proposal_submitter_email',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.PROPOSAL,
 	});
-	await createBaseField({
+	await createBaseField(null, {
 		label: 'Organization Name',
 		description: 'The name of the applying organization.',
 		shortCode: 'organization_name',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.ORGANIZATION,
 	});
-	await createBaseField({
+	await createBaseField(null, {
 		label: 'Organization EIN',
 		description: 'The name of the applying organization.',
 		shortCode: 'organization_tax_id',

--- a/src/tasks/copyBaseFields.ts
+++ b/src/tasks/copyBaseFields.ts
@@ -55,7 +55,7 @@ export const fetchBaseFieldsFromRemote = async (
 
 const copyBaseField = async (targetBaseField: BaseField) => {
 	const { scope, dataType, shortCode, label, description } = targetBaseField;
-	const copiedBaseField = await createOrUpdateBaseField({
+	const copiedBaseField = await createOrUpdateBaseField(null, {
 		scope,
 		dataType,
 		shortCode,
@@ -65,7 +65,7 @@ const copyBaseField = async (targetBaseField: BaseField) => {
 	await Promise.all(
 		Object.entries(targetBaseField.localizations).map(
 			async ([language, baseFieldLocalization]) => {
-				await createOrUpdateBaseFieldLocalization({
+				await createOrUpdateBaseFieldLocalization(null, {
 					baseFieldId: copiedBaseField.id,
 					language,
 					label: baseFieldLocalization.label,

--- a/src/tasks/processBulkUploadTask.ts
+++ b/src/tasks/processBulkUploadTask.ts
@@ -156,7 +156,7 @@ const assertBulkUploadTaskCsvIsValid = async (
 const createOpportunityForBulkUploadTask = async (
 	bulkUploadTask: BulkUploadTask,
 ): Promise<Opportunity> =>
-	createOpportunity({
+	createOpportunity(null, {
 		title: `Bulk Upload (${bulkUploadTask.createdAt})`,
 	});
 
@@ -176,7 +176,7 @@ const createApplicationFormFieldsForBulkUploadTask = async (
 					`No base field could be found with shortCode "${shortCode}"`,
 				);
 			}
-			const applicationFormField = await createApplicationFormField({
+			const applicationFormField = await createApplicationFormField(null, {
 				applicationFormId,
 				baseFieldId: baseField.id,
 				position: index,
@@ -204,7 +204,7 @@ const createOrLoadChangemaker = async (
 		return await loadChangemakerByTaxId(writeValues.taxId);
 	} catch {
 		if (writeValues.name !== undefined) {
-			return createChangemaker({
+			return createChangemaker(null, {
 				...writeValues,
 				name: writeValues.name, // This looks silly, but TypeScript isn't guarding `writeValues`, just `writeValues.name`.
 			});
@@ -273,7 +273,7 @@ export const processBulkUploadTask = async (
 		await assertBulkUploadTaskCsvIsValid(bulkUploadFile.path);
 		const opportunity =
 			await createOpportunityForBulkUploadTask(bulkUploadTask);
-		const applicationForm = await createApplicationForm({
+		const applicationForm = await createApplicationForm(null, {
 			opportunityId: opportunity.id,
 		});
 
@@ -290,12 +290,12 @@ export const processBulkUploadTask = async (
 		let recordNumber = 0;
 		await parser.forEach(async (record: string[]) => {
 			recordNumber += 1;
-			const proposal = await createProposal({
+			const proposal = await createProposal(null, {
 				opportunityId: opportunity.id,
 				externalId: `${recordNumber}`,
 				createdBy: bulkUploadTask.createdBy,
 			});
-			const proposalVersion = await createProposalVersion({
+			const proposalVersion = await createProposalVersion(null, {
 				proposalId: proposal.id,
 				applicationFormId: applicationForm.id,
 				sourceId: bulkUploadTask.sourceId,
@@ -312,7 +312,7 @@ export const processBulkUploadTask = async (
 				});
 
 				if (changemaker !== undefined) {
-					await createChangemakerProposal({
+					await createChangemakerProposal(null, {
 						changemakerId: changemaker.id,
 						proposalId: proposal.id,
 					});
@@ -331,7 +331,7 @@ export const processBulkUploadTask = async (
 						fieldValue,
 						applicationFormField.baseField.dataType,
 					);
-					return createProposalFieldValue({
+					return createProposalFieldValue(null, {
 						proposalVersionId: proposalVersion.id,
 						applicationFormFieldId: applicationFormField.id,
 						value: fieldValue,

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -26,7 +26,7 @@ export const getTestUserKeycloakUserId = () =>
 	stringToKeycloakId('11111111-1111-1111-1111-111111111111'); // This value is not a reference, it's just a static GUID
 
 export const createTestUser = async () =>
-	createUser({
+	createUser(null, {
 		keycloakUserId: getTestUserKeycloakUserId(),
 	});
 


### PR DESCRIPTION
This PR continues the process of updating our db operation utilities to use a generator, and then improving that generator to accept an authentication context.

It also has the generator accept an optional db which means all create / update operations will now support transactions instead of just a few of them.

Related to #1147