### PR TITLE
Improve the deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,24 +1,23 @@
+name: Deploy
+
 on:
   workflow_run:
-    workflows: [lint, test, test-current-node, sdk, build]
+    workflows:
+      - 'Lint'
+      - 'Test'
+      - 'Test on current Node.js'
+      - 'Build (sdk)'
+      - 'Build and push docker image'
     types:
       - completed
 
 jobs:
-  checks:
-    runs-on: ubuntu-latest
-    outputs:
-      result: ${{ steps.wait.outputs.result }}
-    steps:
-      - id: wait
-        uses: uplift-ltd/wait-for-workflow-run-action@v2
-
   deploy-to-test-env:
     runs-on: ubuntu-latest
     environment:
       name: test
-    needs: checks
-    if: ${{ needs.checks.outputs.result == 'success' }}
+    name: deploy-to-test
     steps:
+      - uses: ahmadnassri/action-workflow-run-wait@v1.4.4
       - run: |
           curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${secrets.DIGITAL_OCEAN_TOKEN}" "https://api.digitalocean.com/v2/apps/${secrets.DIGITAL_OCEAN_APP_ID}/deployments" -d '{ "force_build": true }' | jq -e .deployment.id


### PR DESCRIPTION
The previous script would attempt to run several times or not at all. This commit introduces a different barrier action that might work. It also appears that the `workflow_run` might expect names of workflows rather than filenames of workflows, this uses names.

Issue #1410