### PR TITLE
UserChangemakerPermission required fields in doc

### DIFF
--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1272,7 +1272,13 @@
 						"readOnly": true
 					}
 				},
-				"required": ["id", "", "createdAt"]
+				"required": [
+					"permission",
+					"changemakerId",
+					"userKeycloakUserId",
+					"createdBy",
+					"createdAt"
+				]
 			},
 			"UserFunderPermission": {
 				"type": "object",


### PR DESCRIPTION
Set the required fields in OpenAPI spec for UserChangemakerPermission.

Issue #1291 Keycloak groups to assist with PDC object permissions