### PR TITLE
Deploy to Production Digital Ocean environment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,7 +5,20 @@
 The deploy task requires an API key, secret `DIGITAL_OCEAN_TOKEN`, and an
 environment with a variable `DIGITAL_OCEAN_APP_ID`. The App ID is a UUID.
 
-The reason the task pipes to `jq` is twofold:
+In order for `@dependabot merge` to access `DIGITAL_OCEAN_TOKEN`, it needs to be
+added to the repository secrets in the dependabot area in addition to the
+actions area (see repository Settings -> Security -> Secrets and Variables).
+The Digital Ocean API token does not vary by environment because both Test and
+Production run on Digital Ocean App Platforms. To generate such a token, visit
+https://cloud.digitalocean.com/account/api/tokens and create a token with access
+to Create, Read, and Update Apps.
+
+The `DIGITAL_OCEAN_APP_ID` varies by environment. It is specified in the
+repository Settings -> Code and automation -> Environments area, one per each.
+The App ID can be found in the URL of the Digital Ocean cloud management
+interface for the Test or Production App.
+
+The reason the deploy task pipes to `jq` is twofold:
 
 1. It filters out secrets by selecting a single expected deployment id.
 2. It helps return an error when there is no expected deployment id (`-e`).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,22 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Wait for lint, test, and other workflows to succeed
+        uses: kachick/wait-other-jobs@v3
+        timeout-minutes: 24
+        with:
+          wait-list: |
+            [
+              {
+                "workflowFile": "lint.yml"
+              },
+              {
+                "workflowFile": "test.yml"
+              },
+              {
+                "workflowFile": "sdk.yml"
+              },
+            ]
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   deploy-to-test-env:
     runs-on: ubuntu-latest
     environment: Test
-    name: deploy-to-test
+    name: Deploy to Test environment
     env:
       TOKEN: ${{ secrets.DIGITAL_OCEAN_TOKEN }}
       URL: ${{ vars.DEPLOYMENT_URL }}
@@ -34,6 +34,19 @@ jobs:
               }
             ]
       - name: Deploy to Digital Ocean Test environment
+        run: |
+          set -eo pipefail
+          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ env.TOKEN }}" --url "${{ env.URL }}" -d '{ "force_build": true }' | jq -e .deployment.id
+  deploy-to-production-env:
+    runs-on: ubuntu-latest
+    environment: Production
+    name: Deploy to Production environment
+    env:
+      TOKEN: ${{ secrets.DIGITAL_OCEAN_TOKEN }}
+      URL: ${{ vars.DEPLOYMENT_URL }}
+    needs: deploy-to-test-env
+    steps:
+      - name: Deploy to Digital Ocean Production environment
         run: |
           set -eo pipefail
           curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ env.TOKEN }}" --url "${{ env.URL }}" -d '{ "force_build": true }' | jq -e .deployment.id

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,8 @@ jobs:
       TOKEN: ${{ secrets.DIGITAL_OCEAN_TOKEN }}
       URL: ${{ vars.DEPLOYMENT_URL }}
     steps:
-      - uses: kachick/wait-other-jobs@v3.6.0
+      - name: Wait for lint, test, build, and other workflows to succeed
+        uses: kachick/wait-other-jobs@v3
         timeout-minutes: 24
         with:
           wait-list: |
@@ -32,6 +33,7 @@ jobs:
                 "workflowFile": "build.yml"
               }
             ]
-      - run: |
+      - name: Deploy to Digital Ocean Test environment
+        run: |
           set -eo pipefail
           curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ env.TOKEN }}" --url "${{ env.URL }}" -d '{ "force_build": true }' | jq -e .deployment.id


### PR DESCRIPTION
To limit the chances of interleaving workflow runs deploying an
unintended version of PDC, condition the build/push step on successful
completion of lint, test, and sdk tasks.

Use names for steps for friendlier presentation in GH UIs.

Use fuzzy versioning for actions to match our current practice.

Improve deployment workflow documentation

Include production deployment in deploy script

Deploy to production when the call to deploy to test succeeds. Without
this commit, the deployment actions only target the test environment.

While this deployment pipeline does not (yet) validate that the test
environment is working after deployment to test, it at least validates
that the command to deploy succeeded via `needs: deploy-to-test-env`.

