### PR TITLE
Trigger a deployment when workflows succeed

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,11 @@
+# GitHub Workflow Notes for the Philanthropy Data Commons service
+
+## Deploy
+
+The deploy task requires an API key, secret `DIGITAL_OCEAN_TOKEN`, and an
+environment with a variable `DIGITAL_OCEAN_APP_ID`. The App ID is a UUID.
+
+The reason the task pipes to `jq` is twofold:
+
+1. It filters out secrets by selecting a single expected deployment id.
+2. It helps return an error when there is no expected deployment id (`-e`).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_run:
+    workflows: [lint, test, test-current-node, sdk, build]
+    types:
+      - completed
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.wait.outputs.result }}
+    steps:
+      - id: wait
+        uses: uplift-ltd/wait-for-workflow-run-action@v2
+
+  deploy-to-test-env:
+    runs-on: ubuntu-latest
+    environment:
+      name: test
+    needs: checks
+    if: ${{ needs.checks.outputs.result == 'success' }}
+    steps:
+      - run: |
+          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${secrets.DIGITAL_OCEAN_TOKEN}" "https://api.digitalocean.com/v2/apps/${secrets.DIGITAL_OCEAN_APP_ID}/deployments" -d '{ "force_build": true }' | jq -e .deployment.id


### PR DESCRIPTION
The new `deploy` workflow should trigger a deployment of the newly built (in the `build` workflow) image to Digital Ocean App Platform when several previous tasks such as `test` and `build` succeeded.

The `build` task is assumed to have updated the `latest` image tag and therefore the deployment command called by `curl` here should deploy the image just created in most cases. There may still be a chance of interleaving workflow executions causing the unintended image to be deployed. Until a more robust solution is found, this may have to do.

The situation as of writing is that no new code is delivered to production so this commit is a step toward getting an automated deployment working in a test environment and we expect to improve it to deploy to production.

Issue #1410