### PR TITLE
Allow updates to changemakers by ID

### DIFF
--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -931,5 +931,20 @@ describe('/changemakers', () => {
 				fields: [],
 			});
 		});
+
+		it('Returns 404 when changemaker is not found', async () => {
+			const newChangemakerFields = {
+				keycloakOrganizationId: stringToKeycloakId(
+					'd064b254-ea77-4f12-9ab3-eda695480e93',
+				),
+				name: 'Changemaker 5121900900194636437083568517070852137161',
+			};
+			await request(app)
+				.patch(`/changemakers/58597992`)
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send(newChangemakerFields)
+				.expect(404);
+		});
 	});
 });

--- a/src/database/operations/changemakers/updateChangemaker.ts
+++ b/src/database/operations/changemakers/updateChangemaker.ts
@@ -5,6 +5,10 @@ const updateChangemaker = generateCreateOrUpdateItemOperation<
 	Changemaker,
 	Partial<WritableChangemaker>,
 	[changemakerId: Id]
->('changemakers.updateById', ['keycloakOrganizationId'], ['changemakerId']);
+>(
+	'changemakers.updateById',
+	['taxId', 'name', 'keycloakOrganizationId'],
+	['changemakerId'],
+);
 
 export { updateChangemaker };

--- a/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
+++ b/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
@@ -1,3 +1,4 @@
+import { NoDataReturnedError } from '../../../errors/NoDataReturnedError';
 import {
 	getIsAdministratorFromAuthContext,
 	getKeycloakUserIdFromAuthContext,
@@ -63,7 +64,9 @@ const generateCreateOrUpdateItemOperation =
 		const result = await db.sql<JsonResultSet<T>>(queryName, queryParameters);
 		const { object } = result.rows[0] ?? {};
 		if (object === undefined) {
-			throw new Error('The database did not return a query result.');
+			throw new NoDataReturnedError(
+				'The database did not return a query result.',
+			);
 		}
 		return object;
 	};

--- a/src/database/queries/changemakers/updateById.sql
+++ b/src/database/queries/changemakers/updateById.sql
@@ -1,4 +1,9 @@
 UPDATE changemakers
-SET keycloak_organization_id = :keycloakOrganizationId
+SET
+	tax_id = coalesce(:taxId, tax_id),
+	name = coalesce(:name, name),
+	keycloak_organization_id = coalesce(
+		:keycloakOrganizationId, keycloak_organization_id
+	)
 WHERE id = :changemakerId
 RETURNING changemaker_to_json(changemakers) AS object;

--- a/src/errors/NoDataReturnedError.ts
+++ b/src/errors/NoDataReturnedError.ts
@@ -1,0 +1,8 @@
+/**
+ * The purpose of this marker class is to signal that the database query
+ * succeeded but returned no data. In some situations such as a `PUT`, the
+ * resulting HTTP status may need to be 500, whereas in other situations such as
+ * a `PATCH`, HTTP 404 is more appropriate. The handler determines whether to
+ * override the default 500.
+ */
+export class NoDataReturnedError extends Error {}

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -27,8 +27,12 @@ type NotFoundErrorDetails =
 export class NotFoundError extends Error {
 	public details: NotFoundErrorDetails;
 
-	public constructor(message: string, details: NotFoundErrorDetails) {
-		super(message);
+	public constructor(
+		message: string,
+		details: NotFoundErrorDetails,
+		options?: object,
+	) {
+		super(message, options);
 		this.name = this.constructor.name;
 		this.details = details;
 	}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,5 +3,6 @@ export * from './FailedMiddlewareError';
 export * from './InputConflictError';
 export * from './InputValidationError';
 export * from './InternalValidationError';
+export * from './NoDataReturnedError';
 export * from './NotFoundError';
 export * from './UnauthorizedError';

--- a/src/handlers/changemakersHandlers.ts
+++ b/src/handlers/changemakersHandlers.ts
@@ -19,6 +19,7 @@ import {
 	FailedMiddlewareError,
 	InputValidationError,
 	NoDataReturnedError,
+	NotFoundError,
 } from '../errors';
 import {
 	extractPaginationParameters,
@@ -144,7 +145,18 @@ const patchChangemaker = (
 				// it is more likely to be "ID not found" than a programming error. In
 				// the case of a `PUT`, on the other hand, leave it as a 500 because a
 				// `PUT` should succeed when all the inputs were valid.
-				res.status(404).send();
+				next(
+					new NotFoundError(
+						'The given changemaker was not found.',
+						{
+							entityType: 'Changemaker',
+							entityPrimaryKey: {
+								changemakerId,
+							},
+						},
+						{ cause: error },
+					),
+				);
 			}
 			next(error);
 		});

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -345,6 +345,23 @@
 				},
 				"required": ["id", "taxId", "name", "createdAt", "fields"]
 			},
+			"PartialChangemaker": {
+				"type": "object",
+				"properties": {
+					"taxId": {
+						"type": "string",
+						"example": "11-1111111"
+					},
+					"name": {
+						"type": "string",
+						"example": "Example Inc."
+					},
+					"keycloakOrganizationId": {
+						"$ref": "#/components/schemas/keycloakOrganizationId"
+					}
+				},
+				"required": []
+			},
 			"ChangemakerProposal": {
 				"type": "object",
 				"properties": {
@@ -1800,6 +1817,59 @@
 				"responses": {
 					"200": {
 						"description": "The requested changemaker.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Changemaker"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Authentication was not provided or was invalid.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PdcError"
+								}
+							}
+						}
+					}
+				}
+			},
+			"patch": {
+				"operationId": "updateChangemakerById",
+				"summary": "Updates one or more fields of a specific changemaker.",
+				"tags": ["Changemakers"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "changemakerId",
+						"description": "The PDC-generated ID of a changemaker.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/PartialChangemaker"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "The updated changemaker.",
 						"content": {
 							"application/json": {
 								"schema": {

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1843,7 +1843,7 @@
 				"tags": ["Changemakers"],
 				"security": [
 					{
-						"auth": []
+						"auth": ["realm_access:roles:administrator"]
 					}
 				],
 				"parameters": [
@@ -1878,8 +1878,28 @@
 							}
 						}
 					},
+					"400": {
+						"description": "At least one valid field was not provided or invalid fields were provided.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PdcError"
+								}
+							}
+						}
+					},
 					"401": {
 						"description": "Authentication was not provided or was invalid.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PdcError"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "The given changemaker ID was not found.",
 						"content": {
 							"application/json": {
 								"schema": {

--- a/src/routers/changemakersRouter.ts
+++ b/src/routers/changemakersRouter.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { changemakersHandlers } from '../handlers/changemakersHandlers';
-import { requireAuthentication } from '../middleware';
+import { requireAdministratorRole, requireAuthentication } from '../middleware';
 
 const changemakersRouter = express.Router();
 
@@ -12,6 +12,13 @@ changemakersRouter.post(
 	'/',
 	requireAuthentication,
 	changemakersHandlers.postChangemaker,
+);
+
+changemakersRouter.patch(
+	'/:changemakerId',
+	requireAuthentication,
+	requireAdministratorRole,
+	changemakersHandlers.patchChangemaker,
 );
 
 export { changemakersRouter };

--- a/src/types/Changemaker.ts
+++ b/src/types/Changemaker.ts
@@ -56,6 +56,8 @@ const partialWritableChangemakerSchema: JSONSchemaType<PartialWritableChangemake
 				nullable: true,
 			},
 		},
+		additionalProperties: false,
+		minProperties: 1,
 	};
 
 const isPartialWritableChangemaker = ajv.compile(

--- a/src/types/Changemaker.ts
+++ b/src/types/Changemaker.ts
@@ -37,9 +37,36 @@ const writableChangemakerSchema: JSONSchemaType<WritableChangemaker> = {
 
 const isWritableChangemaker = ajv.compile(writableChangemakerSchema);
 
+type PartialWritableChangemaker = Partial<WritableChangemaker>;
+
+const partialWritableChangemakerSchema: JSONSchemaType<PartialWritableChangemaker> =
+	{
+		type: 'object',
+		properties: {
+			taxId: {
+				type: 'string',
+				nullable: true,
+			},
+			name: {
+				type: 'string',
+				nullable: true,
+			},
+			keycloakOrganizationId: {
+				...keycloakIdSchema,
+				nullable: true,
+			},
+		},
+	};
+
+const isPartialWritableChangemaker = ajv.compile(
+	partialWritableChangemakerSchema,
+);
 export {
 	isWritableChangemaker,
 	Changemaker,
 	WritableChangemaker,
 	writableChangemakerSchema,
+	PartialWritableChangemaker,
+	partialWritableChangemakerSchema,
+	isPartialWritableChangemaker,
 };


### PR DESCRIPTION
The purpose of this change is to allow a keycloakOrganizationId to be added to a changemaker after a changemaker has been created. Often a changemaker will be created by bulk upload, for example, prior to the Keycloak organization to be associated with the changemaker.

The exposure of the new endpoint `PATCH /changemakers` allows an administrator, after creating a Keycloak organization in Keycloak, to associate the relevant changemaker in the PDC service.

Issue #1291 Keycloak groups to assist with PDC object permissions
