### PR TITLE
Improve deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: kachick/wait-other-jobs@v3.6.0
         timeout-minutes: 24
         with:
-          waitlist: |
+          wait-list: |
             [
               {
                 "workflowFile": "lint.yml"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,12 +8,14 @@ on:
 jobs:
   deploy-to-test-env:
     runs-on: ubuntu-latest
-    environment:
-      name: test
+    environment: Test
     name: deploy-to-test
     steps:
       - uses: kachick/wait-other-jobs@v3.6.0
         timeout-minutes: 24
+        env:
+          TOKEN: ${{ secrets.DIGITAL_OCEAN_TOKEN }}
+          APP_ID: ${{ secrets.DIGITAL_OCEAN_APP_ID }}
         with:
           wait-list: |
             [
@@ -31,4 +33,4 @@ jobs:
               }
             ]
       - run: |
-          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.DIGITAL_OCEAN_TOKEN }}" "https://api.digitalocean.com/v2/apps/${{ secrets.DIGITAL_OCEAN_APP_ID }}/deployments" -d '{ "force_build": true }' | jq -e .deployment.id
+          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" --url "https://api.digitalocean.com/v2/apps/$APP_ID/deployments" -d '{ "force_build": true }' | jq -e .deployment.id


### PR DESCRIPTION
Clean up deploy script
 
Set the environment more simply and correctly, pass secrets through the `env` as documented, explicitly mark the URL in `curl` call.

Correct a parameter to deploy barrier action

Issue #1410 