### PR TITLE
Add dependabot ignore for major node-fetch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@typescript-eslint/parser'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'node-fetch'
+        update-types: ['version-update:semver-major']
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
Now that we use the node-fetch package for the basefields sync worker, we'd like to avoid any complications
with major version updates. This PR adds an ignore block for the node-fetch package in dependabot

Closes #1433 