### PR TITLE
Add required database context to operations

### DIFF
--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -16,14 +16,14 @@ import { mockJwt as authHeader } from '../test/mockJwt';
 const logger = getLogger(__filename);
 
 const createTestBaseFields = async () => {
-	await createBaseField(null, {
+	await createBaseField(db, null, {
 		label: 'Organization Name',
 		description: 'The organizational name of the applicant',
 		shortCode: 'organizationName',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.ORGANIZATION,
 	});
-	await createBaseField(null, {
+	await createBaseField(db, null, {
 		label: 'Years of work',
 		description: 'The number of years the project will take to complete',
 		shortCode: 'yearsOfWork',
@@ -50,19 +50,19 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns all application forms present in the database', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Tremendous opportunity 👌',
 			});
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Good opportunity',
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 2,
 			});
 			const response = await request(app)
@@ -95,41 +95,41 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns an application form with its fields', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Holiday opportunity 🎄',
 			});
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Another holiday opportunity 🕎',
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 2,
 			});
 			await createTestBaseFields();
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 3,
 				baseFieldId: 2,
 				position: 1,
 				label: 'Anni Worki',
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 3,
 				baseFieldId: 1,
 				position: 2,
 				label: 'Org Nomen',
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 2,
 				baseFieldId: 1,
 				position: 2,
 				label: 'Name of Organization',
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 2,
 				baseFieldId: 2,
 				position: 1,
@@ -213,7 +213,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('creates exactly one application form', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Tremendous opportunity 👌',
 			});
 			const before = await loadTableMetrics('application_forms');
@@ -239,7 +239,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('creates exactly the number of provided fields', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Tremendous opportunity 👌',
 			});
 			await createTestBaseFields();
@@ -282,13 +282,13 @@ describe('/applicationForms', () => {
 		});
 
 		it('increments version when creating a second form for an opportunity', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Tremendous opportunity 👌',
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
 			const result = await request(app)
@@ -371,7 +371,7 @@ describe('/applicationForms', () => {
 		});
 
 		it('returns 500 UnknownError if a generic Error is thrown when inserting the field', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Tremendous opportunity 👌',
 			});
 			await createTestBaseFields();

--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createBaseField,
 	createOrUpdateBaseFieldLocalization,
 	loadBaseFieldLocalizationsBundleByBaseFieldId,
@@ -15,7 +16,7 @@ import {
 } from '../test/mockJwt';
 
 const createTestBaseField = async () =>
-	createBaseField(null, {
+	createBaseField(db, null, {
 		label: 'Summary',
 		description: 'A summary of the proposal',
 		shortCode: 'summary',
@@ -24,14 +25,14 @@ const createTestBaseField = async () =>
 	});
 
 const createTestBaseFieldWithLocalization = async () => {
-	const baseField = await createBaseField(null, {
+	const baseField = await createBaseField(db, null, {
 		label: 'Summary',
 		description: 'A summary of the proposal',
 		shortCode: 'summary',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.PROPOSAL,
 	});
-	await createOrUpdateBaseFieldLocalization(null, {
+	await createOrUpdateBaseFieldLocalization(db, null, {
 		baseFieldId: baseField.id,
 		label: 'Le Resume',
 		description: 'Le Resume de la Applicant',
@@ -50,14 +51,14 @@ describe('/baseFields', () => {
 		});
 
 		it('returns all base fields present in the database', async () => {
-			const baseFieldOne = await createBaseField(null, {
+			const baseFieldOne = await createBaseField(db, null, {
 				label: 'First Name',
 				description: 'The first name of the applicant',
 				shortCode: 'firstName',
 				dataType: BaseFieldDataType.STRING,
 				scope: BaseFieldScope.PROPOSAL,
 			});
-			const baseFieldTwo = await createBaseField(null, {
+			const baseFieldTwo = await createBaseField(db, null, {
 				label: 'Last Name',
 				description: 'The last name of the applicant',
 				shortCode: 'lastName',
@@ -65,14 +66,14 @@ describe('/baseFields', () => {
 				scope: BaseFieldScope.PROPOSAL,
 			});
 
-			await createOrUpdateBaseFieldLocalization(null, {
+			await createOrUpdateBaseFieldLocalization(db, null, {
 				baseFieldId: baseFieldOne.id,
 				language: 'fr',
 				label: 'prenom',
 				description: 'le prenom',
 			});
 
-			await createOrUpdateBaseFieldLocalization(null, {
+			await createOrUpdateBaseFieldLocalization(db, null, {
 				baseFieldId: baseFieldTwo.id,
 				language: 'fr',
 				label: 'postnom',
@@ -288,7 +289,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns 409 conflict when a duplicate short name is submitted', async () => {
-			await createBaseField(null, {
+			await createBaseField(db, null, {
 				label: 'First Name',
 				description: 'The first name of the applicant',
 				shortCode: 'firstName',
@@ -331,7 +332,7 @@ describe('/baseFields', () => {
 			// Not using the helper here because observing a change in values is explicitly
 			// the point of the test, so having full explicit control of the original value
 			// seems important.  Some day when we add better test tooling we can have it all.
-			await createBaseField(null, {
+			await createBaseField(db, null, {
 				label: 'Summary',
 				description: 'A summary of the proposal',
 				shortCode: 'summary',
@@ -502,7 +503,7 @@ describe('/baseFields', () => {
 		});
 
 		it('returns all base field localizations related to the given baseFieldId', async () => {
-			await createBaseField(null, {
+			await createBaseField(db, null, {
 				label: 'First Name',
 				description: 'The first name of the applicant',
 				shortCode: 'firstName',
@@ -510,14 +511,14 @@ describe('/baseFields', () => {
 				scope: BaseFieldScope.PROPOSAL,
 			});
 
-			await createOrUpdateBaseFieldLocalization(null, {
+			await createOrUpdateBaseFieldLocalization(db, null, {
 				baseFieldId: 1,
 				language: 'fr',
 				label: 'prenom',
 				description: 'le prenom',
 			});
 
-			await createOrUpdateBaseFieldLocalization(null, {
+			await createOrUpdateBaseFieldLocalization(db, null, {
 				baseFieldId: 1,
 				language: 'en',
 				label: 'First Name',
@@ -589,6 +590,7 @@ describe('/baseFields', () => {
 			const after = await loadTableMetrics('base_field_localizations');
 			const baseFieldLocalizations =
 				await loadBaseFieldLocalizationsBundleByBaseFieldId(
+					db,
 					null,
 					testBaseField.id,
 					NO_LIMIT,
@@ -606,13 +608,13 @@ describe('/baseFields', () => {
 
 		it('updates only the specified base field if it does exist', async () => {
 			const testBaseField = await createTestBaseField();
-			await createOrUpdateBaseFieldLocalization(null, {
+			await createOrUpdateBaseFieldLocalization(db, null, {
 				baseFieldId: 1,
 				language: 'fr',
 				label: 'Résume',
 				description: 'Le Résume de proposal',
 			});
-			await createOrUpdateBaseFieldLocalization(null, {
+			await createOrUpdateBaseFieldLocalization(db, null, {
 				baseFieldId: 1,
 				language: 'en',
 				label: 'Summary',
@@ -631,6 +633,7 @@ describe('/baseFields', () => {
 			const after = await loadTableMetrics('base_field_localizations');
 			const baseFieldLocalizations =
 				await loadBaseFieldLocalizationsBundleByBaseFieldId(
+					db,
 					null,
 					testBaseField.id,
 					NO_LIMIT,

--- a/src/__tests__/baseFieldsCopyTasks.int.test.ts
+++ b/src/__tests__/baseFieldsCopyTasks.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createBaseFieldsCopyTask,
 	createUser,
 	loadTableMetrics,
@@ -37,17 +38,17 @@ describe('/tasks/baseFieldsCopy', () => {
 
 		it('returns all BaseFieldsCopy Tasks for administrative users', async () => {
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser(null, {
+			const anotherUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
 
-			await createBaseFieldsCopyTask(null, {
+			await createBaseFieldsCopyTask(db, null, {
 				pdcApiUrl: MOCK_API_URL,
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
 
-			await createBaseFieldsCopyTask(null, {
+			await createBaseFieldsCopyTask(db, null, {
 				pdcApiUrl: MOCK_API_URL,
 				status: TaskStatus.COMPLETED,
 				createdBy: anotherUser.keycloakUserId,
@@ -86,7 +87,7 @@ describe('/tasks/baseFieldsCopy', () => {
 			const testUser = await loadTestUser();
 			await Array.from(Array(20)).reduce(async (p) => {
 				await p;
-				await createBaseFieldsCopyTask(null, {
+				await createBaseFieldsCopyTask(db, null, {
 					pdcApiUrl: MOCK_API_URL,
 					status: TaskStatus.COMPLETED,
 					createdBy: testUser.keycloakUserId,

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createBulkUploadTask,
 	createUser,
 	loadSystemSource,
@@ -36,34 +37,34 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns bulk upload tasks associated with the requesting user', async () => {
-			const systemUser = await loadSystemUser(null);
-			const systemSource = await loadSystemSource(null);
+			const systemUser = await loadSystemUser(db, null);
+			const systemSource = await loadSystemSource(db, null);
 			const testUser = await loadTestUser();
-			const thirdUser = await createUser(null, {
+			const thirdUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: TaskStatus.COMPLETED,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'baz.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-baz',
 				status: TaskStatus.COMPLETED,
 				createdBy: systemUser.keycloakUserId,
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'boop.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-boop',
@@ -107,19 +108,19 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns all bulk uploads for administrative users', async () => {
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser(null, {
+			const anotherUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -163,19 +164,19 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns upload tasks for specified createdBy user', async () => {
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser(null, {
+			const anotherUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -210,19 +211,19 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns upload tasks for the admin user when createdBy is set to me as an admin', async () => {
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser(null, {
+			const anotherUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createBulkUploadTask(null, {
+			await createBulkUploadTask(db, null, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -255,11 +256,11 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('supports pagination', async () => {
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			const testUser = await loadTestUser();
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
-				await createBulkUploadTask(null, {
+				await createBulkUploadTask(db, null, {
 					sourceId: systemSource.id,
 					fileName: `bar-${i + 1}.csv`,
 					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
@@ -359,7 +360,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('creates exactly one bulk upload task', async () => {
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			const before = await loadTableMetrics('bulk_upload_tasks');
 			const result = await request(app)
 				.post('/tasks/bulkUploads/')
@@ -390,7 +391,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when no file name is provided', async () => {
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			const result = await request(app)
 				.post('/tasks/bulkUploads')
 				.type('application/json')
@@ -407,7 +408,7 @@ describe('/tasks/bulkUploads', () => {
 		});
 
 		it('returns 400 bad request when an invalid file name is provided', async () => {
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			const result = await request(app)
 				.post('/tasks/bulkUploads')
 				.type('application/json')

--- a/src/__tests__/changemakerProposals.int.test.ts
+++ b/src/__tests__/changemakerProposals.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createOpportunity,
 	createChangemaker,
 	createChangemakerProposal,
@@ -11,12 +12,12 @@ import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 
 const insertTestChangemakers = async () => {
-	await createChangemaker(null, {
+	await createChangemaker(db, null, {
 		taxId: '11-1111111',
 		name: 'Example Inc.',
 		keycloakOrganizationId: null,
 	});
-	await createChangemaker(null, {
+	await createChangemaker(db, null, {
 		taxId: '22-2222222',
 		name: 'Another Inc.',
 		keycloakOrganizationId: '402b1208-be48-11ef-8af9-b767e5e8e4ee',
@@ -30,26 +31,26 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns the ChangemakerProposals for the specified changemaker', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				opportunityId: 1,
 				externalId: '2',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemakerProposal(null, {
+			await createChangemakerProposal(db, null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});
-			await createChangemakerProposal(null, {
+			await createChangemakerProposal(db, null, {
 				changemakerId: 1,
 				proposalId: 2,
 			});
@@ -109,26 +110,26 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns the ProposalChangemakers for the specified proposal', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				opportunityId: 1,
 				externalId: '2',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemakerProposal(null, {
+			await createChangemakerProposal(db, null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});
-			await createChangemakerProposal(null, {
+			await createChangemakerProposal(db, null, {
 				changemakerId: 2,
 				proposalId: 2,
 			});
@@ -180,12 +181,12 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('creates exactly one ChangemakerProposal', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			await insertTestChangemakers();
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
@@ -228,12 +229,12 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 400 bad request when no proposalId is sent', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
@@ -253,12 +254,12 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 400 bad request when no changemakerId is sent', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
@@ -278,7 +279,7 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 422 Conflict when a non-existent proposal is sent', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			await insertTestChangemakers();
@@ -297,11 +298,11 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 422 Conflict when a non-existent changemaker is sent', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
@@ -321,17 +322,17 @@ describe('/changemakerProposals', () => {
 		});
 
 		it('returns 409 Conflict when attempting to create a duplicate ChangemakerProposal', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
 			await insertTestChangemakers();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				opportunityId: 1,
 				externalId: '1',
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemakerProposal(null, {
+			await createChangemakerProposal(db, null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createApplicationForm,
 	createApplicationFormField,
 	createBaseField,
@@ -34,12 +35,12 @@ import {
 } from '../types';
 
 const insertTestChangemakers = async () => {
-	await createChangemaker(null, {
+	await createChangemaker(db, null, {
 		taxId: '11-1111111',
 		name: 'Example Inc.',
 		keycloakOrganizationId: null,
 	});
-	await createChangemaker(null, {
+	await createChangemaker(db, null, {
 		taxId: '22-2222222',
 		name: 'Another Inc.',
 		keycloakOrganizationId: '57ceaca8-be48-11ef-8c91-5732d98a77e1',
@@ -93,7 +94,7 @@ describe('/changemakers', () => {
 		it('returns according to pagination parameters', async () => {
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
-				await createChangemaker(null, {
+				await createChangemaker(db, null, {
 					taxId: '11-1111111',
 					name: `Changemaker ${i + 1}`,
 					keycloakOrganizationId: null,
@@ -157,26 +158,26 @@ describe('/changemakers', () => {
 		});
 
 		it('returns a subset of changemakers present in the database when a proposal filter is provided', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemaker(null, {
+			await createChangemaker(db, null, {
 				taxId: '123-123-123',
 				name: 'Canadian Company',
 				keycloakOrganizationId: null,
 			});
-			await createChangemaker(null, {
+			await createChangemaker(db, null, {
 				taxId: '123-123-123',
 				name: 'Another Canadian Company',
 				keycloakOrganizationId: null,
 			});
-			await createChangemakerProposal(null, {
+			await createChangemakerProposal(db, null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});
@@ -200,30 +201,30 @@ describe('/changemakers', () => {
 		});
 
 		it('does not return duplicate changemakers when a changemaker has multiple proposals', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createChangemaker(null, {
+			await createChangemaker(db, null, {
 				taxId: '123-123-123',
 				name: 'Canadian Company',
 				keycloakOrganizationId: null,
 			});
-			await createChangemakerProposal(null, {
+			await createChangemakerProposal(db, null, {
 				changemakerId: 1,
 				proposalId: 1,
 			});
-			await createChangemakerProposal(null, {
+			await createChangemakerProposal(db, null, {
 				changemakerId: 1,
 				proposalId: 2,
 			});
@@ -308,77 +309,77 @@ describe('/changemakers', () => {
 			let secondDataProviderSourceId: Id;
 
 			beforeEach(async () => {
-				systemSource = await loadSystemSource(null);
-				systemUser = await loadSystemUser(null);
-				baseFieldEmail = await createBaseField(null, {
+				systemSource = await loadSystemSource(db, null);
+				systemUser = await loadSystemUser(db, null);
+				baseFieldEmail = await createBaseField(db, null, {
 					label: 'Fifty one fifty three',
 					shortCode: 'fifty_one_fifty_three',
 					description: 'Five thousand one hundred fifty three.',
 					dataType: BaseFieldDataType.EMAIL,
 					scope: BaseFieldScope.ORGANIZATION,
 				});
-				baseFieldPhone = await createBaseField(null, {
+				baseFieldPhone = await createBaseField(db, null, {
 					label: 'Fifty three ninety nine',
 					shortCode: 'fifty_three_ninety_nine',
 					description: 'Five thousand three hundred ninety nine.',
 					dataType: BaseFieldDataType.PHONE_NUMBER,
 					scope: BaseFieldScope.ORGANIZATION,
 				});
-				baseFieldWebsite = await createBaseField(null, {
+				baseFieldWebsite = await createBaseField(db, null, {
 					label: 'Fifty four seventy one 5471',
 					shortCode: 'fifty_four_seventy_one',
 					description: 'Five thousand four hundred seventy one.',
 					dataType: BaseFieldDataType.URL,
 					scope: BaseFieldScope.ORGANIZATION,
 				});
-				firstChangemaker = await createChangemaker(null, {
+				firstChangemaker = await createChangemaker(db, null, {
 					name: 'Five thousand one hundred forty seven reasons',
 					taxId: '05119',
 					keycloakOrganizationId: null,
 				});
-				secondChangemaker = await createChangemaker(null, {
+				secondChangemaker = await createChangemaker(db, null, {
 					taxId: '5387',
 					name: 'Changemaker 5387',
 					keycloakOrganizationId: '8b15d276-be48-11ef-a061-5b4a50e82d50',
 				});
 				secondChangemakerSourceId = (
-					await createSource(null, {
+					await createSource(db, null, {
 						changemakerId: secondChangemaker.id,
 						label: `${secondChangemaker.name} source`,
 					})
 				).id;
-				firstFunder = await createOrUpdateFunder(null, {
+				firstFunder = await createOrUpdateFunder(db, null, {
 					shortCode: 'funder_5393',
 					name: 'Funder 5393',
 					keycloakOrganizationId: null,
 				});
-				firstFunderOpportunity = await createOpportunity(null, {
+				firstFunderOpportunity = await createOpportunity(db, null, {
 					title: `${firstFunder.name} opportunity`,
 				});
 				firstFunderSourceId = (
-					await createSource(null, {
+					await createSource(db, null, {
 						funderShortCode: firstFunder.shortCode,
 						label: `${firstFunder.name} source`,
 					})
 				).id;
-				firstDataProvider = await createOrUpdateDataProvider(null, {
+				firstDataProvider = await createOrUpdateDataProvider(db, null, {
 					shortCode: 'data_provider_5431',
 					name: 'Data Platform Provider 5431',
 					keycloakOrganizationId: null,
 				});
-				secondDataProvider = await createOrUpdateDataProvider(null, {
+				secondDataProvider = await createOrUpdateDataProvider(db, null, {
 					shortCode: 'data_provider_5477',
 					name: 'Data Platform Provider 5477',
 					keycloakOrganizationId: null,
 				});
 				firstDataProviderSourceId = (
-					await createSource(null, {
+					await createSource(db, null, {
 						dataProviderShortCode: firstDataProvider.shortCode,
 						label: `${firstDataProvider.name} source`,
 					})
 				).id;
 				secondDataProviderSourceId = (
-					await createSource(null, {
+					await createSource(db, null, {
 						dataProviderShortCode: secondDataProvider.shortCode,
 						label: `${secondDataProvider.name} source`,
 					})
@@ -391,26 +392,26 @@ describe('/changemakers', () => {
 				const changemakerId = firstChangemaker.id;
 				const opportunityId = firstFunderOpportunity.id;
 				const proposalId = (
-					await createProposal(null, {
+					await createProposal(db, null, {
 						opportunityId,
 						externalId: 'Proposal',
 						createdBy: systemUser.keycloakUserId,
 					})
 				).id;
-				await createChangemakerProposal(null, {
+				await createChangemakerProposal(db, null, {
 					changemakerId,
 					proposalId,
 				});
 				// I need 3 application form fields here. May as well make them use distinct forms too.
 				const applicationFormIdEarliest = (
-					await createApplicationForm(null, {
+					await createApplicationForm(db, null, {
 						opportunityId,
 					})
 				).id;
 				// Older field that is valid
-				await createProposalFieldValue(null, {
+				await createProposalFieldValue(db, null, {
 					proposalVersionId: (
-						await createProposalVersion(null, {
+						await createProposalVersion(db, null, {
 							proposalId,
 							applicationFormId: applicationFormIdEarliest,
 							sourceId: systemSource.id,
@@ -418,7 +419,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField(null, {
+						await createApplicationFormField(db, null, {
 							label: 'Org email',
 							applicationFormId: applicationFormIdEarliest,
 							baseFieldId,
@@ -430,13 +431,13 @@ describe('/changemakers', () => {
 					isValid: true,
 				});
 				const applicationFormIdLatestValid = (
-					await createApplicationForm(null, {
+					await createApplicationForm(db, null, {
 						opportunityId,
 					})
 				).id;
-				const latestValidValue = await createProposalFieldValue(null, {
+				const latestValidValue = await createProposalFieldValue(db, null, {
 					proposalVersionId: (
-						await createProposalVersion(null, {
+						await createProposalVersion(db, null, {
 							proposalId,
 							applicationFormId: applicationFormIdLatestValid,
 							sourceId: systemSource.id,
@@ -444,7 +445,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField(null, {
+						await createApplicationFormField(db, null, {
 							label: 'Email contact',
 							applicationFormId: applicationFormIdLatestValid,
 							baseFieldId,
@@ -456,14 +457,14 @@ describe('/changemakers', () => {
 					isValid: true,
 				});
 				const applicationFormIdLatest = (
-					await createApplicationForm(null, {
+					await createApplicationForm(db, null, {
 						opportunityId,
 					})
 				).id;
 				// Latest value but invalid
-				await createProposalFieldValue(null, {
+				await createProposalFieldValue(db, null, {
 					proposalVersionId: (
-						await createProposalVersion(null, {
+						await createProposalVersion(db, null, {
 							proposalId,
 							applicationFormId: applicationFormIdLatest,
 							sourceId: systemSource.id,
@@ -471,7 +472,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField(null, {
+						await createApplicationFormField(db, null, {
 							label: 'Contact email address',
 							applicationFormId: applicationFormIdLatest,
 							baseFieldId,
@@ -507,52 +508,56 @@ describe('/changemakers', () => {
 				const baseFieldId = baseFieldPhone.id;
 				const opportunity = firstFunderOpportunity;
 				const proposalId = (
-					await createProposal(null, {
+					await createProposal(db, null, {
 						opportunityId: opportunity.id,
 						externalId: `Proposal to ${opportunity.title}`,
 						createdBy: systemUser.keycloakUserId,
 					})
 				).id;
-				await createChangemakerProposal(null, {
+				await createChangemakerProposal(db, null, {
 					changemakerId: changemaker.id,
 					proposalId,
 				});
 				const applicationFormIdChangemakerEarliest = (
-					await createApplicationForm(null, {
+					await createApplicationForm(db, null, {
 						opportunityId: opportunity.id,
 					})
 				).id;
 				// Set up older field value that is from the changemaker. We'll expect this to be returned.
-				const changemakerEarliestValue = await createProposalFieldValue(null, {
-					proposalVersionId: (
-						await createProposalVersion(null, {
-							proposalId,
-							applicationFormId: applicationFormIdChangemakerEarliest,
-							sourceId: changemakerSourceId,
-							createdBy: systemUser.keycloakUserId,
-						})
-					).id,
-					applicationFormFieldId: (
-						await createApplicationFormField(null, {
-							label: 'Org phone',
-							applicationFormId: applicationFormIdChangemakerEarliest,
-							baseFieldId,
-							position: 5407,
-						})
-					).id,
-					position: 5413,
-					value: '+15555555555',
-					isValid: true,
-				});
+				const changemakerEarliestValue = await createProposalFieldValue(
+					db,
+					null,
+					{
+						proposalVersionId: (
+							await createProposalVersion(db, null, {
+								proposalId,
+								applicationFormId: applicationFormIdChangemakerEarliest,
+								sourceId: changemakerSourceId,
+								createdBy: systemUser.keycloakUserId,
+							})
+						).id,
+						applicationFormFieldId: (
+							await createApplicationFormField(db, null, {
+								label: 'Org phone',
+								applicationFormId: applicationFormIdChangemakerEarliest,
+								baseFieldId,
+								position: 5407,
+							})
+						).id,
+						position: 5413,
+						value: '+15555555555',
+						isValid: true,
+					},
+				);
 				const applicationFormIdFunderLatest = (
-					await createApplicationForm(null, {
+					await createApplicationForm(db, null, {
 						opportunityId: opportunity.id,
 					})
 				).id;
 				// Set up newer field value that is from the funder.
-				await createProposalFieldValue(null, {
+				await createProposalFieldValue(db, null, {
 					proposalVersionId: (
-						await createProposalVersion(null, {
+						await createProposalVersion(db, null, {
 							proposalId,
 							applicationFormId: applicationFormIdFunderLatest,
 							sourceId: funderSourceId,
@@ -560,7 +565,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField(null, {
+						await createApplicationFormField(db, null, {
 							label: 'Phone contact',
 							applicationFormId: applicationFormIdFunderLatest,
 							baseFieldId,
@@ -593,25 +598,25 @@ describe('/changemakers', () => {
 				const baseFieldId = baseFieldPhone.id;
 				const opportunity = firstFunderOpportunity;
 				const proposalId = (
-					await createProposal(null, {
+					await createProposal(db, null, {
 						opportunityId: opportunity.id,
 						externalId: `Another proposal to ${opportunity.title}`,
 						createdBy: systemUser.keycloakUserId,
 					})
 				).id;
-				await createChangemakerProposal(null, {
+				await createChangemakerProposal(db, null, {
 					changemakerId: changemaker.id,
 					proposalId,
 				});
 				const applicationFormIdFunderEarliest = (
-					await createApplicationForm(null, {
+					await createApplicationForm(db, null, {
 						opportunityId: opportunity.id,
 					})
 				).id;
 				// Set up older field value that is from the funder. We'll expect this to be returned.
-				const funderEarliestValue = await createProposalFieldValue(null, {
+				const funderEarliestValue = await createProposalFieldValue(db, null, {
 					proposalVersionId: (
-						await createProposalVersion(null, {
+						await createProposalVersion(db, null, {
 							proposalId,
 							applicationFormId: applicationFormIdFunderEarliest,
 							sourceId: funderSourceId,
@@ -619,7 +624,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField(null, {
+						await createApplicationFormField(db, null, {
 							label: 'Organization phone 5437',
 							applicationFormId: applicationFormIdFunderEarliest,
 							baseFieldId,
@@ -631,14 +636,14 @@ describe('/changemakers', () => {
 					isValid: true,
 				});
 				const applicationFormIdDataProviderLatest = (
-					await createApplicationForm(null, {
+					await createApplicationForm(db, null, {
 						opportunityId: opportunity.id,
 					})
 				).id;
 				// Set up newer field value that is from the data platform provider.
-				await createProposalFieldValue(null, {
+				await createProposalFieldValue(db, null, {
 					proposalVersionId: (
-						await createProposalVersion(null, {
+						await createProposalVersion(db, null, {
 							proposalId,
 							applicationFormId: applicationFormIdDataProviderLatest,
 							sourceId: dataProviderSourceId,
@@ -646,7 +651,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField(null, {
+						await createApplicationFormField(db, null, {
 							label: 'Phone contact',
 							applicationFormId: applicationFormIdDataProviderLatest,
 							baseFieldId,
@@ -675,25 +680,25 @@ describe('/changemakers', () => {
 				// Set up data platform provider sources.
 				// Associate one opportunity, one changemaker, and two responses with a base field.
 				const proposalId = (
-					await createProposal(null, {
+					await createProposal(db, null, {
 						opportunityId: firstFunderOpportunity.id,
 						externalId: `Yet another proposal to ${firstFunderOpportunity.title}`,
 						createdBy: systemUser.keycloakUserId,
 					})
 				).id;
-				await createChangemakerProposal(null, {
+				await createChangemakerProposal(db, null, {
 					changemakerId: changemaker.id,
 					proposalId,
 				});
 				const applicationFormIdDataProviderEarliest = (
-					await createApplicationForm(null, {
+					await createApplicationForm(db, null, {
 						opportunityId: firstFunderOpportunity.id,
 					})
 				).id;
 				// Set up older field value.
-				await createProposalFieldValue(null, {
+				await createProposalFieldValue(db, null, {
 					proposalVersionId: (
-						await createProposalVersion(null, {
+						await createProposalVersion(db, null, {
 							proposalId,
 							applicationFormId: applicationFormIdDataProviderEarliest,
 							sourceId: firstDataProviderSourceId,
@@ -701,7 +706,7 @@ describe('/changemakers', () => {
 						})
 					).id,
 					applicationFormFieldId: (
-						await createApplicationFormField(null, {
+						await createApplicationFormField(db, null, {
 							label: 'Organization website 5479',
 							applicationFormId: applicationFormIdDataProviderEarliest,
 							baseFieldId: baseFieldWebsite.id,
@@ -713,32 +718,36 @@ describe('/changemakers', () => {
 					isValid: true,
 				});
 				const applicationFormIdDataProviderLatest = (
-					await createApplicationForm(null, {
+					await createApplicationForm(db, null, {
 						opportunityId: firstFunderOpportunity.id,
 					})
 				).id;
 				// Set up newer field value.
-				const dataProviderNewestValue = await createProposalFieldValue(null, {
-					proposalVersionId: (
-						await createProposalVersion(null, {
-							proposalId,
-							applicationFormId: applicationFormIdDataProviderLatest,
-							sourceId: secondDataProviderSourceId,
-							createdBy: systemUser.keycloakUserId,
-						})
-					).id,
-					applicationFormFieldId: (
-						await createApplicationFormField(null, {
-							label: 'Phone contact',
-							applicationFormId: applicationFormIdDataProviderLatest,
-							baseFieldId: baseFieldWebsite.id,
-							position: 5501,
-						})
-					).id,
-					position: 5503,
-					value: '+16666665503',
-					isValid: true,
-				});
+				const dataProviderNewestValue = await createProposalFieldValue(
+					db,
+					null,
+					{
+						proposalVersionId: (
+							await createProposalVersion(db, null, {
+								proposalId,
+								applicationFormId: applicationFormIdDataProviderLatest,
+								sourceId: secondDataProviderSourceId,
+								createdBy: systemUser.keycloakUserId,
+							})
+						).id,
+						applicationFormFieldId: (
+							await createApplicationFormField(db, null, {
+								label: 'Phone contact',
+								applicationFormId: applicationFormIdDataProviderLatest,
+								baseFieldId: baseFieldWebsite.id,
+								position: 5501,
+							})
+						).id,
+						position: 5503,
+						value: '+16666665503',
+						isValid: true,
+					},
+				);
 				await request(app)
 					.get(`/changemakers/${changemaker.id}`)
 					.set(authHeader)
@@ -815,7 +824,7 @@ describe('/changemakers', () => {
 		});
 
 		it('returns 409 conflict when an existing EIN + name combination is submitted', async () => {
-			await createChangemaker(null, {
+			await createChangemaker(db, null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,

--- a/src/__tests__/dataProviders.int.test.ts
+++ b/src/__tests__/dataProviders.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createOrUpdateDataProvider,
 	loadDataProvider,
 	loadSystemDataProvider,
@@ -22,12 +23,12 @@ describe('/dataProviders', () => {
 
 		it('returns all data providers present in the database', async () => {
 			const systemDataProvider = await loadSystemDataProvider();
-			await createOrUpdateDataProvider(null, {
+			await createOrUpdateDataProvider(db, null, {
 				shortCode: 'dataRUs',
 				name: 'Data R Us',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateDataProvider(null, {
+			await createOrUpdateDataProvider(db, null, {
 				shortCode: 'nonProfitWarehouse',
 				name: 'Nonprofit Warehouse',
 				keycloakOrganizationId: null,
@@ -64,12 +65,12 @@ describe('/dataProviders', () => {
 		});
 
 		it('returns exactly one data provider selected by short code', async () => {
-			await createOrUpdateDataProvider(null, {
+			await createOrUpdateDataProvider(db, null, {
 				shortCode: 'dataRUs',
 				name: 'Data R Us',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateDataProvider(null, {
+			await createOrUpdateDataProvider(db, null, {
 				shortCode: 'nonProfitWarehouse',
 				name: 'Nonprofit Warehouse',
 				keycloakOrganizationId: null,
@@ -88,7 +89,7 @@ describe('/dataProviders', () => {
 		});
 
 		it('returns 404 when short code is not found', async () => {
-			await createOrUpdateDataProvider(null, {
+			await createOrUpdateDataProvider(db, null, {
 				shortCode: 'dataRUs',
 				name: 'Data R Us',
 				keycloakOrganizationId: null,
@@ -134,16 +135,20 @@ describe('/dataProviders', () => {
 		});
 
 		it('updates an existing data provider and no others', async () => {
-			await createOrUpdateDataProvider(null, {
+			await createOrUpdateDataProvider(db, null, {
 				shortCode: 'firework',
 				name: 'boring text base firework',
 				keycloakOrganizationId: null,
 			});
-			const anotherDataProviderBefore = await createOrUpdateDataProvider(null, {
-				shortCode: 'anotherFirework',
-				name: 'another boring text base firework',
-				keycloakOrganizationId: null,
-			});
+			const anotherDataProviderBefore = await createOrUpdateDataProvider(
+				db,
+				null,
+				{
+					shortCode: 'anotherFirework',
+					name: 'another boring text base firework',
+					keycloakOrganizationId: null,
+				},
+			);
 			const before = await loadTableMetrics('data_providers');
 			const result = await agent
 				.put('/dataProviders/firework')
@@ -155,6 +160,7 @@ describe('/dataProviders', () => {
 				})
 				.expect(201);
 			const anotherDataProviderAfter = await loadDataProvider(
+				db,
 				null,
 				'anotherFirework',
 			);

--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createOrUpdateFunder,
 	loadFunder,
 	loadTableMetrics,
@@ -27,12 +28,12 @@ describe('/funders', () => {
 		});
 
 		it('returns all funders present in the database', async () => {
-			await createOrUpdateFunder(null, {
+			await createOrUpdateFunder(db, null, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateFunder(null, {
+			await createOrUpdateFunder(db, null, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: null,
@@ -65,12 +66,12 @@ describe('/funders', () => {
 		});
 
 		it('returns exactly one funder selected by short code', async () => {
-			await createOrUpdateFunder(null, {
+			await createOrUpdateFunder(db, null, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateFunder(null, {
+			await createOrUpdateFunder(db, null, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: '0de87edc-be40-11ef-8249-0312f1b87538',
@@ -89,7 +90,7 @@ describe('/funders', () => {
 		});
 
 		it('returns 404 when short code is not found', async () => {
-			await createOrUpdateFunder(null, {
+			await createOrUpdateFunder(db, null, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: null,
@@ -134,12 +135,12 @@ describe('/funders', () => {
 		});
 
 		it('updates an existing funder and no others', async () => {
-			await createOrUpdateFunder(null, {
+			await createOrUpdateFunder(db, null, {
 				shortCode: 'firework',
 				name: 'boring text-based firework',
 				keycloakOrganizationId: null,
 			});
-			const anotherFunderBefore = await createOrUpdateFunder(null, {
+			const anotherFunderBefore = await createOrUpdateFunder(db, null, {
 				shortCode: 'anotherFirework',
 				name: 'another boring text based firework',
 				keycloakOrganizationId: null,
@@ -152,7 +153,7 @@ describe('/funders', () => {
 				.send({ name: '🎆' })
 				.expect(201);
 			const after = await loadTableMetrics('data_providers');
-			const anotherFunderAfter = await loadFunder(null, 'anotherFirework');
+			const anotherFunderAfter = await loadFunder(db, null, 'anotherFirework');
 			expect(result.body).toStrictEqual({
 				shortCode: 'firework',
 				name: '🎆',

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import { app } from '../app';
-import { createOpportunity, loadTableMetrics } from '../database';
+import { db, createOpportunity, loadTableMetrics } from '../database';
 import { expectTimestamp } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
 
@@ -18,10 +18,10 @@ describe('/opportunities', () => {
 		});
 
 		it('returns all opportunities present in the database', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Tremendous opportunity 👌',
 			});
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Terrific opportunity 👐',
 			});
 			const response = await request(app)
@@ -52,9 +52,9 @@ describe('/opportunities', () => {
 		});
 
 		it('returns exactly one opportunity selected by id', async () => {
-			await createOpportunity(null, { title: '🔥' });
-			await createOpportunity(null, { title: '✨' });
-			await createOpportunity(null, { title: '🚀' });
+			await createOpportunity(db, null, { title: '🔥' });
+			await createOpportunity(db, null, { title: '✨' });
+			await createOpportunity(db, null, { title: '🚀' });
 
 			const response = await request(app)
 				.get(`/opportunities/2`)
@@ -90,7 +90,7 @@ describe('/opportunities', () => {
 		});
 
 		it('returns 404 when id is not found', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'This definitely should not be returned',
 			});
 			await request(app).get('/opportunities/9001').set(authHeader).expect(404);

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createApplicationForm,
 	createApplicationFormField,
 	createBaseField,
@@ -18,14 +19,14 @@ import { mockJwt as authHeader } from '../test/mockJwt';
 const logger = getLogger(__filename);
 
 const createTestBaseFields = async () => {
-	await createBaseField(null, {
+	await createBaseField(db, null, {
 		label: 'First Name',
 		description: 'The first name of the applicant',
 		shortCode: 'firstName',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.PROPOSAL,
 	});
-	await createBaseField(null, {
+	await createBaseField(db, null, {
 		label: 'Last Name',
 		description: 'The last name of the applicant',
 		shortCode: 'lastName',
@@ -41,18 +42,18 @@ describe('/proposalVersions', () => {
 		});
 
 		it('returns exactly one proposal version selected by id', async () => {
-			const systemSource = await loadSystemSource(null);
-			const opportunity = await createOpportunity(null, { title: '🔥' });
+			const systemSource = await loadSystemSource(db, null);
+			const opportunity = await createOpportunity(db, null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			const proposal = await createProposal(null, {
+			const proposal = await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			const applicationForm = await createApplicationForm(null, {
+			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
 			});
-			const proposalVersion = await createProposalVersion(null, {
+			const proposalVersion = await createProposalVersion(db, null, {
 				proposalId: proposal.id,
 				applicationFormId: applicationForm.id,
 				sourceId: systemSource.id,
@@ -102,15 +103,15 @@ describe('/proposalVersions', () => {
 		});
 
 		it('creates exactly one proposal version', async () => {
-			const systemSource = await loadSystemSource(null);
-			await createOpportunity(null, { title: '🔥' });
+			const systemSource = await loadSystemSource(db, null);
+			await createOpportunity(db, null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
 			const before = await loadTableMetrics('proposal_versions');
@@ -138,25 +139,25 @@ describe('/proposalVersions', () => {
 		});
 
 		it('creates exactly the number of provided field values', async () => {
-			const systemSource = await loadSystemSource(null);
-			await createOpportunity(null, { title: '🔥' });
+			const systemSource = await loadSystemSource(db, null);
+			await createOpportunity(db, null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
 			await createTestBaseFields();
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'First Name',
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 2,
 				position: 2,
@@ -268,15 +269,15 @@ describe('/proposalVersions', () => {
 		});
 
 		it('returns 409 Conflict when the provided proposal does not exist', async () => {
-			const systemSource = await loadSystemSource(null);
-			await createOpportunity(null, { title: '🔥' });
+			const systemSource = await loadSystemSource(db, null);
+			await createOpportunity(db, null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
 			const result = await request(app)
@@ -303,14 +304,14 @@ describe('/proposalVersions', () => {
 		});
 
 		it('returns 409 conflict when the provided source does not exist', async () => {
-			await createOpportunity(null, { title: '🔥' });
+			await createOpportunity(db, null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
 			const result = await request(app)
@@ -336,15 +337,15 @@ describe('/proposalVersions', () => {
 		});
 
 		it('Returns 409 Conflict if the provided application form does not exist', async () => {
-			const systemSource = await loadSystemSource(null);
-			await createOpportunity(null, { title: '🔥' });
+			const systemSource = await loadSystemSource(db, null);
+			await createOpportunity(db, null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
 			const before = await loadTableMetrics('proposal_field_values');
@@ -376,19 +377,19 @@ describe('/proposalVersions', () => {
 		});
 
 		it('Returns 409 Conflict if the provided application form ID is not associated with the proposal opportunity', async () => {
-			const systemSource = await loadSystemSource(null);
-			await createOpportunity(null, { title: '🔥' });
-			await createOpportunity(null, { title: '💧' });
+			const systemSource = await loadSystemSource(db, null);
+			await createOpportunity(db, null, { title: '🔥' });
+			await createOpportunity(db, null, { title: '💧' });
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 2,
 			});
 			const before = await loadTableMetrics('proposal_field_values');
@@ -422,15 +423,15 @@ describe('/proposalVersions', () => {
 		});
 
 		it('Returns 409 Conflict if a provided application form field ID does not exist', async () => {
-			const systemSource = await loadSystemSource(null);
-			await createOpportunity(null, { title: '🔥' });
+			const systemSource = await loadSystemSource(db, null);
+			await createOpportunity(db, null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
 			const before = await loadTableMetrics('proposal_field_values');
@@ -469,28 +470,28 @@ describe('/proposalVersions', () => {
 		});
 
 		it('Returns 409 Conflict if a provided application form field ID is not associated with the supplied application form ID', async () => {
-			const systemSource = await loadSystemSource(null);
-			await createOpportunity(null, { title: '🔥' });
+			const systemSource = await loadSystemSource(db, null);
+			await createOpportunity(db, null, { title: '🔥' });
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
 			await createTestBaseFields();
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'First Name',
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 2,
 				position: 2,

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -29,14 +29,14 @@ import {
 } from '../types';
 
 const createTestBaseFields = async () => {
-	await createBaseField(null, {
+	await createBaseField(db, null, {
 		label: 'Summary',
 		description: 'A summary of the proposal',
 		shortCode: 'summary',
 		dataType: BaseFieldDataType.STRING,
 		scope: BaseFieldScope.PROPOSAL,
 	});
-	await createBaseField(null, {
+	await createBaseField(db, null, {
 		label: 'Title',
 		description: 'The title of the proposal',
 		shortCode: 'title',
@@ -63,46 +63,46 @@ describe('/proposals', () => {
 		});
 
 		it('returns proposals associated with the requesting user', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const testUser = await loadTestUser();
-			const secondUser = await createUser(null, {
+			const secondUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			await createTestBaseFields();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-3',
 				opportunityId: 1,
 				createdBy: secondUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createProposalVersion(null, {
+			await createProposalVersion(db, null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'Short summary',
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
@@ -178,28 +178,28 @@ describe('/proposals', () => {
 		});
 
 		it('returns a subset of proposals present in the database when a changemaker filter is provided', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
 			await createTestBaseFields();
-			const proposal = await createProposal(null, {
+			const proposal = await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			const changemaker = await createChangemaker(null, {
+			const changemaker = await createChangemaker(db, null, {
 				taxId: '123-123-123',
 				name: 'Canadian Company',
 				keycloakOrganizationId: null,
 			});
-			await createChangemakerProposal(null, {
+			await createChangemakerProposal(db, null, {
 				changemakerId: changemaker.id,
 				proposalId: proposal.id,
 			});
@@ -245,52 +245,52 @@ describe('/proposals', () => {
 		});
 
 		it('returns a subset of proposals present in the database when search is provided', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			await createTestBaseFields();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createProposalVersion(null, {
+			await createProposalVersion(db, null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion(null, {
+			await createProposalVersion(db, null, {
 				proposalId: 2,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'Short summary',
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'This is a summary',
 				isValid: true,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 1,
 				position: 1,
@@ -357,21 +357,21 @@ describe('/proposals', () => {
 		});
 
 		it('returns all proposals present in the database regardless of createdBy value when loading as an administrator', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser(null, {
+			const anotherUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
 			await createTestBaseFields();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: anotherUser.keycloakUserId,
@@ -404,21 +404,21 @@ describe('/proposals', () => {
 		});
 
 		it('returns a correct subset of proposals when createdBy is provided as an administrator', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser(null, {
+			const anotherUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
 			await createTestBaseFields();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: anotherUser.keycloakUserId,
@@ -445,21 +445,21 @@ describe('/proposals', () => {
 		});
 
 		it("returns just the administrator's proposals when createdBy is set to `me` as an administrator", async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
-			const anotherUser = await createUser(null, {
+			const anotherUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
 			await createTestBaseFields();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-1',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-2',
 				opportunityId: 1,
 				createdBy: anotherUser.keycloakUserId,
@@ -487,51 +487,51 @@ describe('/proposals', () => {
 			// This should pass even if the default text search config is 'simple'.
 			// See https://github.com/PhilanthropyDataCommons/service/issues/336
 			await db.query("set default_text_search_config = 'simple';");
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: 'Grand opportunity',
 			});
 			const testUser = await loadTestUser();
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			await createTestBaseFields();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-4999',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: 'proposal-5003',
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createProposalVersion(null, {
+			await createProposalVersion(db, null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion(null, {
+			await createProposalVersion(db, null, {
 				proposalId: 2,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 1,
 				label: 'Concise summary',
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'This is a summary',
 				isValid: true,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 1,
 				position: 1,
@@ -598,14 +598,14 @@ describe('/proposals', () => {
 		});
 
 		it('returns according to pagination parameters', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 
 			const testUser = await loadTestUser();
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
-				await createProposal(null, {
+				await createProposal(db, null, {
 					externalId: `proposal-${i + 1}`,
 					opportunityId: 1,
 					createdBy: testUser.keycloakUserId,
@@ -693,13 +693,13 @@ describe('/proposals', () => {
 		});
 
 		it('returns 404 when given id is not owned by the current user', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '⛰️',
 			});
-			const anotherUser = await createUser(null, {
+			const anotherUser = await createUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: `proposal-1`,
 				opportunityId: 1,
 				createdBy: anotherUser.keycloakUserId,
@@ -737,17 +737,17 @@ describe('/proposals', () => {
 		});
 
 		it('returns the one proposal asked for', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '⛰️',
 			});
 
 			const testUser = await loadTestUser();
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: `proposal-1`,
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: `proposal-2`,
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
@@ -768,66 +768,66 @@ describe('/proposals', () => {
 		});
 
 		it('returns one proposal with deep fields', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🌎',
 			});
 			await createTestBaseFields();
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 2,
 				position: 1,
 				label: 'Short summary or title',
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 2,
 				label: 'Long summary or abstract',
 			});
 			const testUser = await loadTestUser();
-			const systemSource = await loadSystemSource(null);
-			await createProposal(null, {
+			const systemSource = await loadSystemSource(db, null);
+			await createProposal(db, null, {
 				externalId: `proposal-2525-01-04T00Z`,
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion(null, {
+			await createProposalVersion(db, null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion(null, {
+			await createProposalVersion(db, null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'Title for version 1 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 2,
 				position: 2,
 				value: 'Abstract for version 1 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'Title for version 2 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 2,
 				position: 2,
@@ -983,65 +983,65 @@ describe('/proposals', () => {
 
 		it('returns the proposal if an administrator requests a proposal they do not own', async () => {
 			const testUser = await loadTestUser();
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			await createTestBaseFields();
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🌎',
 			});
-			await createApplicationForm(null, {
+			await createApplicationForm(db, null, {
 				opportunityId: 1,
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 2,
 				position: 1,
 				label: 'Short summary or title',
 			});
-			await createApplicationFormField(null, {
+			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
 				baseFieldId: 1,
 				position: 2,
 				label: 'Long summary or abstract',
 			});
-			await createProposal(null, {
+			await createProposal(db, null, {
 				externalId: `proposal-2525-01-04T00Z`,
 				opportunityId: 1,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion(null, {
+			await createProposalVersion(db, null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalVersion(null, {
+			await createProposalVersion(db, null, {
 				proposalId: 1,
 				applicationFormId: 1,
 				sourceId: systemSource.id,
 				createdBy: testUser.keycloakUserId,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'Title for version 1 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 1,
 				applicationFormFieldId: 2,
 				position: 2,
 				value: 'Abstract for version 1 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 1,
 				position: 1,
 				value: 'Title for version 2 from 2525-01-04',
 				isValid: true,
 			});
-			await createProposalFieldValue(null, {
+			await createProposalFieldValue(db, null, {
 				proposalVersionId: 2,
 				applicationFormFieldId: 2,
 				position: 2,
@@ -1209,7 +1209,7 @@ describe('/proposals', () => {
 		});
 
 		it('creates exactly one proposal', async () => {
-			await createOpportunity(null, {
+			await createOpportunity(db, null, {
 				title: '🔥',
 			});
 			const before = await loadTableMetrics('proposals');

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createChangemaker,
 	createOrUpdateDataProvider,
 	createOrUpdateFunder,
@@ -23,7 +24,7 @@ describe('/sources', () => {
 		});
 
 		it('returns the system source when no data has been added', async () => {
-			const systemSource = await loadSystemSource(null);
+			const systemSource = await loadSystemSource(db, null);
 			await agent
 				.get('/sources')
 				.set(authHeader)
@@ -34,13 +35,13 @@ describe('/sources', () => {
 		});
 
 		it('returns all sources present in the database', async () => {
-			const systemSource = await loadSystemSource(null);
-			const changemaker = await createChangemaker(null, {
+			const systemSource = await loadSystemSource(db, null);
+			const changemaker = await createChangemaker(db, null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			const source = await createSource(null, {
+			const source = await createSource(db, null, {
 				label: 'Example Inc.',
 				changemakerId: changemaker.id,
 			});
@@ -58,12 +59,12 @@ describe('/sources', () => {
 		});
 
 		it('returns exactly one source selected by id', async () => {
-			const changemaker = await createChangemaker(null, {
+			const changemaker = await createChangemaker(db, null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			const source = await createSource(null, {
+			const source = await createSource(db, null, {
 				label: 'Example Inc.',
 				changemakerId: changemaker.id,
 			});
@@ -95,12 +96,12 @@ describe('/sources', () => {
 		});
 
 		it('returns 404 when id is not found', async () => {
-			const changemaker = await createChangemaker(null, {
+			const changemaker = await createChangemaker(db, null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createSource(null, {
+			await createSource(db, null, {
 				label: 'not to be returned',
 				changemakerId: changemaker.id,
 			});
@@ -118,7 +119,7 @@ describe('/sources', () => {
 		});
 
 		it('creates and returns exactly one changemaker source', async () => {
-			const changemaker = await createChangemaker(null, {
+			const changemaker = await createChangemaker(db, null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -146,7 +147,7 @@ describe('/sources', () => {
 		});
 
 		it('creates and returns exactly one funder source', async () => {
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'foo',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -174,7 +175,7 @@ describe('/sources', () => {
 		});
 
 		it('creates and returns exactly one data provider source', async () => {
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'foo',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -202,7 +203,7 @@ describe('/sources', () => {
 		});
 
 		it('returns 400 bad request when no label sent', async () => {
-			const changemaker = await createChangemaker(null, {
+			const changemaker = await createChangemaker(db, null, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,

--- a/src/__tests__/userDataProviderPermissions.int.test.ts
+++ b/src/__tests__/userDataProviderPermissions.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createOrUpdateDataProvider,
 	createOrUpdateUserDataProviderPermission,
 	loadUserDataProviderPermission,
@@ -19,7 +20,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 	describe('PUT /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -34,7 +35,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -83,7 +84,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('creates and returns the new user data provider permission when user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -107,12 +108,12 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('creates and returns the new user data provider permission when user has permission to manage the data provider', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission(null, {
+			await createOrUpdateUserDataProviderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.MANAGE,
@@ -137,13 +138,13 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('does not update `createdBy`, but returns the user data provider permission when user has permission to manage the data provider', async () => {
 			const user = await loadTestUser();
-			const systemUser = await loadSystemUser(null);
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const systemUser = await loadSystemUser(db, null);
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission(null, {
+			await createOrUpdateUserDataProviderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.MANAGE,
@@ -170,7 +171,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 	describe('DELETE /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -185,7 +186,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -233,7 +234,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('returns 404 if the permission does not exist', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -249,12 +250,12 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('returns 404 if the permission had existed and previously been deleted', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission(null, {
+			await createOrUpdateUserDataProviderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.EDIT,
@@ -276,18 +277,19 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('deletes the user data provider permission when the user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission(null, {
+			await createOrUpdateUserDataProviderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.EDIT,
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserDataProviderPermission(
+				db,
 				null,
 				user.keycloakUserId,
 				dataProvider.shortCode,
@@ -309,6 +311,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 				.expect(204);
 			await expect(
 				loadUserDataProviderPermission(
+					db,
 					null,
 					user.keycloakUserId,
 					dataProvider.shortCode,
@@ -319,24 +322,25 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 
 		it('deletes the user data provider permission when the user has permission to manage the data provider', async () => {
 			const user = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission(null, {
+			await createOrUpdateUserDataProviderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.MANAGE,
 				createdBy: user.keycloakUserId,
 			});
-			await createOrUpdateUserDataProviderPermission(null, {
+			await createOrUpdateUserDataProviderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				dataProviderShortCode: dataProvider.shortCode,
 				permission: Permission.EDIT,
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserDataProviderPermission(
+				db,
 				null,
 				user.keycloakUserId,
 				dataProvider.shortCode,
@@ -358,6 +362,7 @@ describe('/users/dataProviders/:dataProviderShortcode/permissions/:permission', 
 				.expect(204);
 			await expect(
 				loadUserDataProviderPermission(
+					db,
 					null,
 					user.keycloakUserId,
 					dataProvider.shortCode,

--- a/src/__tests__/userFunderPermissions.int.test.ts
+++ b/src/__tests__/userFunderPermissions.int.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
+	db,
 	createOrUpdateFunder,
 	createOrUpdateUserFunderPermission,
 	loadSystemUser,
@@ -19,7 +20,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 	describe('PUT /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -34,7 +35,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -83,7 +84,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('creates and returns the new user funder permission when user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -107,12 +108,12 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('creates and returns the new user funder permission when user has permission to manage the funder', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission(null, {
+			await createOrUpdateUserFunderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.MANAGE,
@@ -137,13 +138,13 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('does not update `createdBy`, but returns the user funder permission when user has permission to manage the funder', async () => {
 			const user = await loadTestUser();
-			const systemUser = await loadSystemUser(null);
-			const funder = await createOrUpdateFunder(null, {
+			const systemUser = await loadSystemUser(db, null);
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission(null, {
+			await createOrUpdateUserFunderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.MANAGE,
@@ -170,7 +171,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 	describe('DELETE /', () => {
 		it('returns 401 if the request lacks authentication', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -185,7 +186,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('returns 401 if the authenticated user lacks permission', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -231,7 +232,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('returns 404 if the permission does not exist', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -247,12 +248,12 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('returns 404 if the permission had existed and previously been deleted', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission(null, {
+			await createOrUpdateUserFunderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.EDIT,
@@ -274,18 +275,19 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('deletes the user funder permission when the user has administrative credentials', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission(null, {
+			await createOrUpdateUserFunderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.EDIT,
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserFunderPermission(
+				db,
 				null,
 				user.keycloakUserId,
 				funder.shortCode,
@@ -307,6 +309,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				.expect(204);
 			await expect(
 				loadUserFunderPermission(
+					db,
 					null,
 					user.keycloakUserId,
 					funder.shortCode,
@@ -317,24 +320,25 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 
 		it('deletes the user funder permission when the user has permission to manage the funder', async () => {
 			const user = await loadTestUser();
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserFunderPermission(null, {
+			await createOrUpdateUserFunderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.MANAGE,
 				createdBy: user.keycloakUserId,
 			});
-			await createOrUpdateUserFunderPermission(null, {
+			await createOrUpdateUserFunderPermission(db, null, {
 				userKeycloakUserId: user.keycloakUserId,
 				funderShortCode: funder.shortCode,
 				permission: Permission.EDIT,
 				createdBy: user.keycloakUserId,
 			});
 			const permission = await loadUserFunderPermission(
+				db,
 				null,
 				user.keycloakUserId,
 				funder.shortCode,
@@ -356,6 +360,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				.expect(204);
 			await expect(
 				loadUserFunderPermission(
+					db,
 					null,
 					user.keycloakUserId,
 					funder.shortCode,

--- a/src/__tests__/users.int.test.ts
+++ b/src/__tests__/users.int.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
 import { app } from '../app';
 import {
+	db,
 	createChangemaker,
 	createOrUpdateDataProvider,
 	createOrUpdateFunder,
@@ -21,7 +22,7 @@ import {
 import { keycloakIdToString, stringToKeycloakId, Permission } from '../types';
 
 const createAdditionalTestUser = async () =>
-	createUser(null, {
+	createUser(db, null, {
 		keycloakUserId: stringToKeycloakId('123e4567-e89b-12d3-a456-426614174000'),
 	});
 
@@ -57,36 +58,36 @@ describe('/users', () => {
 		});
 
 		it('returns the permissions associated with a user', async () => {
-			const systemUser = await loadSystemUser(null);
+			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
-			const dataProvider = await createOrUpdateDataProvider(null, {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
 				name: 'Test Provider',
 				shortCode: 'testProvider',
 				keycloakOrganizationId: null,
 			});
-			const funder = await createOrUpdateFunder(null, {
+			const funder = await createOrUpdateFunder(db, null, {
 				name: 'Test Funder',
 				shortCode: 'testFunder',
 				keycloakOrganizationId: null,
 			});
-			const changemaker = await createChangemaker(null, {
+			const changemaker = await createChangemaker(db, null, {
 				name: 'Test Changemaker',
 				taxId: '12-3456789',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserDataProviderPermission(null, {
+			await createOrUpdateUserDataProviderPermission(db, null, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				permission: Permission.MANAGE,
 				dataProviderShortCode: dataProvider.shortCode,
 				createdBy: systemUser.keycloakUserId,
 			});
-			await createOrUpdateUserFunderPermission(null, {
+			await createOrUpdateUserFunderPermission(db, null, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				permission: Permission.EDIT,
 				funderShortCode: funder.shortCode,
 				createdBy: systemUser.keycloakUserId,
 			});
-			await createOrUpdateUserChangemakerPermission(null, {
+			await createOrUpdateUserChangemakerPermission(db, null, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				permission: Permission.VIEW,
 				changemakerId: changemaker.id,
@@ -121,14 +122,14 @@ describe('/users', () => {
 		});
 
 		it('does not return deleted permissions associated with a user', async () => {
-			const systemUser = await loadSystemUser(null);
+			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
-			const changemaker = await createChangemaker(null, {
+			const changemaker = await createChangemaker(db, null, {
 				name: 'Test Changemaker',
 				taxId: '12-3456789',
 				keycloakOrganizationId: null,
 			});
-			await createOrUpdateUserChangemakerPermission(null, {
+			await createOrUpdateUserChangemakerPermission(db, null, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				permission: Permission.VIEW,
 				changemakerId: changemaker.id,
@@ -162,7 +163,7 @@ describe('/users', () => {
 		});
 
 		it('returns all users when the user is an administrator', async () => {
-			const systemUser = await loadSystemUser(null);
+			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
 			const anotherUser = await createAdditionalTestUser();
 			const { count: userCount } = await loadTableMetrics('users');
@@ -204,7 +205,7 @@ describe('/users', () => {
 			const uuids = Array.from(Array(20)).map(() => uuidv4());
 			await uuids.reduce(async (p, uuid) => {
 				await p;
-				await createUser(null, {
+				await createUser(db, null, {
 					keycloakUserId: uuid,
 				});
 			}, Promise.resolve());

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,11 @@
-import { loadSystemUser } from './database';
+import { db, loadSystemUser } from './database';
 import { InternalValidationError } from './errors';
 import type { User } from './types';
 
 let systemUser: User | null = null;
 
 export const loadConfig = async () => {
-	systemUser = await loadSystemUser(null);
+	systemUser = await loadSystemUser(db, null);
 };
 
 export const getSystemUser = (): User => {

--- a/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
+++ b/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
@@ -1,9 +1,9 @@
-import { db as defaultDb } from '../../db';
 import {
 	getIsAdministratorFromAuthContext,
 	getKeycloakUserIdFromAuthContext,
 } from '../../../types';
 import type { AuthContext, JsonResultSet } from '../../../types';
+import type TinyPg from 'tinypg';
 
 // This may seem silly but it is necessary to get all keys of all
 // possible types in the event the type is a Union (e.g. A | B | C)
@@ -26,9 +26,9 @@ const generateCreateOrUpdateItemOperation =
 		savedAttributes: KeysOfUnion<P>[],
 	) =>
 	async (
+		db: TinyPg,
 		authContext: AuthContext | null,
 		createValues: P,
-		db = defaultDb,
 	): Promise<T> => {
 		const authContextKeycloakUserId =
 			getKeycloakUserIdFromAuthContext(authContext);

--- a/src/database/operations/generators/generateLoadBundleOperation.ts
+++ b/src/database/operations/generators/generateLoadBundleOperation.ts
@@ -1,10 +1,10 @@
-import { db } from '../../db';
 import { loadTableMetrics } from '../generic/loadTableMetrics';
 import {
 	getIsAdministratorFromAuthContext,
 	getKeycloakUserIdFromAuthContext,
 } from '../../../types';
 import type { AuthContext, Bundle, JsonResultSet } from '../../../types';
+import type TinyPg from 'tinypg';
 
 /**
  * Generates a bundle loader function for a specific query and table.
@@ -25,6 +25,7 @@ const generateLoadBundleOperation = <T, P extends [...args: unknown[]]>(
 ) => {
 	const generatedParameterNames = [...parameterNames, 'limit', 'offset'];
 	return async (
+		db: TinyPg,
 		authContext: AuthContext | null,
 		...args: [...P, limit: number | undefined, offset: number | undefined]
 	): Promise<Bundle<T>> => {

--- a/src/database/operations/generators/generateLoadItemOperation.ts
+++ b/src/database/operations/generators/generateLoadItemOperation.ts
@@ -1,10 +1,10 @@
-import { db } from '../../db';
 import { NotFoundError } from '../../../errors';
 import {
 	getIsAdministratorFromAuthContext,
 	getKeycloakUserIdFromAuthContext,
 } from '../../../types';
 import type { AuthContext, JsonResultSet } from '../../../types';
+import type TinyPg from 'tinypg';
 
 /**
  * Generates an item loader function for a specific query and table.
@@ -24,7 +24,11 @@ const generateLoadItemOperation =
 		entityType: string,
 		parameterNames: { [K in keyof P]: string },
 	) =>
-	async (authContext: AuthContext | null, ...args: [...P]): Promise<T> => {
+	async (
+		db: TinyPg,
+		authContext: AuthContext | null,
+		...args: [...P]
+	): Promise<T> => {
 		const authContextKeycloakUserId =
 			getKeycloakUserIdFromAuthContext(authContext);
 		const authContextIsAdministrator =

--- a/src/database/operations/sources/__test__/loadSystemSource.int.test.ts
+++ b/src/database/operations/sources/__test__/loadSystemSource.int.test.ts
@@ -1,9 +1,10 @@
+import { db } from '../../../db';
 import { loadSystemSource } from '..';
 import { expectTimestamp } from '../../../../test/utils';
 
 describe('loadSystemSource', () => {
 	it('loads the expected system source', async () => {
-		const systemSource = await loadSystemSource(null);
+		const systemSource = await loadSystemSource(db, null);
 		expect(systemSource).toMatchObject({
 			createdAt: expectTimestamp,
 			dataProvider: {

--- a/src/database/operations/users/__tests__/loadSystemUser.unit.test.ts
+++ b/src/database/operations/users/__tests__/loadSystemUser.unit.test.ts
@@ -14,6 +14,6 @@ describe('loadSystemUser', () => {
 				}) as Result<object>,
 		);
 
-		await expect(loadSystemUser(null)).rejects.toThrow(NotFoundError);
+		await expect(loadSystemUser(db, null)).rejects.toThrow(NotFoundError);
 	});
 });

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	createApplicationForm,
 	createApplicationFormField,
 	getLimitValues,
@@ -21,7 +22,7 @@ const getApplicationForms = (
 ): void => {
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
-	loadApplicationFormBundle(null, limit, offset)
+	loadApplicationFormBundle(db, null, limit, offset)
 		.then((applicationForms) => {
 			res.status(200).contentType('application/json').send(applicationForms);
 		})
@@ -44,7 +45,7 @@ const getApplicationForm = (
 		next(new InputValidationError('Invalid request.', isId.errors ?? []));
 		return;
 	}
-	loadApplicationForm(null, applicationFormId)
+	loadApplicationForm(db, null, applicationFormId)
 		.then((applicationForm) => {
 			res.status(200).contentType('application/json').send(applicationForm);
 		})
@@ -73,10 +74,10 @@ const postApplicationForms = (
 	}
 	const { fields } = req.body;
 
-	createApplicationForm(null, req.body)
+	createApplicationForm(db, null, req.body)
 		.then((applicationForm) => {
 			const queries = fields.map(async (field) =>
-				createApplicationFormField(null, {
+				createApplicationFormField(db, null, {
 					...field,
 					applicationFormId: applicationForm.id,
 				}),

--- a/src/handlers/baseFieldsCopyTasksHandlers.ts
+++ b/src/handlers/baseFieldsCopyTasksHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	createBaseFieldsCopyTask,
 	loadBaseFieldsCopyTaskBundle,
 	getLimitValues,
@@ -41,7 +42,7 @@ const postBaseFieldsCopyTask = (
 	const { pdcApiUrl } = req.body;
 	const createdBy = req.user.keycloakUserId;
 	(async () => {
-		const baseFieldsCopyTask = await createBaseFieldsCopyTask(null, {
+		const baseFieldsCopyTask = await createBaseFieldsCopyTask(db, null, {
 			pdcApiUrl,
 			status: TaskStatus.PENDING,
 			createdBy,
@@ -76,6 +77,7 @@ const getBaseFieldsCopyTasks = (
 	const { createdBy } = extractCreatedByParameters(req);
 	(async () => {
 		const baseFieldsCopyTaskBundle = await loadBaseFieldsCopyTaskBundle(
+			db,
 			req,
 			createdBy,
 			limit,

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -1,5 +1,6 @@
 import { DatabaseError, InputValidationError } from '../errors';
 import {
+	db,
 	createBaseField,
 	loadBaseFields,
 	updateBaseField,
@@ -19,7 +20,7 @@ import {
 import type { Request, Response, NextFunction } from 'express';
 
 const assertBaseFieldExists = async (baseFieldId: number): Promise<void> => {
-	await loadBaseField(null, baseFieldId);
+	await loadBaseField(db, null, baseFieldId);
 };
 
 const getBaseFields = (
@@ -55,7 +56,7 @@ const postBaseField = (
 		return;
 	}
 
-	createBaseField(null, req.body)
+	createBaseField(db, null, req.body)
 		.then((baseField) => {
 			res.status(201).contentType('application/json').send(baseField);
 		})
@@ -117,6 +118,7 @@ const getBaseFieldLocalizationsByBaseFieldId = (
 	assertBaseFieldExists(baseFieldId)
 		.then(() => {
 			loadBaseFieldLocalizationsBundleByBaseFieldId(
+				db,
 				null,
 				baseFieldId,
 				limit,
@@ -183,7 +185,7 @@ const putBaseFieldLocalization = (
 	const { label, description } = req.body;
 	assertBaseFieldExists(baseFieldId)
 		.then(() => {
-			createOrUpdateBaseFieldLocalization(null, {
+			createOrUpdateBaseFieldLocalization(db, null, {
 				label,
 				description,
 				baseFieldId,

--- a/src/handlers/bulkUploadTasksHandlers.ts
+++ b/src/handlers/bulkUploadTasksHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	assertSourceExists,
 	createBulkUploadTask,
 	getLimitValues,
@@ -56,7 +57,7 @@ const postBulkUploadTask = (
 
 	assertSourceExists(sourceId)
 		.then(async () => {
-			const bulkUploadTask = await createBulkUploadTask(null, {
+			const bulkUploadTask = await createBulkUploadTask(db, null, {
 				sourceId,
 				fileName,
 				sourceKey,
@@ -102,6 +103,7 @@ const getBulkUploadTasks = (
 	const { createdBy } = extractCreatedByParameters(req);
 	(async () => {
 		const bulkUploadTaskBundle = await loadBulkUploadTaskBundle(
+			db,
 			req,
 			createdBy,
 			limit,

--- a/src/handlers/changemakerProposalsHandlers.ts
+++ b/src/handlers/changemakerProposalsHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	createChangemakerProposal,
 	getLimitValues,
 	loadChangemakerProposalBundle,
@@ -27,6 +28,7 @@ const getChangemakerProposals = (
 
 	(async () => {
 		const changemakerProposalBundle = await loadChangemakerProposalBundle(
+			db,
 			null,
 			changemakerId,
 			proposalId,
@@ -61,7 +63,7 @@ const postChangemakerProposal = (
 		return;
 	}
 
-	createChangemakerProposal(null, req.body)
+	createChangemakerProposal(db, null, req.body)
 		.then((changemakerProposal) => {
 			res.status(201).contentType('application/json').send(changemakerProposal);
 		})

--- a/src/handlers/changemakersHandlers.ts
+++ b/src/handlers/changemakersHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	getLimitValues,
 	loadChangemakerBundle,
 	loadChangemaker,
@@ -32,7 +33,7 @@ const postChangemaker = (
 		);
 		return;
 	}
-	createChangemaker(null, req.body)
+	createChangemaker(db, null, req.body)
 		.then((changemaker) => {
 			res.status(201).contentType('application/json').send(changemaker);
 		})
@@ -54,7 +55,7 @@ const getChangemakers = (
 	const { limit, offset } = getLimitValues(paginationParameters);
 	const { proposalId } = extractProposalParameters(req);
 	const authContext = isAuthContext(req) ? req : null;
-	loadChangemakerBundle(authContext, proposalId, limit, offset)
+	loadChangemakerBundle(db, authContext, proposalId, limit, offset)
 		.then((changemakerBundle) => {
 			res.status(200).contentType('application/json').send(changemakerBundle);
 		})
@@ -79,6 +80,7 @@ const getChangemaker = (
 	}
 	const authContext = isAuthContext(req) ? req : undefined;
 	loadChangemaker(
+		db,
 		null,
 		getKeycloakUserIdFromAuthContext(authContext),
 		changemakerId,

--- a/src/handlers/dataProvidersHandlers.ts
+++ b/src/handlers/dataProvidersHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	getLimitValues,
 	createOrUpdateDataProvider,
 	loadDataProviderBundle,
@@ -30,7 +31,7 @@ const getDataProviders = (
 	const paginationParameters = extractPaginationParameters(req);
 	(async () => {
 		const { offset, limit } = getLimitValues(paginationParameters);
-		const bundle = await loadDataProviderBundle(req, limit, offset);
+		const bundle = await loadDataProviderBundle(db, req, limit, offset);
 
 		res.status(200).contentType('application/json').send(bundle);
 	})().catch((error: unknown) => {
@@ -54,7 +55,7 @@ const getDataProvider = (
 		);
 		return;
 	}
-	loadDataProvider(null, dataProviderShortCode)
+	loadDataProvider(db, null, dataProviderShortCode)
 		.then((item) => {
 			res.status(200).contentType('application/json').send(item);
 		})
@@ -94,7 +95,7 @@ const putDataProvider = (
 	}
 	const { name, keycloakOrganizationId } = req.body;
 	(async () => {
-		const dataProvider = await createOrUpdateDataProvider(null, {
+		const dataProvider = await createOrUpdateDataProvider(db, null, {
 			shortCode,
 			name,
 			keycloakOrganizationId,

--- a/src/handlers/fundersHandlers.ts
+++ b/src/handlers/fundersHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	createOrUpdateFunder,
 	getLimitValues,
 	loadFunderBundle,
@@ -26,7 +27,7 @@ const getFunders = (req: Request, res: Response, next: NextFunction): void => {
 	const paginationParameters = extractPaginationParameters(req);
 	(async () => {
 		const { offset, limit } = getLimitValues(paginationParameters);
-		const funderBundle = await loadFunderBundle(req, limit, offset);
+		const funderBundle = await loadFunderBundle(db, req, limit, offset);
 
 		res.status(200).contentType('application/json').send(funderBundle);
 	})().catch((error: unknown) => {
@@ -46,7 +47,7 @@ const getFunder = (req: Request, res: Response, next: NextFunction): void => {
 		);
 		return;
 	}
-	loadFunder(null, funderShortCode)
+	loadFunder(db, null, funderShortCode)
 		.then((funder) => {
 			res.status(200).contentType('application/json').send(funder);
 		})
@@ -83,7 +84,7 @@ const putFunder = (req: Request, res: Response, next: NextFunction): void => {
 	const { name, keycloakOrganizationId } = req.body;
 
 	(async () => {
-		const funder = await createOrUpdateFunder(null, {
+		const funder = await createOrUpdateFunder(db, null, {
 			shortCode,
 			name,
 			keycloakOrganizationId,

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	createOpportunity,
 	getLimitValues,
 	loadOpportunity,
@@ -20,7 +21,7 @@ const getOpportunities = (
 ): void => {
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
-	loadOpportunityBundle(null, limit, offset)
+	loadOpportunityBundle(db, null, limit, offset)
 		.then((opportunityBundle) => {
 			res.status(200).contentType('application/json').send(opportunityBundle);
 		})
@@ -43,7 +44,7 @@ const getOpportunity = (
 		next(new InputValidationError('Invalid id parameter.', isId.errors ?? []));
 		return;
 	}
-	loadOpportunity(null, opportunityId)
+	loadOpportunity(db, null, opportunityId)
 		.then((opportunity) => {
 			res.status(200).contentType('application/json').send(opportunity);
 		})
@@ -70,7 +71,7 @@ const postOpportunity = (
 		);
 		return;
 	}
-	createOpportunity(null, req.body)
+	createOpportunity(db, null, req.body)
 		.then((opportunity) => {
 			res.status(201).contentType('application/json').send(opportunity);
 		})

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -35,7 +35,7 @@ const assertApplicationFormExistsForProposal = async (
 ): Promise<void> => {
 	let applicationForm: ApplicationForm;
 	try {
-		applicationForm = await loadApplicationForm(null, applicationFormId);
+		applicationForm = await loadApplicationForm(db, null, applicationFormId);
 	} catch {
 		throw new InputConflictError('The Application Form does not exist.', {
 			entityType: 'ApplicationForm',
@@ -45,7 +45,7 @@ const assertApplicationFormExistsForProposal = async (
 
 	let proposal: Proposal;
 	try {
-		proposal = await loadProposal(null, proposalId);
+		proposal = await loadProposal(db, null, proposalId);
 	} catch (err) {
 		if (err instanceof NotFoundError) {
 			throw new InputConflictError(
@@ -83,6 +83,7 @@ const assertProposalFieldValuesMapToApplicationForm = async (
 			const { applicationFormFieldId } = proposalFieldValue;
 			try {
 				const applicationFormField = await loadApplicationFormField(
+					db,
 					null,
 					proposalFieldValue.applicationFormFieldId,
 				);
@@ -150,14 +151,15 @@ const postProposalVersion = (
 		.then(() => {
 			db.transaction(async (transactionDb) => {
 				const proposalVersion = await createProposalVersion(
+					transactionDb,
 					null,
 					{ proposalId, applicationFormId, sourceId, createdBy },
-					transactionDb,
 				);
 				const proposalFieldValues = await Promise.all(
 					fieldValues.map(async (fieldValue) => {
 						const { value, applicationFormFieldId } = fieldValue;
 						const applicationFormField = await loadApplicationFormField(
+							db,
 							null,
 							applicationFormFieldId,
 						);
@@ -166,13 +168,13 @@ const postProposalVersion = (
 							applicationFormField.baseField.dataType,
 						);
 						const proposalFieldValue = await createProposalFieldValue(
+							transactionDb,
 							null,
 							{
 								...fieldValue,
 								proposalVersionId: proposalVersion.id,
 								isValid,
 							},
-							transactionDb,
 						);
 						return proposalFieldValue;
 					}),
@@ -230,7 +232,7 @@ const getProposalVersion = (
 		);
 		return;
 	}
-	loadProposalVersion(null, proposalVersionId)
+	loadProposalVersion(db, null, proposalVersionId)
 		.then((item) => {
 			res.status(200).contentType('application/json').send(item);
 		})

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	assertProposalAuthorization,
 	createProposal,
 	getLimitValues,
@@ -41,6 +42,7 @@ const getProposals = (
 
 	(async () => {
 		const proposalBundle = await loadProposalBundle(
+			db,
 			req,
 			createdBy,
 			changemakerId,
@@ -71,7 +73,7 @@ const getProposal = (req: Request, res: Response, next: NextFunction): void => {
 	}
 	(async () => {
 		await assertProposalAuthorization(proposalId, req);
-		const proposal = await loadProposal(null, proposalId);
+		const proposal = await loadProposal(db, null, proposalId);
 		res.status(200).contentType('application/json').send(proposal);
 	})().catch((error: unknown) => {
 		if (isTinyPgErrorWithQueryContext(error)) {
@@ -104,7 +106,7 @@ const postProposal = (
 	const { externalId, opportunityId } = req.body;
 	const createdBy = req.user.keycloakUserId;
 
-	createProposal(null, {
+	createProposal(db, null, {
 		opportunityId,
 		externalId,
 		createdBy,

--- a/src/handlers/sourcesHandlers.ts
+++ b/src/handlers/sourcesHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	createSource,
 	getLimitValues,
 	loadSource,
@@ -36,7 +37,7 @@ const postSource = (req: Request, res: Response, next: NextFunction): void => {
 	// Normally we try to avoid passing the body directly vs extracting the values and passing them.
 	// Because because writableSource is a union type it is hard to extract the values directly without
 	// losing type context that the union provided.
-	createSource(null, req.body)
+	createSource(db, null, req.body)
 		.then((item) => {
 			res.status(201).contentType('application/json').send(item);
 		})
@@ -57,7 +58,7 @@ const getSources = (req: Request, res: Response, next: NextFunction): void => {
 	const paginationParameters = extractPaginationParameters(req);
 	(async () => {
 		const { offset, limit } = getLimitValues(paginationParameters);
-		const bundle = await loadSourceBundle(req, limit, offset);
+		const bundle = await loadSourceBundle(db, req, limit, offset);
 
 		res.status(200).contentType('application/json').send(bundle);
 	})().catch((error: unknown) => {
@@ -75,7 +76,7 @@ const getSource = (req: Request, res: Response, next: NextFunction): void => {
 		next(new InputValidationError('Invalid request body.', isId.errors ?? []));
 		return;
 	}
-	loadSource(null, sourceId)
+	loadSource(db, null, sourceId)
 		.then((item) => {
 			res.status(200).contentType('application/json').send(item);
 		})

--- a/src/handlers/userChangemakerPermissionsHandlers.ts
+++ b/src/handlers/userChangemakerPermissionsHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	assertUserChangemakerPermissionExists,
 	createOrUpdateUserChangemakerPermission,
 	removeUserChangemakerPermission,
@@ -125,7 +126,7 @@ const putUserChangemakerPermission = (
 
 	(async () => {
 		const userChangemakerPermission =
-			await createOrUpdateUserChangemakerPermission(null, {
+			await createOrUpdateUserChangemakerPermission(db, null, {
 				userKeycloakUserId,
 				changemakerId,
 				permission,

--- a/src/handlers/userDataProviderPermissionsHandlers.ts
+++ b/src/handlers/userDataProviderPermissionsHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	assertUserDataProviderPermissionExists,
 	createOrUpdateUserDataProviderPermission,
 	removeUserDataProviderPermission,
@@ -126,6 +127,7 @@ const putUserDataProviderPermission = (
 
 	(async () => {
 		const userFunderPermission = await createOrUpdateUserDataProviderPermission(
+			db,
 			null,
 			{
 				userKeycloakUserId,

--- a/src/handlers/userFunderPermissionsHandlers.ts
+++ b/src/handlers/userFunderPermissionsHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	db,
 	assertUserFunderPermissionExists,
 	createOrUpdateUserFunderPermission,
 	removeUserFunderPermission,
@@ -126,6 +127,7 @@ const putUserFunderPermission = (
 
 	(async () => {
 		const userFunderPermission = await createOrUpdateUserFunderPermission(
+			db,
 			null,
 			{
 				userKeycloakUserId,

--- a/src/handlers/usersHandlers.ts
+++ b/src/handlers/usersHandlers.ts
@@ -1,4 +1,4 @@
-import { getLimitValues, loadUserBundle } from '../database';
+import { db, getLimitValues, loadUserBundle } from '../database';
 import { isAuthContext, isTinyPgErrorWithQueryContext } from '../types';
 import { DatabaseError, FailedMiddlewareError } from '../errors';
 import {
@@ -17,7 +17,13 @@ const getUsers = (req: Request, res: Response, next: NextFunction): void => {
 	const { keycloakUserId } = extractKeycloakUserIdParameters(req);
 
 	(async () => {
-		const userBundle = await loadUserBundle(req, keycloakUserId, limit, offset);
+		const userBundle = await loadUserBundle(
+			db,
+			req,
+			keycloakUserId,
+			limit,
+			offset,
+		);
 
 		res.status(200).contentType('application/json').send(userBundle);
 	})().catch((error: unknown) => {

--- a/src/middleware/__tests__/addUserContext.int.test.ts
+++ b/src/middleware/__tests__/addUserContext.int.test.ts
@@ -1,5 +1,5 @@
 import { addUserContext } from '../addUserContext';
-import { loadUserByKeycloakUserId, loadTableMetrics } from '../../database';
+import { db, loadUserByKeycloakUserId, loadTableMetrics } from '../../database';
 import { generateNextWithAssertions } from '../../test/utils';
 import { stringToKeycloakId } from '../../types';
 import { InputValidationError } from '../../errors';
@@ -42,6 +42,7 @@ describe('addUserContext', () => {
 					expect(err).toBe(undefined);
 					const { count: userCount } = await loadTableMetrics('users');
 					const user = await loadUserByKeycloakUserId(
+						db,
 						null,
 						stringToKeycloakId('123e4567-e89b-12d3-a456-426614174000'),
 					);

--- a/src/middleware/addUserContext.ts
+++ b/src/middleware/addUserContext.ts
@@ -1,4 +1,4 @@
-import { createUser, loadUserByKeycloakUserId } from '../database';
+import { db, createUser, loadUserByKeycloakUserId } from '../database';
 import {
 	getAuthSubFromRequest,
 	isKeycloakId,
@@ -12,9 +12,9 @@ import type { AuthenticatedRequest, KeycloakId } from '../types';
 
 const selectOrCreateUser = async (keycloakUserId: KeycloakId) => {
 	try {
-		return await loadUserByKeycloakUserId(null, keycloakUserId);
+		return await loadUserByKeycloakUserId(db, null, keycloakUserId);
 	} catch {
-		const user = await createUser(null, { keycloakUserId });
+		const user = await createUser(db, null, { keycloakUserId });
 		return user;
 	}
 };

--- a/src/tasks/copyBaseFields.ts
+++ b/src/tasks/copyBaseFields.ts
@@ -5,6 +5,7 @@ import {
 	isBaseField,
 	BaseField,
 } from '../types';
+import { db } from '../database/db';
 import {
 	createOrUpdateBaseField,
 	createOrUpdateBaseFieldLocalization,
@@ -55,7 +56,7 @@ export const fetchBaseFieldsFromRemote = async (
 
 const copyBaseField = async (targetBaseField: BaseField) => {
 	const { scope, dataType, shortCode, label, description } = targetBaseField;
-	const copiedBaseField = await createOrUpdateBaseField(null, {
+	const copiedBaseField = await createOrUpdateBaseField(db, null, {
 		scope,
 		dataType,
 		shortCode,
@@ -65,7 +66,7 @@ const copyBaseField = async (targetBaseField: BaseField) => {
 	await Promise.all(
 		Object.entries(targetBaseField.localizations).map(
 			async ([language, baseFieldLocalization]) => {
-				await createOrUpdateBaseFieldLocalization(null, {
+				await createOrUpdateBaseFieldLocalization(db, null, {
 					baseFieldId: copiedBaseField.id,
 					language,
 					label: baseFieldLocalization.label,
@@ -90,6 +91,7 @@ export const copyBaseFields = async (
 		`Started BasefieldsCopy Job for BaseFieldsCopyTask ID ${payload.baseFieldsCopyTaskId}`,
 	);
 	const baseFieldsCopyTask = await loadBaseFieldsCopyTask(
+		db,
 		null,
 		payload.baseFieldsCopyTaskId,
 	);

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,4 +1,4 @@
-import { createUser, loadUserByKeycloakUserId } from '../database';
+import { db, createUser, loadUserByKeycloakUserId } from '../database';
 import { stringToKeycloakId } from '../types';
 
 export const isoTimestampPattern =
@@ -26,12 +26,12 @@ export const getTestUserKeycloakUserId = () =>
 	stringToKeycloakId('11111111-1111-1111-1111-111111111111'); // This value is not a reference, it's just a static GUID
 
 export const createTestUser = async () =>
-	createUser(null, {
+	createUser(db, null, {
 		keycloakUserId: getTestUserKeycloakUserId(),
 	});
 
 export const loadTestUser = async () =>
-	loadUserByKeycloakUserId(null, getTestUserKeycloakUserId());
+	loadUserByKeycloakUserId(db, null, getTestUserKeycloakUserId());
 
 export const NO_OFFSET = 0;
 


### PR DESCRIPTION
This PR adds a required `db` context to all database operation functions, and updates calling code to provide it.

Resolves #1147 