### PR TITLE
Reference env vars the GH way in deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,4 @@ jobs:
             ]
       - run: |
           set -eo pipefail
-          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" --url "$URL" -d '{ "force_build": true }' | jq -e .deployment.id
+          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ env.TOKEN }}" --url "${{ env.URL }}" -d '{ "force_build": true }' | jq -e .deployment.id


### PR DESCRIPTION
The variables should come through with this change.

Issue #1410