### PR TITLE
Lengthen deploy barrier timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     workflows:
       - 'Lint'
       - 'Test'
-      - 'Test on current Node.js'
       - 'Build (sdk)'
       - 'Build and push docker image'
     types:
@@ -19,5 +18,7 @@ jobs:
     name: deploy-to-test
     steps:
       - uses: ahmadnassri/action-workflow-run-wait@v1.4.4
+        with:
+          timeout: 1440000
       - run: |
           curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${secrets.DIGITAL_OCEAN_TOKEN}" "https://api.digitalocean.com/v2/apps/${secrets.DIGITAL_OCEAN_APP_ID}/deployments" -d '{ "force_build": true }' | jq -e .deployment.id

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           timeout: 1440000
       - run: |
-          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${secrets.DIGITAL_OCEAN_TOKEN}" "https://api.digitalocean.com/v2/apps/${secrets.DIGITAL_OCEAN_APP_ID}/deployments" -d '{ "force_build": true }' | jq -e .deployment.id
+          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.DIGITAL_OCEAN_TOKEN }}" "https://api.digitalocean.com/v2/apps/${{ secrets.DIGITAL_OCEAN_APP_ID }}/deployments" -d '{ "force_build": true }' | jq -e .deployment.id


### PR DESCRIPTION
Given that the tests usually take around six minutes, set a timeout of
several (four) times that, 24 minutes. This should help the barrier
action work (more) properly.

Correct the deploy script's variable substitution

The correct form is like `${{ secrets.VARIABLE }}`.