### PR TITLE
Use generator for update operations

### DIFF
--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -17,7 +17,6 @@ import {
 	loadSystemUser,
 	loadTableMetrics,
 	createOrUpdateDataProvider,
-	updateChangemaker,
 } from '../database';
 import { expectTimestamp, loadTestUser } from '../test/utils';
 import { mockJwt as authHeader } from '../test/mockJwt';
@@ -32,10 +31,8 @@ import {
 	Opportunity,
 	PostgresErrorCode,
 	Source,
-	stringToKeycloakId,
 	User,
 } from '../types';
-import { NotFoundError } from '../errors';
 
 const insertTestChangemakers = async () => {
 	await createChangemaker(db, null, {
@@ -850,50 +847,6 @@ describe('/changemakers', () => {
 					},
 				],
 			});
-		});
-	});
-
-	describe('Update keycloakOrganizationId', () => {
-		it('Successfully sets a keycloakOrganizationId where previously null', async () => {
-			const changemaker = await createChangemaker(db, null, {
-				taxId: '4833091201209397622311990956044204588593',
-				name: 'Changemaker 4833091201209397622311990956044204588593',
-				keycloakOrganizationId: null,
-			});
-			const newOrganizationId = stringToKeycloakId(
-				'64e6da25-a6ba-43ce-97ba-1c5958bcc7ae',
-			);
-			const result = await updateChangemaker(changemaker.id, newOrganizationId);
-			expect(result).toStrictEqual({
-				...changemaker,
-				keycloakOrganizationId: newOrganizationId,
-			});
-		});
-
-		it('Successfully sets a keycloakOrganizationId where previously non-null', async () => {
-			const changemaker = await createChangemaker(db, null, {
-				taxId: '1099594605318784561881495063299923285326',
-				name: 'Changemaker 1099594605318784561881495063299923285326',
-				keycloakOrganizationId: '7733cef4-8a08-4089-a699-9be1e5536733',
-			});
-			const newOrganizationId = stringToKeycloakId(
-				'0a78a90b-b2fe-42d0-8c46-b5ce959d6f24',
-			);
-			const result = await updateChangemaker(changemaker.id, newOrganizationId);
-			expect(result).toStrictEqual({
-				...changemaker,
-				keycloakOrganizationId: newOrganizationId,
-			});
-		});
-
-		it('Throws NotFoundError when the changemaker id does not exist', async () => {
-			const newOrganizationId = stringToKeycloakId(
-				'1377aea8-0ef5-4e0f-8beb-a799a93e898b',
-			);
-			const result = updateChangemaker(65222406, newOrganizationId);
-			await expect(async () => {
-				await result;
-			}).rejects.toThrowError(NotFoundError);
 		});
 	});
 });

--- a/src/database/operations/applicationFormFields/createApplicationFormField.ts
+++ b/src/database/operations/applicationFormFields/createApplicationFormField.ts
@@ -6,12 +6,12 @@ import type {
 
 const createApplicationFormField = generateCreateOrUpdateItemOperation<
 	ApplicationFormField,
-	WritableApplicationFormField
->('applicationFormFields.insertOne', [
-	'applicationFormId',
-	'baseFieldId',
-	'position',
-	'label',
-]);
+	WritableApplicationFormField,
+	[]
+>(
+	'applicationFormFields.insertOne',
+	['applicationFormId', 'baseFieldId', 'position', 'label'],
+	[],
+);
 
 export { createApplicationFormField };

--- a/src/database/operations/applicationForms/createApplicationForm.ts
+++ b/src/database/operations/applicationForms/createApplicationForm.ts
@@ -3,7 +3,8 @@ import type { ApplicationForm, WritableApplicationForm } from '../../../types';
 
 const createApplicationForm = generateCreateOrUpdateItemOperation<
 	ApplicationForm,
-	WritableApplicationForm
->('applicationForms.insertOne', ['opportunityId']);
+	WritableApplicationForm,
+	[]
+>('applicationForms.insertOne', ['opportunityId'], []);
 
 export { createApplicationForm };

--- a/src/database/operations/baseFieldLocalization/createOrUpdateBaseFieldLocalizations.ts
+++ b/src/database/operations/baseFieldLocalization/createOrUpdateBaseFieldLocalizations.ts
@@ -6,12 +6,12 @@ import type {
 
 const createOrUpdateBaseFieldLocalization = generateCreateOrUpdateItemOperation<
 	BaseFieldLocalization,
-	InternallyWritableBaseFieldLocalization
->('baseFieldLocalizations.createOrUpdateByPrimaryKey', [
-	'baseFieldId',
-	'language',
-	'label',
-	'description',
-]);
+	InternallyWritableBaseFieldLocalization,
+	[]
+>(
+	'baseFieldLocalizations.createOrUpdateByPrimaryKey',
+	['baseFieldId', 'language', 'label', 'description'],
+	[],
+);
 
 export { createOrUpdateBaseFieldLocalization };

--- a/src/database/operations/baseFields/createBaseField.ts
+++ b/src/database/operations/baseFields/createBaseField.ts
@@ -3,13 +3,12 @@ import type { BaseField, WritableBaseField } from '../../../types';
 
 const createBaseField = generateCreateOrUpdateItemOperation<
 	BaseField,
-	WritableBaseField
->('baseFields.insertOne', [
-	'scope',
-	'dataType',
-	'shortCode',
-	'label',
-	'description',
-]);
+	WritableBaseField,
+	[]
+>(
+	'baseFields.insertOne',
+	['scope', 'dataType', 'shortCode', 'label', 'description'],
+	[],
+);
 
 export { createBaseField };

--- a/src/database/operations/baseFields/createOrUpdateBaseField.ts
+++ b/src/database/operations/baseFields/createOrUpdateBaseField.ts
@@ -3,13 +3,12 @@ import type { BaseField, WritableBaseField } from '../../../types';
 
 const createOrUpdateBaseField = generateCreateOrUpdateItemOperation<
 	BaseField,
-	WritableBaseField
->('baseFields.createOrUpdateByShortcode', [
-	'scope',
-	'dataType',
-	'shortCode',
-	'label',
-	'description',
-]);
+	WritableBaseField,
+	[]
+>(
+	'baseFields.createOrUpdateByShortcode',
+	['scope', 'dataType', 'shortCode', 'label', 'description'],
+	[],
+);
 
 export { createOrUpdateBaseField };

--- a/src/database/operations/baseFields/updateBaseField.ts
+++ b/src/database/operations/baseFields/updateBaseField.ts
@@ -1,33 +1,14 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
-import type {
-	BaseField,
-	JsonResultSet,
-	WritableBaseField,
-} from '../../../types';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { BaseField, WritableBaseField } from '../../../types';
 
-export const updateBaseField = async (
-	id: number,
-	updateValues: WritableBaseField,
-): Promise<BaseField> => {
-	const { label, description, shortCode, dataType, scope } = updateValues;
-	const result = await db.sql<JsonResultSet<BaseField>>(
-		'baseFields.updateById',
-		{
-			id,
-			label,
-			description,
-			shortCode,
-			dataType,
-			scope,
-		},
-	);
-	const baseField = result.rows[0]?.object;
-	if (baseField === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'BaseField',
-			entityId: id,
-		});
-	}
-	return baseField;
-};
+const updateBaseField = generateCreateOrUpdateItemOperation<
+	BaseField,
+	WritableBaseField,
+	[baseFieldId: number]
+>(
+	'baseFields.updateById',
+	['label', 'description', 'shortCode', 'dataType', 'scope'],
+	['baseFieldId'],
+);
+
+export { updateBaseField };

--- a/src/database/operations/baseFieldsCopyTasks/createBaseFieldsCopyTask.ts
+++ b/src/database/operations/baseFieldsCopyTasks/createBaseFieldsCopyTask.ts
@@ -6,7 +6,8 @@ import type {
 
 const createBaseFieldsCopyTask = generateCreateOrUpdateItemOperation<
 	BaseFieldsCopyTask,
-	InternallyWritableBaseFieldsCopyTask
->('baseFieldsCopyTasks.insertOne', ['status', 'pdcApiUrl', 'createdBy']);
+	InternallyWritableBaseFieldsCopyTask,
+	[]
+>('baseFieldsCopyTasks.insertOne', ['status', 'pdcApiUrl', 'createdBy'], []);
 
 export { createBaseFieldsCopyTask };

--- a/src/database/operations/baseFieldsCopyTasks/updateBaseFieldsCopyTask.ts
+++ b/src/database/operations/baseFieldsCopyTasks/updateBaseFieldsCopyTask.ts
@@ -1,30 +1,13 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
-	JsonResultSet,
 	BaseFieldsCopyTask,
 	InternallyWritableBaseFieldsCopyTask,
 } from '../../../types';
 
-export const updateBaseFieldsCopyTask = async (
-	id: number,
-	updateValues: Partial<InternallyWritableBaseFieldsCopyTask>,
-): Promise<BaseFieldsCopyTask> => {
-	const { status } = updateValues;
+const updateBaseFieldsCopyTask = generateCreateOrUpdateItemOperation<
+	BaseFieldsCopyTask,
+	Partial<InternallyWritableBaseFieldsCopyTask>,
+	[baseFieldsCopyTaskId: number]
+>('baseFieldsCopyTasks.updateById', ['status'], ['baseFieldsCopyTaskId']);
 
-	const result = await db.sql<JsonResultSet<BaseFieldsCopyTask>>(
-		'baseFieldsCopyTasks.updateById',
-		{
-			id,
-			status,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'BaseFieldsCopyTask',
-			entityId: id,
-		});
-	}
-	return object;
-};
+export { updateBaseFieldsCopyTask };

--- a/src/database/operations/bulkUploadTasks/createBulkUploadTask.ts
+++ b/src/database/operations/bulkUploadTasks/createBulkUploadTask.ts
@@ -6,13 +6,12 @@ import type {
 
 const createBulkUploadTask = generateCreateOrUpdateItemOperation<
 	BulkUploadTask,
-	InternallyWritableBulkUploadTask
->('bulkUploadTasks.insertOne', [
-	'sourceId',
-	'fileName',
-	'sourceKey',
-	'status',
-	'createdBy',
-]);
+	InternallyWritableBulkUploadTask,
+	[]
+>(
+	'bulkUploadTasks.insertOne',
+	['sourceId', 'fileName', 'sourceKey', 'status', 'createdBy'],
+	[],
+);
 
 export { createBulkUploadTask };

--- a/src/database/operations/bulkUploadTasks/updateBulkUploadTask.ts
+++ b/src/database/operations/bulkUploadTasks/updateBulkUploadTask.ts
@@ -1,37 +1,17 @@
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
+import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
-	JsonResultSet,
 	BulkUploadTask,
 	InternallyWritableBulkUploadTask,
 } from '../../../types';
 
-export const updateBulkUploadTask = async (
-	id: number,
-	updateValues: Partial<InternallyWritableBulkUploadTask>,
-): Promise<BulkUploadTask> => {
-	const { fileSize, sourceKey, status } = updateValues;
-	const defaultValues = {
-		fileSize: -1,
-		sourceKey: '',
-		status: '',
-	};
-	const result = await db.sql<JsonResultSet<BulkUploadTask>>(
-		'bulkUploadTasks.updateById',
-		{
-			...defaultValues,
-			id,
-			fileSize,
-			sourceKey,
-			status,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'BulkUploadTask',
-			entityId: id,
-		});
-	}
-	return object;
-};
+const updateBulkUploadTask = generateCreateOrUpdateItemOperation<
+	BulkUploadTask,
+	Partial<InternallyWritableBulkUploadTask>,
+	[bulkUploadTaskId: number]
+>(
+	'bulkUploadTasks.updateById',
+	['fileSize', 'sourceKey', 'status'],
+	['bulkUploadTaskId'],
+);
+
+export { updateBulkUploadTask };

--- a/src/database/operations/changemakerProposals/createChangemakerProposal.ts
+++ b/src/database/operations/changemakerProposals/createChangemakerProposal.ts
@@ -6,7 +6,8 @@ import {
 
 const createChangemakerProposal = generateCreateOrUpdateItemOperation<
 	ChangemakerProposal,
-	WritableChangemakerProposal
->('changemakersProposals.insertOne', ['changemakerId', 'proposalId']);
+	WritableChangemakerProposal,
+	[]
+>('changemakersProposals.insertOne', ['changemakerId', 'proposalId'], []);
 
 export { createChangemakerProposal };

--- a/src/database/operations/changemakers/__test__/updateChangemakers.int.test.ts
+++ b/src/database/operations/changemakers/__test__/updateChangemakers.int.test.ts
@@ -1,0 +1,62 @@
+import { createChangemaker, updateChangemaker } from '..';
+import { stringToKeycloakId } from '../../../../types';
+import { db } from '../../../db';
+
+describe('updateChangemaker', () => {
+	it('Successfully sets a keycloakOrganizationId where previously null', async () => {
+		const changemaker = await createChangemaker(db, null, {
+			taxId: '4833091201209397622311990956044204588593',
+			name: 'Changemaker 4833091201209397622311990956044204588593',
+			keycloakOrganizationId: null,
+		});
+		const newOrganizationId = stringToKeycloakId(
+			'64e6da25-a6ba-43ce-97ba-1c5958bcc7ae',
+		);
+		const result = await updateChangemaker(
+			db,
+			null,
+			{ keycloakOrganizationId: newOrganizationId },
+			changemaker.id,
+		);
+		expect(result).toStrictEqual({
+			...changemaker,
+			keycloakOrganizationId: newOrganizationId,
+		});
+	});
+
+	it('Successfully sets a keycloakOrganizationId where previously non-null', async () => {
+		const changemaker = await createChangemaker(db, null, {
+			taxId: '1099594605318784561881495063299923285326',
+			name: 'Changemaker 1099594605318784561881495063299923285326',
+			keycloakOrganizationId: '7733cef4-8a08-4089-a699-9be1e5536733',
+		});
+		const newOrganizationId = stringToKeycloakId(
+			'0a78a90b-b2fe-42d0-8c46-b5ce959d6f24',
+		);
+		const result = await updateChangemaker(
+			db,
+			null,
+			{ keycloakOrganizationId: newOrganizationId },
+			changemaker.id,
+		);
+		expect(result).toStrictEqual({
+			...changemaker,
+			keycloakOrganizationId: newOrganizationId,
+		});
+	});
+
+	it('Throws Error when the changemaker id does not exist', async () => {
+		const newOrganizationId = stringToKeycloakId(
+			'1377aea8-0ef5-4e0f-8beb-a799a93e898b',
+		);
+		const result = updateChangemaker(
+			db,
+			null,
+			{ keycloakOrganizationId: newOrganizationId },
+			65222406,
+		);
+		await expect(async () => {
+			await result;
+		}).rejects.toThrowError();
+	});
+});

--- a/src/database/operations/changemakers/createChangemaker.ts
+++ b/src/database/operations/changemakers/createChangemaker.ts
@@ -3,7 +3,8 @@ import type { Changemaker, WritableChangemaker } from '../../../types';
 
 const createChangemaker = generateCreateOrUpdateItemOperation<
 	Changemaker,
-	WritableChangemaker
->('changemakers.insertOne', ['taxId', 'name', 'keycloakOrganizationId']);
+	WritableChangemaker,
+	[]
+>('changemakers.insertOne', ['taxId', 'name', 'keycloakOrganizationId'], []);
 
 export { createChangemaker };

--- a/src/database/operations/changemakers/updateChangemaker.ts
+++ b/src/database/operations/changemakers/updateChangemaker.ts
@@ -1,26 +1,10 @@
-import { Changemaker, Id, JsonResultSet, KeycloakId } from '../../../types';
-import { db } from '../../db';
-import { NotFoundError } from '../../../errors';
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { Changemaker, Id, WritableChangemaker } from '../../../types';
 
-export const updateChangemaker = async (
-	changemakerId: Id,
-	keycloakOrganizationId: KeycloakId,
-): Promise<Changemaker> => {
-	const result = await db.sql<JsonResultSet<Changemaker>>(
-		'changemakers.updateById',
-		{
-			changemakerId,
-			keycloakOrganizationId,
-		},
-	);
-	const { object } = result.rows[0] ?? {};
-	if (object === undefined) {
-		throw new NotFoundError(`Entity not found`, {
-			entityType: 'Changemaker',
-			lookupValues: {
-				changemakerId,
-			},
-		});
-	}
-	return object;
-};
+const updateChangemaker = generateCreateOrUpdateItemOperation<
+	Changemaker,
+	Partial<WritableChangemaker>,
+	[changemakerId: Id]
+>('changemakers.updateById', ['keycloakOrganizationId'], ['changemakerId']);
+
+export { updateChangemaker };

--- a/src/database/operations/dataProviders/createOrUpdateDataProvider.ts
+++ b/src/database/operations/dataProviders/createOrUpdateDataProvider.ts
@@ -6,11 +6,12 @@ import type {
 
 const createOrUpdateDataProvider = generateCreateOrUpdateItemOperation<
 	DataProvider,
-	InternallyWritableDataProvider
->('dataProviders.insertOrUpdateOne', [
-	'shortCode',
-	'name',
-	'keycloakOrganizationId',
-]);
+	InternallyWritableDataProvider,
+	[]
+>(
+	'dataProviders.insertOrUpdateOne',
+	['shortCode', 'name', 'keycloakOrganizationId'],
+	[],
+);
 
 export { createOrUpdateDataProvider };

--- a/src/database/operations/funders/createOrUpdateFunder.ts
+++ b/src/database/operations/funders/createOrUpdateFunder.ts
@@ -3,7 +3,12 @@ import type { Funder, InternallyWritableFunder } from '../../../types';
 
 const createOrUpdateFunder = generateCreateOrUpdateItemOperation<
 	Funder,
-	InternallyWritableFunder
->('funders.insertOrUpdateOne', ['shortCode', 'name', 'keycloakOrganizationId']);
+	InternallyWritableFunder,
+	[]
+>(
+	'funders.insertOrUpdateOne',
+	['shortCode', 'name', 'keycloakOrganizationId'],
+	[],
+);
 
 export { createOrUpdateFunder };

--- a/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
+++ b/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
@@ -56,7 +56,7 @@ const generateCreateOrUpdateItemOperation =
 		);
 		const queryParameters = {
 			...authenticationQueryParameters,
-			savedItemAttributeQueryParameters,
+			...savedItemAttributeQueryParameters,
 			...operationQueryParameters,
 		};
 

--- a/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
+++ b/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
@@ -21,29 +21,44 @@ type KeysOfUnion<T> = T extends T ? keyof T : never;
  * @returns {Function} A function that takes query parameters, limit, and offset, and returns a promise that resolves to a bundle of entries and total count.
  */
 const generateCreateOrUpdateItemOperation =
-	<T, P extends Record<string, unknown>>(
+	<T, I extends Record<string, unknown>, P extends [...args: unknown[]]>(
 		queryName: string,
-		savedAttributes: KeysOfUnion<P>[],
+		saveItemAttributes: KeysOfUnion<I>[],
+		parameterNames: { [K in keyof P]: string },
 	) =>
 	async (
 		db: TinyPg,
 		authContext: AuthContext | null,
-		createValues: P,
+		createValues: I,
+		...args: [...P]
 	): Promise<T> => {
 		const authContextKeycloakUserId =
 			getKeycloakUserIdFromAuthContext(authContext);
 		const authContextIsAdministrator =
 			getIsAdministratorFromAuthContext(authContext);
-		const queryParameters = savedAttributes.reduce(
+		const authenticationQueryParameters = {
+			authContextKeycloakUserId,
+			authContextIsAdministrator,
+		};
+		const savedItemAttributeQueryParameters = saveItemAttributes.reduce(
 			(acc, attribute) => ({
 				...acc,
 				[attribute]: createValues[attribute],
 			}),
-			{
-				authContextKeycloakUserId,
-				authContextIsAdministrator,
-			},
+			{},
 		);
+		const operationQueryParameters = parameterNames.reduce(
+			(acc, parameterName, index) => ({
+				...acc,
+				[parameterName]: args[index],
+			}),
+			{},
+		);
+		const queryParameters = {
+			...authenticationQueryParameters,
+			savedItemAttributeQueryParameters,
+			...operationQueryParameters,
+		};
 
 		const result = await db.sql<JsonResultSet<T>>(queryName, queryParameters);
 		const { object } = result.rows[0] ?? {};

--- a/src/database/operations/opportunities/createOpportunity.ts
+++ b/src/database/operations/opportunities/createOpportunity.ts
@@ -3,7 +3,8 @@ import type { WritableOpportunity, Opportunity } from '../../../types';
 
 const createOpportunity = generateCreateOrUpdateItemOperation<
 	Opportunity,
-	WritableOpportunity
->('opportunities.insertOne', ['title']);
+	WritableOpportunity,
+	[]
+>('opportunities.insertOne', ['title'], []);
 
 export { createOpportunity };

--- a/src/database/operations/proposalFieldValues/createProposalFieldValue.ts
+++ b/src/database/operations/proposalFieldValues/createProposalFieldValue.ts
@@ -6,13 +6,18 @@ import type {
 
 const createProposalFieldValue = generateCreateOrUpdateItemOperation<
 	ProposalFieldValue,
-	InternallyWritableProposalFieldValue
->('proposalFieldValues.insertOne', [
-	'proposalVersionId',
-	'applicationFormFieldId',
-	'position',
-	'value',
-	'isValid',
-]);
+	InternallyWritableProposalFieldValue,
+	[]
+>(
+	'proposalFieldValues.insertOne',
+	[
+		'proposalVersionId',
+		'applicationFormFieldId',
+		'position',
+		'value',
+		'isValid',
+	],
+	[],
+);
 
 export { createProposalFieldValue };

--- a/src/database/operations/proposalVersions/createProposalVersion.ts
+++ b/src/database/operations/proposalVersions/createProposalVersion.ts
@@ -6,12 +6,12 @@ import type {
 
 const createProposalVersion = generateCreateOrUpdateItemOperation<
 	ProposalVersion,
-	InternallyWritableProposalVersion
->('proposalVersions.insertOne', [
-	'proposalId',
-	'applicationFormId',
-	'sourceId',
-	'createdBy',
-]);
+	InternallyWritableProposalVersion,
+	[]
+>(
+	'proposalVersions.insertOne',
+	['proposalId', 'applicationFormId', 'sourceId', 'createdBy'],
+	[],
+);
 
 export { createProposalVersion };

--- a/src/database/operations/proposals/createProposal.ts
+++ b/src/database/operations/proposals/createProposal.ts
@@ -3,7 +3,8 @@ import type { Proposal, InternallyWritableProposal } from '../../../types';
 
 const createProposal = generateCreateOrUpdateItemOperation<
 	Proposal,
-	InternallyWritableProposal
->('proposals.insertOne', ['opportunityId', 'externalId', 'createdBy']);
+	InternallyWritableProposal,
+	[]
+>('proposals.insertOne', ['opportunityId', 'externalId', 'createdBy'], []);
 
 export { createProposal };

--- a/src/database/operations/sources/createSource.ts
+++ b/src/database/operations/sources/createSource.ts
@@ -3,12 +3,12 @@ import type { Source, WritableSource } from '../../../types';
 
 const createSource = generateCreateOrUpdateItemOperation<
 	Source,
-	WritableSource
->('sources.insertOne', [
-	'label',
-	'dataProviderShortCode',
-	'funderShortCode',
-	'changemakerId',
-]);
+	WritableSource,
+	[]
+>(
+	'sources.insertOne',
+	['label', 'dataProviderShortCode', 'funderShortCode', 'changemakerId'],
+	[],
+);
 
 export { createSource };

--- a/src/database/operations/userChangemakerPermissions/createOrUpdateUserChangemakerPermission.ts
+++ b/src/database/operations/userChangemakerPermissions/createOrUpdateUserChangemakerPermission.ts
@@ -7,12 +7,12 @@ import type {
 const createOrUpdateUserChangemakerPermission =
 	generateCreateOrUpdateItemOperation<
 		UserChangemakerPermission,
-		InternallyWritableUserChangemakerPermission
-	>('userChangemakerPermissions.insertOrUpdateOne', [
-		'userKeycloakUserId',
-		'permission',
-		'changemakerId',
-		'createdBy',
-	]);
+		InternallyWritableUserChangemakerPermission,
+		[]
+	>(
+		'userChangemakerPermissions.insertOrUpdateOne',
+		['userKeycloakUserId', 'permission', 'changemakerId', 'createdBy'],
+		[],
+	);
 
 export { createOrUpdateUserChangemakerPermission };

--- a/src/database/operations/userDataProviderPermissions/createOrUpdateUserDataProviderPermission.ts
+++ b/src/database/operations/userDataProviderPermissions/createOrUpdateUserDataProviderPermission.ts
@@ -7,12 +7,12 @@ import type {
 const createOrUpdateUserDataProviderPermission =
 	generateCreateOrUpdateItemOperation<
 		UserDataProviderPermission,
-		InternallyWritableUserDataProviderPermission
-	>('userDataProviderPermissions.insertOrUpdateOne', [
-		'userKeycloakUserId',
-		'permission',
-		'dataProviderShortCode',
-		'createdBy',
-	]);
+		InternallyWritableUserDataProviderPermission,
+		[]
+	>(
+		'userDataProviderPermissions.insertOrUpdateOne',
+		['userKeycloakUserId', 'permission', 'dataProviderShortCode', 'createdBy'],
+		[],
+	);
 
 export { createOrUpdateUserDataProviderPermission };

--- a/src/database/operations/userFunderPermissions/createOrUpdateUserFunderPermission.ts
+++ b/src/database/operations/userFunderPermissions/createOrUpdateUserFunderPermission.ts
@@ -6,12 +6,12 @@ import type {
 
 const createOrUpdateUserFunderPermission = generateCreateOrUpdateItemOperation<
 	UserFunderPermission,
-	InternallyWritableUserFunderPermission
->('userFunderPermissions.insertOrUpdateOne', [
-	'userKeycloakUserId',
-	'permission',
-	'funderShortCode',
-	'createdBy',
-]);
+	InternallyWritableUserFunderPermission,
+	[]
+>(
+	'userFunderPermissions.insertOrUpdateOne',
+	['userKeycloakUserId', 'permission', 'funderShortCode', 'createdBy'],
+	[],
+);
 
 export { createOrUpdateUserFunderPermission };

--- a/src/database/operations/users/createUser.ts
+++ b/src/database/operations/users/createUser.ts
@@ -1,9 +1,10 @@
 import { generateCreateOrUpdateItemOperation } from '../generators';
 import type { User, WritableUser } from '../../../types';
 
-const createUser = generateCreateOrUpdateItemOperation<User, WritableUser>(
+const createUser = generateCreateOrUpdateItemOperation<User, WritableUser, []>(
 	'users.insertOne',
 	['keycloakUserId'],
+	[],
 );
 
 export { createUser };

--- a/src/database/queries/baseFields/updateById.sql
+++ b/src/database/queries/baseFields/updateById.sql
@@ -4,5 +4,5 @@ UPDATE base_fields SET
 	short_code = :shortCode,
 	data_type = :dataType,
 	scope = :scope
-WHERE id = :id
+WHERE id = :baseFieldId
 RETURNING base_field_to_json(base_fields) AS object;

--- a/src/database/queries/baseFieldsCopyTasks/updateById.sql
+++ b/src/database/queries/baseFieldsCopyTasks/updateById.sql
@@ -1,5 +1,5 @@
 UPDATE base_fields_copy_tasks
 SET
 	status = coalesce(:status, status)
-WHERE id = :id
+WHERE id = :baseFieldsCopyTaskId
 RETURNING base_fields_copy_task_to_json(base_fields_copy_tasks) AS object;

--- a/src/database/queries/bulkUploadTasks/updateById.sql
+++ b/src/database/queries/bulkUploadTasks/updateById.sql
@@ -3,5 +3,5 @@ SET
 	file_size = coalesce(:fileSize, file_size),
 	source_key = coalesce(:sourceKey, source_key),
 	status = coalesce(:status, status)
-WHERE id = :id
+WHERE id = :bulkUploadTaskId
 RETURNING bulk_upload_task_to_json(bulk_upload_tasks) AS object;

--- a/src/handlers/baseFieldsHandlers.ts
+++ b/src/handlers/baseFieldsHandlers.ts
@@ -70,12 +70,12 @@ const postBaseField = (
 };
 
 const putBaseField = (
-	req: Request<{ id: string }>,
+	req: Request<{ baseFieldId: string }>,
 	res: Response,
 	next: NextFunction,
 ) => {
-	const id = Number.parseInt(req.params.id, 10);
-	if (Number.isNaN(id)) {
+	const baseFieldId = Number.parseInt(req.params.baseFieldId, 10);
+	if (Number.isNaN(baseFieldId)) {
 		next(new InputValidationError('Invalid id parameter.', isId.errors ?? []));
 		return;
 	}
@@ -90,7 +90,7 @@ const putBaseField = (
 		return;
 	}
 
-	updateBaseField(id, body)
+	updateBaseField(baseFieldId, body)
 		.then((baseField) => {
 			res.status(200).contentType('application/json').send(baseField);
 		})

--- a/src/routers/baseFieldsRouter.ts
+++ b/src/routers/baseFieldsRouter.ts
@@ -11,7 +11,7 @@ baseFieldsRouter.post(
 	baseFieldsHandlers.postBaseField,
 );
 baseFieldsRouter.put(
-	'/:id',
+	'/:baseFieldId',
 	requireAdministratorRole,
 	baseFieldsHandlers.putBaseField,
 );

--- a/src/tasks/copyBaseFields.ts
+++ b/src/tasks/copyBaseFields.ts
@@ -107,9 +107,14 @@ export const copyBaseFields = async (
 	let remoteBaseFields: BaseField[];
 	let taskFailed = false;
 
-	await updateBaseFieldsCopyTask(baseFieldsCopyTask.id, {
-		status: TaskStatus.IN_PROGRESS,
-	});
+	await updateBaseFieldsCopyTask(
+		db,
+		null,
+		{
+			status: TaskStatus.IN_PROGRESS,
+		},
+		baseFieldsCopyTask.id,
+	);
 
 	try {
 		remoteBaseFields = await fetchBaseFieldsFromRemote(
@@ -118,9 +123,14 @@ export const copyBaseFields = async (
 		);
 	} catch (err) {
 		helpers.logger.warn('Fetching data from remote instance failed', { err });
-		await updateBaseFieldsCopyTask(baseFieldsCopyTask.id, {
-			status: TaskStatus.FAILED,
-		});
+		await updateBaseFieldsCopyTask(
+			db,
+			null,
+			{
+				status: TaskStatus.FAILED,
+			},
+			baseFieldsCopyTask.id,
+		);
 		return;
 	}
 
@@ -136,12 +146,22 @@ export const copyBaseFields = async (
 	}
 
 	if (taskFailed) {
-		await updateBaseFieldsCopyTask(baseFieldsCopyTask.id, {
-			status: TaskStatus.FAILED,
-		});
+		await updateBaseFieldsCopyTask(
+			db,
+			null,
+			{
+				status: TaskStatus.FAILED,
+			},
+			baseFieldsCopyTask.id,
+		);
 	} else {
-		await updateBaseFieldsCopyTask(baseFieldsCopyTask.id, {
-			status: TaskStatus.COMPLETED,
-		});
+		await updateBaseFieldsCopyTask(
+			db,
+			null,
+			{
+				status: TaskStatus.COMPLETED,
+			},
+			baseFieldsCopyTask.id,
+		);
 	}
 };


### PR DESCRIPTION
This continues the process of using generators for our db operations.  This in turn results in use of `db` and `authContext` parameters.

Related to #1407 