### PR TITLE
Create `UserGroupPermissions` entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.16.7 2025-02-05
+
 ### Added
 
 - Manage user-funder permissions using `PUT`, and `DELETE` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
 - Manage user-data-provider permissions using `PUT`, and `DELETE` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
-
-### Added
-
+- Manage user-group-changemaker permissions using `PUT`, and `DELETE` on `/userGroups/{keycloakOrganizationId}/changemaker/{changemakerId}/permissions/{permission}`.
+- Manage user-group-data-provider permissions using `PUT`, and `DELETE` on `/userGroups/{keycloakOrganizationId}/dataProvider/{dataProviderShortCode}/permissions/{permission}`
+- Manage user-group-funder permissions using `PUT`, and `DELETE` on `/userGroups/{keycloakOrganizationId}/funders/{funderShortCode}/permissions/{permission}`
 - Manage user-funder permissions using `PUT`, and `DELETE` on `/user/{keycloakUserId}/funders/{funderShortCode}/permissions/{permission}`.
 
 ## 0.16.6 2024-12-23

--- a/src/__tests__/userGroupChangemakerPermissions.int.test.ts
+++ b/src/__tests__/userGroupChangemakerPermissions.int.test.ts
@@ -1,0 +1,316 @@
+import request from 'supertest';
+import { app } from '../app';
+import {
+	db,
+	createChangemaker,
+	createOrUpdateUserGroupChangemakerPermission,
+	loadUserGroupChangemakerPermission,
+	removeUserGroupChangemakerPermission,
+} from '../database';
+import { expectTimestamp, loadTestUser } from '../test/utils';
+import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
+} from '../test/mockJwt';
+import { KeycloakId, keycloakIdToString, Permission } from '../types';
+import { NotFoundError } from '../errors';
+
+const mockKeycloakOrganizationId = '123e4567-e89b-12d3-a456-426614174000';
+
+describe('/userGroups/changemakers/:changemakerId/permissions/:permission', () => {
+	describe('PUT /', () => {
+		it('returns 401 if the request lacks authentication', async () => {
+			const organizationAsChangemaker = await createChangemaker(db, null, {
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			const changemaker = await createChangemaker(db, null, {
+				taxId: '11-1111112',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/${changemaker.id}/permissions/${Permission.MANAGE}`,
+				)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 401 if the authenticated user lacks permission', async () => {
+			const organizationAsChangemaker = await createChangemaker(db, null, {
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+
+			const changemaker = await createChangemaker(db, null, {
+				taxId: '11-1111112',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/${changemaker.id}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 400 if the organizationKeycloakId is not a valid keycloak organization ID', async () => {
+			await request(app)
+				.put(
+					`/userGroups/notaguid/changemakers/1/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the changemaker ID is not a valid ID', async () => {
+			const organizationAsChangemaker = await createChangemaker(db, null, {
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/notanId/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the permission is not a valid permission', async () => {
+			const organizationAsChangemaker = await createChangemaker(db, null, {
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/1/permissions/notAPermission`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('creates and returns the new userGroup changemaker permission when user has administrative credentials', async () => {
+			const user = await loadTestUser();
+
+			const organizationAsChangemaker = await createChangemaker(db, null, {
+				taxId: '11-1111111',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+
+			const changemaker = await createChangemaker(db, null, {
+				taxId: '11-1111112',
+				name: 'Example Inc.',
+				keycloakOrganizationId: null,
+			});
+
+			const response = await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/${changemaker.id}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				changemakerId: changemaker.id,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				keycloakOrganizationId:
+					organizationAsChangemaker.keycloakOrganizationId,
+			});
+		});
+
+		describe('DELETE /', () => {
+			it('returns 401 if the request lacks authentication', async () => {
+				const organizationAsChangemaker = await createChangemaker(db, null, {
+					taxId: '11-1111111',
+					name: 'Example Inc.',
+					keycloakOrganizationId: mockKeycloakOrganizationId,
+				});
+				const changemaker = await createChangemaker(db, null, {
+					taxId: '11-1111112',
+					name: 'Example Inc.',
+					keycloakOrganizationId: null,
+				});
+				await request(app)
+					.delete(
+						`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/${changemaker.id}/permissions/${Permission.MANAGE}`,
+					)
+					.send()
+					.expect(401);
+			});
+
+			it('returns 401 if the authenticated user lacks permission', async () => {
+				const organizationAsChangemaker = await createChangemaker(db, null, {
+					taxId: '11-1111111',
+					name: 'Example Inc.',
+					keycloakOrganizationId: mockKeycloakOrganizationId,
+				});
+				const changemaker = await createChangemaker(db, null, {
+					taxId: '11-1111112',
+					name: 'Example Inc.',
+					keycloakOrganizationId: null,
+				});
+				await request(app)
+					.delete(
+						`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/${changemaker.id}/permissions/${Permission.MANAGE}`,
+					)
+					.set(authHeader)
+					.send()
+					.expect(401);
+			});
+
+			it('returns 400 if the userId is not a valid keycloak user ID', async () => {
+				await request(app)
+					.delete(
+						`/userGroups/notaguid/changemakers/1/permissions/${Permission.MANAGE}`,
+					)
+					.set(authHeaderWithAdminRole)
+					.send()
+					.expect(400);
+			});
+
+			it('returns 400 if the changemaker ID is not a valid ID', async () => {
+				const organizationAsChangemaker = await createChangemaker(db, null, {
+					taxId: '11-1111111',
+					name: 'Example Inc.',
+					keycloakOrganizationId: mockKeycloakOrganizationId,
+				});
+				await request(app)
+					.delete(
+						`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/notanId/permissions/${Permission.MANAGE}`,
+					)
+					.set(authHeaderWithAdminRole)
+					.send()
+					.expect(400);
+			});
+
+			it('returns 400 if the permission is not a valid permission', async () => {
+				const user = await loadTestUser();
+				await request(app)
+					.delete(
+						`/userGroups/${keycloakIdToString(user.keycloakUserId)}/changemakers/1/permissions/notAPermission`,
+					)
+					.set(authHeaderWithAdminRole)
+					.send()
+					.expect(400);
+			});
+
+			it('returns 404 if the permission does not exist', async () => {
+				const organizationAsChangemaker = await createChangemaker(db, null, {
+					taxId: '11-1111111',
+					name: 'Example Inc.',
+					keycloakOrganizationId: mockKeycloakOrganizationId,
+				});
+				const changemaker = await createChangemaker(db, null, {
+					taxId: '11-1111112',
+					name: 'Example Inc.',
+					keycloakOrganizationId: null,
+				});
+				await request(app)
+					.delete(
+						`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/${changemaker.id}/permissions/${Permission.MANAGE}`,
+					)
+					.set(authHeaderWithAdminRole)
+					.send()
+					.expect(404);
+			});
+
+			it('returns 404 if the permission had existed and previously been deleted', async () => {
+				const user = await loadTestUser();
+				const organizationAsChangemaker = await createChangemaker(db, null, {
+					taxId: '11-1111111',
+					name: 'Example Inc.',
+					keycloakOrganizationId: mockKeycloakOrganizationId,
+				});
+				const changemaker = await createChangemaker(db, null, {
+					taxId: '11-1111112',
+					name: 'Example Inc.',
+					keycloakOrganizationId: null,
+				});
+				await createOrUpdateUserGroupChangemakerPermission(db, null, {
+					keycloakOrganizationId:
+						organizationAsChangemaker.keycloakOrganizationId as KeycloakId,
+					changemakerId: changemaker.id,
+					permission: Permission.EDIT,
+					createdBy: user.keycloakUserId,
+				});
+				await removeUserGroupChangemakerPermission(
+					organizationAsChangemaker.keycloakOrganizationId as KeycloakId,
+					changemaker.id,
+					Permission.EDIT,
+				);
+				await request(app)
+					.delete(
+						`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/${changemaker.id}/permissions/${Permission.EDIT}`,
+					)
+					.set(authHeaderWithAdminRole)
+					.send()
+					.expect(404);
+			});
+
+			it('deletes the userGroup changemaker permission when the user has administrative credentials', async () => {
+				const user = await loadTestUser();
+				const organizationAsChangemaker = await createChangemaker(db, null, {
+					taxId: '11-1111111',
+					name: 'Example Inc.',
+					keycloakOrganizationId: mockKeycloakOrganizationId,
+				});
+				const changemaker = await createChangemaker(db, null, {
+					taxId: '11-1111112',
+					name: 'Example Inc.',
+					keycloakOrganizationId: null,
+				});
+				await createOrUpdateUserGroupChangemakerPermission(db, null, {
+					keycloakOrganizationId:
+						organizationAsChangemaker.keycloakOrganizationId as KeycloakId,
+					changemakerId: changemaker.id,
+					permission: Permission.EDIT,
+					createdBy: user.keycloakUserId,
+				});
+				const permission = await loadUserGroupChangemakerPermission(
+					db,
+					null,
+					organizationAsChangemaker.keycloakOrganizationId as KeycloakId,
+					changemaker.id,
+					Permission.EDIT,
+				);
+				expect(permission).toEqual({
+					changemakerId: changemaker.id,
+					createdAt: expectTimestamp,
+					createdBy: user.keycloakUserId,
+					permission: Permission.EDIT,
+					keycloakOrganizationId:
+						organizationAsChangemaker.keycloakOrganizationId,
+				});
+				await request(app)
+					.delete(
+						`/userGroups/${keycloakIdToString(organizationAsChangemaker.keycloakOrganizationId as KeycloakId)}/changemakers/${changemaker.id}/permissions/${Permission.EDIT}`,
+					)
+					.set(authHeaderWithAdminRole)
+					.send()
+					.expect(204);
+				await expect(
+					loadUserGroupChangemakerPermission(
+						db,
+						null,
+						user.keycloakUserId,
+						changemaker.id,
+						Permission.EDIT,
+					),
+				).rejects.toThrow(NotFoundError);
+			});
+		});
+	});
+});

--- a/src/__tests__/userGroupDataProviderPermissions.int.test.ts
+++ b/src/__tests__/userGroupDataProviderPermissions.int.test.ts
@@ -1,0 +1,302 @@
+import request from 'supertest';
+import { app } from '../app';
+import {
+	db,
+	createOrUpdateDataProvider,
+	createOrUpdateUserGroupDataProviderPermission,
+	loadUserGroupDataProviderPermission,
+	removeUserGroupDataProviderPermission,
+} from '../database';
+import { expectTimestamp, loadTestUser } from '../test/utils';
+import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
+} from '../test/mockJwt';
+import { KeycloakId, keycloakIdToString, Permission } from '../types';
+import { NotFoundError } from '../errors';
+
+const mockKeycloakOrganizationId = '123e4567-e89b-12d3-a456-426614174000';
+
+describe('/userGroups/dataProviders/:dataProviderShortCode/permissions/:permission', () => {
+	describe('PUT /', () => {
+		it('returns 401 if the request lacks authentication', async () => {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 401 if the authenticated user lacks permission', async () => {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 400 if the organizationKeycloakId is not a valid keycloak organization ID', async () => {
+			await request(app)
+				.put(
+					`/userGroups/notaguid/dataProviders/ExampleInc/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the data provider shortCode is not a valid short code', async () => {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/this is not valid/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the permission is not a valid permission', async () => {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/ExampleInc/permissions/notAPermission`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('creates and returns the new userGroup data provider permission when user has administrative credentials', async () => {
+			const user = await loadTestUser();
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+
+			const response = await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				dataProviderShortCode: dataProvider.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				keycloakOrganizationId:
+					dataProvider.keycloakOrganizationId as KeycloakId,
+			});
+		});
+	});
+
+	describe('DELETE /', () => {
+		it('returns 401 if the request lacks authentication', async () => {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.send()
+				.expect(401);
+		});
+
+		it('returns 401 if the authenticated user lacks permission', async () => {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send()
+				.expect(401);
+		});
+
+		it('returns 400 if the organizationKeycloakId is not a valid keycloak organization ID', async () => {
+			await request(app)
+				.delete(
+					`/userGroups/notaguid/dataProviders/ExampleInc/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(400);
+		});
+
+		it('returns 400 if the data provider shortCode is not a valid short code', async () => {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/this is not valid/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(400);
+		});
+
+		it('returns 400 if the permission is not a valid permission', async () => {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/ExampleInc/permissions/notAPermission`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(400);
+		});
+
+		it('returns 404 if the permission does not exist', async () => {
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(404);
+		});
+
+		it('returns 404 if the permission had existed and previously been deleted', async () => {
+			const user = await loadTestUser();
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await createOrUpdateUserGroupDataProviderPermission(db, null, {
+				keycloakOrganizationId:
+					dataProvider.keycloakOrganizationId as KeycloakId,
+				dataProviderShortCode: dataProvider.shortCode,
+				permission: Permission.EDIT,
+				createdBy: user.keycloakUserId,
+			});
+			await removeUserGroupDataProviderPermission(
+				dataProvider.keycloakOrganizationId as KeycloakId,
+				dataProvider.shortCode,
+				Permission.EDIT,
+			);
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(404);
+		});
+
+		it('deletes the userGroup data provider permission when the user has administrative credentials', async () => {
+			const user = await loadTestUser();
+			const dataProvider = await createOrUpdateDataProvider(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await createOrUpdateUserGroupDataProviderPermission(db, null, {
+				keycloakOrganizationId:
+					dataProvider.keycloakOrganizationId as KeycloakId,
+				dataProviderShortCode: dataProvider.shortCode,
+				permission: Permission.EDIT,
+				createdBy: user.keycloakUserId,
+			});
+			const permission = await loadUserGroupDataProviderPermission(
+				db,
+				null,
+				dataProvider.keycloakOrganizationId as KeycloakId,
+				dataProvider.shortCode,
+				Permission.EDIT,
+			);
+			expect(permission).toEqual({
+				dataProviderShortCode: dataProvider.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						dataProvider.keycloakOrganizationId as KeycloakId,
+					)}/dataProviders/${dataProvider.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(204);
+			await expect(
+				loadUserGroupDataProviderPermission(
+					db,
+					null,
+					dataProvider.keycloakOrganizationId as KeycloakId,
+					dataProvider.shortCode,
+					Permission.EDIT,
+				),
+			).rejects.toThrow(NotFoundError);
+		});
+	});
+});

--- a/src/__tests__/userGroupFunderPermissions.int.test.ts
+++ b/src/__tests__/userGroupFunderPermissions.int.test.ts
@@ -1,0 +1,299 @@
+import request from 'supertest';
+import { app } from '../app';
+import {
+	db,
+	createOrUpdateFunder,
+	createOrUpdateUserGroupFunderPermission,
+	loadUserGroupFunderPermission,
+	removeUserGroupFunderPermission,
+} from '../database';
+import { expectTimestamp, loadTestUser } from '../test/utils';
+import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
+} from '../test/mockJwt';
+import { keycloakIdToString, Permission, KeycloakId } from '../types';
+import { NotFoundError } from '../errors';
+
+const mockKeycloakOrganizationId = '123e4567-e89b-12d3-a456-426614174000';
+
+describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
+	describe('PUT /', () => {
+		it('returns 401 if the request lacks authentication', async () => {
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 401 if the authenticated user lacks permission', async () => {
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send({})
+				.expect(401);
+		});
+
+		it('returns 400 if the organizationKeycloakId is not a valid keycloak organization ID', async () => {
+			await request(app)
+				.put(
+					`/userGroups/notaguid/funders/ExampleInc/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the funder shortCode is not a valid short code', async () => {
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/this is not valid/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('returns 400 if the permission is not a valid permission', async () => {
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+
+			await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/notAPermission`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+		});
+
+		it('creates and returns the new userGroup funder permission when user has administrative credentials', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+
+			const response = await request(app)
+				.put(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(201);
+			expect(response.body).toEqual({
+				funderShortCode: funder.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				keycloakOrganizationId: funder.keycloakOrganizationId as KeycloakId,
+			});
+		});
+	});
+
+	describe('DELETE /', () => {
+		it('returns 401 if the request lacks authentication', async () => {
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.send()
+				.expect(401);
+		});
+
+		it('returns 401 if the authenticated user lacks permission', async () => {
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeader)
+				.send()
+				.expect(401);
+		});
+
+		it('returns 400 if the organizationKeycloakId is not a valid keycloak organization ID', async () => {
+			await request(app)
+				.delete(
+					`/userGroups/notaguid/funders/ExampleInc/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(400);
+		});
+
+		it('returns 400 if the funder shortCode is not a valid short code', async () => {
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/this is not valid/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(400);
+		});
+
+		it('returns 400 if the permission is not a valid permission', async () => {
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/notAPermission`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(400);
+		});
+
+		it('returns 404 if the permission does not exist', async () => {
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/${Permission.MANAGE}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(404);
+		});
+
+		it('returns 404 if the permission had existed and previously been deleted', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await createOrUpdateUserGroupFunderPermission(db, null, {
+				keycloakOrganizationId: funder.keycloakOrganizationId as KeycloakId,
+				funderShortCode: funder.shortCode,
+				permission: Permission.EDIT,
+				createdBy: user.keycloakUserId,
+			});
+			await removeUserGroupFunderPermission(
+				funder.keycloakOrganizationId as KeycloakId,
+				funder.shortCode,
+				Permission.EDIT,
+			);
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(404);
+		});
+
+		it('deletes the userGroup funder permission when the user has administrative credentials', async () => {
+			const user = await loadTestUser();
+			const funder = await createOrUpdateFunder(db, null, {
+				shortCode: 'ExampleInc',
+				name: 'Example Inc.',
+				keycloakOrganizationId: mockKeycloakOrganizationId,
+			});
+			await createOrUpdateUserGroupFunderPermission(db, null, {
+				keycloakOrganizationId: funder.keycloakOrganizationId as KeycloakId,
+				funderShortCode: funder.shortCode,
+				permission: Permission.EDIT,
+				createdBy: user.keycloakUserId,
+			});
+			const permission = await loadUserGroupFunderPermission(
+				db,
+				null,
+				funder.keycloakOrganizationId as KeycloakId,
+				funder.shortCode,
+				Permission.EDIT,
+			);
+			expect(permission).toEqual({
+				funderShortCode: funder.shortCode,
+				createdAt: expectTimestamp,
+				createdBy: user.keycloakUserId,
+				permission: Permission.EDIT,
+				keycloakOrganizationId: funder.keycloakOrganizationId as KeycloakId,
+			});
+			await request(app)
+				.delete(
+					`/userGroups/${keycloakIdToString(
+						funder.keycloakOrganizationId as KeycloakId,
+					)}/funders/${funder.shortCode}/permissions/${Permission.EDIT}`,
+				)
+				.set(authHeaderWithAdminRole)
+				.send()
+				.expect(204);
+			await expect(
+				loadUserGroupFunderPermission(
+					db,
+					null,
+					funder.keycloakOrganizationId as KeycloakId,
+					funder.shortCode,
+					Permission.EDIT,
+				),
+			).rejects.toThrow(NotFoundError);
+		});
+	});
+});

--- a/src/database/initialization/user_group_changemaker_permission_to_json.sql
+++ b/src/database/initialization/user_group_changemaker_permission_to_json.sql
@@ -1,0 +1,16 @@
+SELECT drop_function('user_group_changemaker_permission_to_json');
+
+CREATE FUNCTION user_group_changemaker_permission_to_json(
+	user_group_changemaker_permission user_group_changemaker_permissions
+)
+RETURNS jsonb AS $$
+BEGIN
+  RETURN jsonb_build_object(
+    'keycloakOrganizationId', user_group_changemaker_permission.keycloak_organization_id,
+    'changemakerId', user_group_changemaker_permission.changemaker_id,
+    'permission', user_group_changemaker_permission.permission,
+    'createdBy', user_group_changemaker_permission.created_by,
+    'createdAt', user_group_changemaker_permission.created_at
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/initialization/user_group_data_provider_permission_to_json.sql
+++ b/src/database/initialization/user_group_data_provider_permission_to_json.sql
@@ -1,0 +1,16 @@
+SELECT drop_function('user_group_data_provider_permission_to_json');
+
+CREATE FUNCTION user_group_data_provider_permission_to_json(
+	user_group_data_provider_permission user_group_data_provider_permissions
+)
+RETURNS jsonb AS $$
+BEGIN
+  RETURN jsonb_build_object(
+    'keycloakOrganizationId', user_group_data_provider_permission.keycloak_organization_id,
+    'dataProviderShortCode', user_group_data_provider_permission.data_provider_short_code,
+    'permission', user_group_data_provider_permission.permission,
+    'createdBy', user_group_data_provider_permission.created_by,
+    'createdAt', user_group_data_provider_permission.created_at
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/initialization/user_group_funder_permission_to_json.sql
+++ b/src/database/initialization/user_group_funder_permission_to_json.sql
@@ -1,0 +1,16 @@
+SELECT drop_function('user_group_funder_permission_to_json');
+
+CREATE FUNCTION user_group_funder_permission_to_json(
+	user_group_funder_permission user_group_funder_permissions
+)
+RETURNS jsonb AS $$
+BEGIN
+  RETURN jsonb_build_object(
+    'keycloakOrganizationId', user_group_funder_permission.keycloak_organization_id,
+    'funderShortCode', user_group_funder_permission.funder_short_code,
+    'permission', user_group_funder_permission.permission,
+    'createdBy', user_group_funder_permission.created_by,
+    'createdAt', user_group_funder_permission.created_at
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/migrations/0047-create-user-group-changemaker-permissions.sql
+++ b/src/database/migrations/0047-create-user-group-changemaker-permissions.sql
@@ -1,0 +1,9 @@
+CREATE TABLE user_group_changemaker_permissions (
+	keycloak_organization_id uuid NOT NULL,
+	changemaker_id int NOT NULL REFERENCES changemakers (id) ON DELETE CASCADE,
+	permission permission_t NOT NULL,
+	created_by uuid NOT NULL REFERENCES users (keycloak_user_id) ON DELETE CASCADE,
+	created_at timestamp with time zone NOT NULL DEFAULT now(),
+	not_after timestamp with time zone DEFAULT NULL,
+	PRIMARY KEY (keycloak_organization_id, changemaker_id, permission)
+);

--- a/src/database/migrations/0048-create-user-group-data-provider-permission.sql
+++ b/src/database/migrations/0048-create-user-group-data-provider-permission.sql
@@ -1,0 +1,11 @@
+CREATE TABLE user_group_data_provider_permissions (
+	keycloak_organization_id uuid NOT NULL,
+	data_provider_short_code short_code_t NOT NULL REFERENCES data_providers (
+		short_code
+	) ON DELETE CASCADE,
+	permission permission_t NOT NULL,
+	created_by uuid NOT NULL REFERENCES users (keycloak_user_id) ON DELETE CASCADE,
+	created_at timestamp with time zone NOT NULL DEFAULT now(),
+	not_after timestamp with time zone DEFAULT NULL,
+	PRIMARY KEY (keycloak_organization_id, data_provider_short_code, permission)
+);

--- a/src/database/migrations/0049-create-user-group-funder-permissions.sql
+++ b/src/database/migrations/0049-create-user-group-funder-permissions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE user_group_funder_permissions (
+	keycloak_organization_id uuid NOT NULL,
+	funder_short_code short_code_t NOT NULL REFERENCES funders (
+		short_code
+	) ON DELETE CASCADE,
+	permission permission_t NOT NULL,
+	created_by uuid NOT NULL REFERENCES users (keycloak_user_id) ON DELETE CASCADE,
+	created_at timestamp with time zone NOT NULL DEFAULT now(),
+	not_after timestamp with time zone DEFAULT NULL,
+	PRIMARY KEY (keycloak_organization_id, funder_short_code, permission)
+);

--- a/src/database/operations/index.ts
+++ b/src/database/operations/index.ts
@@ -19,4 +19,5 @@ export * from './userDataProviderPermissions';
 export * from './userFunderPermissions';
 export * from './userGroupChangemakerPermissions';
 export * from './userGroupDataProviderPermissions';
+export * from './userGroupFunderPermissions';
 export * from './users';

--- a/src/database/operations/index.ts
+++ b/src/database/operations/index.ts
@@ -18,4 +18,5 @@ export * from './userChangemakerPermissions';
 export * from './userDataProviderPermissions';
 export * from './userFunderPermissions';
 export * from './userGroupChangemakerPermissions';
+export * from './userGroupDataProviderPermissions';
 export * from './users';

--- a/src/database/operations/index.ts
+++ b/src/database/operations/index.ts
@@ -17,4 +17,5 @@ export * from './sources';
 export * from './userChangemakerPermissions';
 export * from './userDataProviderPermissions';
 export * from './userFunderPermissions';
+export * from './userGroupChangemakerPermissions';
 export * from './users';

--- a/src/database/operations/userGroupChangemakerPermissions/assertUserGroupChangemakerPermissionExists.ts
+++ b/src/database/operations/userGroupChangemakerPermissions/assertUserGroupChangemakerPermissionExists.ts
@@ -1,0 +1,32 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import type { CheckResult, Id, KeycloakId, Permission } from '../../../types';
+
+const assertUserGroupChangemakerPermissionExists = async (
+	keycloakOrganizationId: KeycloakId,
+	changemakerId: Id,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql<CheckResult>(
+		'userGroupChangemakerPermissions.checkExistsByPrimaryKey',
+		{
+			keycloakOrganizationId,
+			changemakerId,
+			permission,
+		},
+	);
+
+	if (result.rows[0]?.result !== true) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'UserGroupChangemakerPermission',
+			entityPrimaryKey: {
+				keycloakOrganizationId: keycloakIdToString(keycloakOrganizationId),
+				changemakerId,
+				permission,
+			},
+		});
+	}
+};
+
+export { assertUserGroupChangemakerPermissionExists };

--- a/src/database/operations/userGroupChangemakerPermissions/createOrUpdateUserGroupChangemakerPermission.ts
+++ b/src/database/operations/userGroupChangemakerPermissions/createOrUpdateUserGroupChangemakerPermission.ts
@@ -1,0 +1,18 @@
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type {
+	InternallyWritableUserGroupChangemakerPermission,
+	UserGroupChangemakerPermission,
+} from '../../../types';
+
+const createOrUpdateUserGroupChangemakerPermission =
+	generateCreateOrUpdateItemOperation<
+		UserGroupChangemakerPermission,
+		InternallyWritableUserGroupChangemakerPermission,
+		[]
+	>(
+		'userGroupChangemakerPermissions.insertOrUpdateOne',
+		['keycloakOrganizationId', 'permission', 'changemakerId', 'createdBy'],
+		[],
+	);
+
+export { createOrUpdateUserGroupChangemakerPermission };

--- a/src/database/operations/userGroupChangemakerPermissions/index.ts
+++ b/src/database/operations/userGroupChangemakerPermissions/index.ts
@@ -1,0 +1,4 @@
+export * from './assertUserGroupChangemakerPermissionExists';
+export * from './createOrUpdateUserGroupChangemakerPermission';
+export * from './loadUserGroupChangemakerPermission';
+export * from './removeUserGroupChangemakerPermission';

--- a/src/database/operations/userGroupChangemakerPermissions/loadUserGroupChangemakerPermission.ts
+++ b/src/database/operations/userGroupChangemakerPermissions/loadUserGroupChangemakerPermission.ts
@@ -1,0 +1,22 @@
+import { generateLoadItemOperation } from '../generators';
+import type {
+	Id,
+	KeycloakId,
+	Permission,
+	UserGroupChangemakerPermission,
+} from '../../../types';
+
+const loadUserGroupChangemakerPermission = generateLoadItemOperation<
+	UserGroupChangemakerPermission,
+	[
+		keycloakOrganizationId: KeycloakId,
+		changemakerId: Id,
+		permission: Permission,
+	]
+>(
+	'userGroupChangemakerPermissions.selectByPrimaryKey',
+	'UserGroupChangemakerPermission',
+	['keycloakOrganizationId', 'changemakerId', 'permission'],
+);
+
+export { loadUserGroupChangemakerPermission };

--- a/src/database/operations/userGroupChangemakerPermissions/removeUserGroupChangemakerPermission.ts
+++ b/src/database/operations/userGroupChangemakerPermissions/removeUserGroupChangemakerPermission.ts
@@ -1,0 +1,32 @@
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import { db } from '../../db';
+import type { KeycloakId, Permission } from '../../../types';
+
+const removeUserGroupChangemakerPermission = async (
+	keycloakOrganizationId: KeycloakId,
+	changemakerId: number,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql('userGroupChangemakerPermissions.deleteOne', {
+		keycloakOrganizationId,
+		permission,
+		changemakerId,
+	});
+
+	if (result.row_count === 0) {
+		throw new NotFoundError(
+			'The item did not exist and could not be deleted.',
+			{
+				entityType: 'UserGroupChangemakerPermission',
+				entityPrimaryKey: {
+					keycloakOrganizationId: keycloakIdToString(keycloakOrganizationId),
+					permission,
+					changemakerId,
+				},
+			},
+		);
+	}
+};
+
+export { removeUserGroupChangemakerPermission };

--- a/src/database/operations/userGroupDataProviderPermissions/assertUserGroupDataProviderPermissionExists.ts
+++ b/src/database/operations/userGroupDataProviderPermissions/assertUserGroupDataProviderPermissionExists.ts
@@ -1,0 +1,37 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import type {
+	CheckResult,
+	KeycloakId,
+	Permission,
+	ShortCode,
+} from '../../../types';
+
+const assertUserGroupDataProviderPermissionExists = async (
+	keycloakOrganizationId: KeycloakId,
+	dataProviderShortCode: ShortCode,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql<CheckResult>(
+		'userGroupDataProviderPermissions.checkExistsByPrimaryKey',
+		{
+			keycloakOrganizationId,
+			dataProviderShortCode,
+			permission,
+		},
+	);
+
+	if (result.rows[0]?.result !== true) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'UserGroupDataProviderPermission',
+			entityPrimaryKey: {
+				keycloakorganizationId: keycloakIdToString(keycloakOrganizationId),
+				dataProviderShortCode,
+				permission,
+			},
+		});
+	}
+};
+
+export { assertUserGroupDataProviderPermissionExists };

--- a/src/database/operations/userGroupDataProviderPermissions/createOrUpdateUserGroupDataProviderPermission.ts
+++ b/src/database/operations/userGroupDataProviderPermissions/createOrUpdateUserGroupDataProviderPermission.ts
@@ -1,0 +1,23 @@
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type {
+	UserGroupDataProviderPermission,
+	InternallyWritableUserGroupDataProviderPermission,
+} from '../../../types';
+
+const createOrUpdateUserGroupDataProviderPermission =
+	generateCreateOrUpdateItemOperation<
+		UserGroupDataProviderPermission,
+		InternallyWritableUserGroupDataProviderPermission,
+		[]
+	>(
+		'userGroupDataProviderPermissions.insertOrUpdateOne',
+		[
+			'keycloakOrganizationId',
+			'permission',
+			'dataProviderShortCode',
+			'createdBy',
+		],
+		[],
+	);
+
+export { createOrUpdateUserGroupDataProviderPermission };

--- a/src/database/operations/userGroupDataProviderPermissions/index.ts
+++ b/src/database/operations/userGroupDataProviderPermissions/index.ts
@@ -1,0 +1,4 @@
+export * from './assertUserGroupDataProviderPermissionExists';
+export * from './createOrUpdateUserGroupDataProviderPermission';
+export * from './loadUserGroupDataProviderPermission';
+export * from './removeUserGroupDataProviderPermission';

--- a/src/database/operations/userGroupDataProviderPermissions/loadUserGroupDataProviderPermission.ts
+++ b/src/database/operations/userGroupDataProviderPermissions/loadUserGroupDataProviderPermission.ts
@@ -1,0 +1,22 @@
+import { generateLoadItemOperation } from '../generators';
+import type {
+	KeycloakId,
+	Permission,
+	ShortCode,
+	UserGroupDataProviderPermission,
+} from '../../../types';
+
+const loadUserGroupDataProviderPermission = generateLoadItemOperation<
+	UserGroupDataProviderPermission,
+	[
+		keycloakOrganizationId: KeycloakId,
+		dataProviderShortCode: ShortCode,
+		permission: Permission,
+	]
+>(
+	'userGroupDataProviderPermissions.selectByPrimaryKey',
+	'UserGroupDataProviderPermission',
+	['keycloakOrganizationId', 'dataProviderShortCode', 'permission'],
+);
+
+export { loadUserGroupDataProviderPermission };

--- a/src/database/operations/userGroupDataProviderPermissions/removeUserGroupDataProviderPermission.ts
+++ b/src/database/operations/userGroupDataProviderPermissions/removeUserGroupDataProviderPermission.ts
@@ -1,0 +1,32 @@
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import { db } from '../../db';
+import type { KeycloakId, Permission, ShortCode } from '../../../types';
+
+const removeUserGroupDataProviderPermission = async (
+	keycloakOrganizationId: KeycloakId,
+	dataProviderShortCode: ShortCode,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql('userGroupDataProviderPermissions.deleteOne', {
+		keycloakOrganizationId,
+		dataProviderShortCode,
+		permission,
+	});
+
+	if (result.row_count === 0) {
+		throw new NotFoundError(
+			'The item did not exist and could not be deleted.',
+			{
+				entityType: 'UserGroupDataProviderPermission',
+				entityPrimaryKey: {
+					keycloakOrganizationId: keycloakIdToString(keycloakOrganizationId),
+					dataProviderShortCode,
+					permission,
+				},
+			},
+		);
+	}
+};
+
+export { removeUserGroupDataProviderPermission };

--- a/src/database/operations/userGroupFunderPermissions/assertUserGroupFunderPermissionExists.ts
+++ b/src/database/operations/userGroupFunderPermissions/assertUserGroupFunderPermissionExists.ts
@@ -1,0 +1,37 @@
+import { db } from '../../db';
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import type {
+	CheckResult,
+	KeycloakId,
+	Permission,
+	ShortCode,
+} from '../../../types';
+
+const assertUserGroupFunderPermissionExists = async (
+	keycloakOrganizationId: KeycloakId,
+	funderShortCode: ShortCode,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql<CheckResult>(
+		'userGroupFunderPermissions.checkExistsByPrimaryKey',
+		{
+			keycloakOrganizationId,
+			funderShortCode,
+			permission,
+		},
+	);
+
+	if (result.rows[0]?.result !== true) {
+		throw new NotFoundError(`Entity not found`, {
+			entityType: 'UserGroupFunderPermission',
+			entityPrimaryKey: {
+				keycloakOrganizationId: keycloakIdToString(keycloakOrganizationId),
+				funderShortCode,
+				permission,
+			},
+		});
+	}
+};
+
+export { assertUserGroupFunderPermissionExists };

--- a/src/database/operations/userGroupFunderPermissions/createOrUpdateUserGroupFunderPermission.ts
+++ b/src/database/operations/userGroupFunderPermissions/createOrUpdateUserGroupFunderPermission.ts
@@ -1,0 +1,18 @@
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type {
+	UserGroupFunderPermission,
+	InternallyWritableUserGroupFunderPermission,
+} from '../../../types';
+
+const createOrUpdateUserGroupFunderPermission =
+	generateCreateOrUpdateItemOperation<
+		UserGroupFunderPermission,
+		InternallyWritableUserGroupFunderPermission,
+		[]
+	>(
+		'userGroupFunderPermissions.insertOrUpdateOne',
+		['keycloakOrganizationId', 'permission', 'funderShortCode', 'createdBy'],
+		[],
+	);
+
+export { createOrUpdateUserGroupFunderPermission };

--- a/src/database/operations/userGroupFunderPermissions/index.ts
+++ b/src/database/operations/userGroupFunderPermissions/index.ts
@@ -1,0 +1,4 @@
+export * from './assertUserGroupFunderPermissionExists';
+export * from './createOrUpdateUserGroupFunderPermission';
+export * from './loadUserGroupFunderPermission';
+export * from './removeUserGroupFunderPermission';

--- a/src/database/operations/userGroupFunderPermissions/loadUserGroupFunderPermission.ts
+++ b/src/database/operations/userGroupFunderPermissions/loadUserGroupFunderPermission.ts
@@ -1,0 +1,22 @@
+import { generateLoadItemOperation } from '../generators';
+import type {
+	KeycloakId,
+	Permission,
+	ShortCode,
+	UserGroupFunderPermission,
+} from '../../../types';
+
+const loadUserGroupFunderPermission = generateLoadItemOperation<
+	UserGroupFunderPermission,
+	[
+		keycloakOrganizationId: KeycloakId,
+		funderShortCode: ShortCode,
+		permission: Permission,
+	]
+>(
+	'userGroupFunderPermissions.selectByPrimaryKey',
+	'UserGroupFunderPermission',
+	['keycloakOrganizationId', 'funderShortCode', 'permission'],
+);
+
+export { loadUserGroupFunderPermission };

--- a/src/database/operations/userGroupFunderPermissions/removeUserGroupFunderPermission.ts
+++ b/src/database/operations/userGroupFunderPermissions/removeUserGroupFunderPermission.ts
@@ -1,0 +1,32 @@
+import { NotFoundError } from '../../../errors';
+import { keycloakIdToString } from '../../../types';
+import { db } from '../../db';
+import type { KeycloakId, Permission, ShortCode } from '../../../types';
+
+const removeUserGroupFunderPermission = async (
+	keycloakOrganizationId: KeycloakId,
+	funderShortCode: ShortCode,
+	permission: Permission,
+): Promise<void> => {
+	const result = await db.sql('userGroupFunderPermissions.deleteOne', {
+		keycloakOrganizationId,
+		funderShortCode,
+		permission,
+	});
+
+	if (result.row_count === 0) {
+		throw new NotFoundError(
+			'The item did not exist and could not be deleted.',
+			{
+				entityType: 'UserGroupFunderPermission',
+				entityPrimaryKey: {
+					keycloakOrganizationId: keycloakIdToString(keycloakOrganizationId),
+					funderShortCode,
+					permission,
+				},
+			},
+		);
+	}
+};
+
+export { removeUserGroupFunderPermission };

--- a/src/database/queries/userGroupChangemakerPermissions/checkExistsByPrimaryKey.sql
+++ b/src/database/queries/userGroupChangemakerPermissions/checkExistsByPrimaryKey.sql
@@ -1,0 +1,9 @@
+SELECT exists(
+	SELECT 1
+	FROM user_group_changemaker_permissions
+	WHERE
+		keycloak_organization_id = :keycloakOrganizationId
+		AND changemaker_id = :changemakerId
+		AND permission = :permission
+		AND NOT is_expired(not_after)
+) AS result;

--- a/src/database/queries/userGroupChangemakerPermissions/deleteOne.sql
+++ b/src/database/queries/userGroupChangemakerPermissions/deleteOne.sql
@@ -1,0 +1,7 @@
+UPDATE user_group_changemaker_permissions
+SET not_after = now()
+WHERE
+	keycloak_organization_id = :keycloakOrganizationId
+	AND permission = :permission
+	AND changemaker_id = :changemakerId
+	AND NOT is_expired(not_after);

--- a/src/database/queries/userGroupChangemakerPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userGroupChangemakerPermissions/insertOrUpdateOne.sql
@@ -1,0 +1,20 @@
+INSERT INTO user_group_changemaker_permissions (
+	keycloak_organization_id,
+	permission,
+	changemaker_id,
+	created_by,
+	not_after
+) VALUES (
+	:keycloakOrganizationId,
+	:permission,
+	:changemakerId,
+	:createdBy,
+	null
+)
+ON CONFLICT (keycloak_organization_id, permission, changemaker_id) DO UPDATE
+SET not_after = null
+RETURNING
+	user_group_changemaker_permission_to_json(
+		user_group_changemaker_permissions
+	)
+		AS object;

--- a/src/database/queries/userGroupChangemakerPermissions/selectByPrimaryKey.sql
+++ b/src/database/queries/userGroupChangemakerPermissions/selectByPrimaryKey.sql
@@ -1,0 +1,10 @@
+SELECT
+	user_group_changemaker_permission_to_json(
+		user_group_changemaker_permissions.*
+	) AS object
+FROM user_group_changemaker_permissions
+WHERE
+	keycloak_organization_id = :keycloakOrganizationId
+	AND changemaker_id = :changemakerId
+	AND permission = :permission
+	AND NOT is_expired(not_after);

--- a/src/database/queries/userGroupDataProviderPermissions/checkExistsByPrimaryKey.sql
+++ b/src/database/queries/userGroupDataProviderPermissions/checkExistsByPrimaryKey.sql
@@ -1,0 +1,9 @@
+SELECT exists(
+	SELECT 1
+	FROM user_group_data_provider_permissions
+	WHERE
+		keycloak_organization_id = :keycloakOrganizationId
+		AND data_provider_short_code = :dataProviderShortCode
+		AND permission = :permission
+		AND NOT is_expired(not_after)
+) AS result;

--- a/src/database/queries/userGroupDataProviderPermissions/deleteOne.sql
+++ b/src/database/queries/userGroupDataProviderPermissions/deleteOne.sql
@@ -1,0 +1,7 @@
+UPDATE user_group_data_provider_permissions
+SET not_after = now()
+WHERE
+	keycloak_organization_id = :keycloakOrganizationId
+	AND permission = :permission
+	AND data_provider_short_code = :dataProviderShortCode
+	AND NOT is_expired(not_after);

--- a/src/database/queries/userGroupDataProviderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userGroupDataProviderPermissions/insertOrUpdateOne.sql
@@ -1,0 +1,22 @@
+INSERT INTO user_group_data_provider_permissions (
+	keycloak_organization_id,
+	permission,
+	data_provider_short_code,
+	created_by,
+	not_after
+) VALUES (
+	:keycloakOrganizationId,
+	:permission,
+	:dataProviderShortCode,
+	:createdBy,
+	null
+)
+ON CONFLICT (
+	keycloak_organization_id, permission, data_provider_short_code
+) DO UPDATE
+SET not_after = null
+RETURNING
+	user_group_data_provider_permission_to_json(
+		user_group_data_provider_permissions
+	)
+		AS object;

--- a/src/database/queries/userGroupDataProviderPermissions/selectByPrimaryKey.sql
+++ b/src/database/queries/userGroupDataProviderPermissions/selectByPrimaryKey.sql
@@ -1,0 +1,10 @@
+SELECT
+	user_group_data_provider_permission_to_json(
+		user_group_data_provider_permissions.*
+	) AS object
+FROM user_group_data_provider_permissions
+WHERE
+	keycloak_organization_id = :keycloakOrganizationId
+	AND data_provider_short_code = :dataProviderShortCode
+	AND permission = :permission
+	AND NOT is_expired(not_after);

--- a/src/database/queries/userGroupFunderPermissions/checkExistsByPrimaryKey.sql
+++ b/src/database/queries/userGroupFunderPermissions/checkExistsByPrimaryKey.sql
@@ -1,0 +1,9 @@
+SELECT exists(
+	SELECT 1
+	FROM user_group_funder_permissions
+	WHERE
+		keycloak_organization_id = :keycloakOrganizationId
+		AND funder_short_code = :funderShortCode
+		AND permission = :permission
+		AND NOT is_expired(not_after)
+) AS result;

--- a/src/database/queries/userGroupFunderPermissions/deleteOne.sql
+++ b/src/database/queries/userGroupFunderPermissions/deleteOne.sql
@@ -1,0 +1,7 @@
+UPDATE user_group_funder_permissions
+SET not_after = now()
+WHERE
+	keycloak_organization_id = :keycloakOrganizationId
+	AND permission = :permission
+	AND funder_short_code = :funderShortCode
+	AND NOT is_expired(not_after);

--- a/src/database/queries/userGroupFunderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userGroupFunderPermissions/insertOrUpdateOne.sql
@@ -1,0 +1,18 @@
+INSERT INTO user_group_funder_permissions (
+	keycloak_organization_id,
+	permission,
+	funder_short_code,
+	created_by,
+	not_after
+) VALUES (
+	:keycloakOrganizationId,
+	:permission,
+	:funderShortCode,
+	:createdBy,
+	NULL
+)
+ON CONFLICT (keycloak_organization_id, permission, funder_short_code) DO UPDATE
+SET not_after = NULL
+RETURNING
+	user_group_funder_permission_to_json(user_group_funder_permissions)
+		AS object;

--- a/src/database/queries/userGroupFunderPermissions/selectByPrimaryKey.sql
+++ b/src/database/queries/userGroupFunderPermissions/selectByPrimaryKey.sql
@@ -1,0 +1,10 @@
+SELECT
+	user_group_funder_permission_to_json(
+		user_group_funder_permissions.*
+	) AS object
+FROM user_group_funder_permissions
+WHERE
+	keycloak_organization_id = :keycloakOrganizationId
+	AND funder_short_code = :funderShortCode
+	AND permission = :permission
+	AND NOT is_expired(not_after);

--- a/src/handlers/userGroupChangemakerPermissionsHandlers.ts
+++ b/src/handlers/userGroupChangemakerPermissionsHandlers.ts
@@ -1,0 +1,153 @@
+import {
+	db,
+	assertUserGroupChangemakerPermissionExists,
+	createOrUpdateUserGroupChangemakerPermission,
+	removeUserGroupChangemakerPermission,
+} from '../database';
+import {
+	isAuthContext,
+	isId,
+	isKeycloakId,
+	isPermission,
+	isTinyPgErrorWithQueryContext,
+	isWritableUserGroupChangemakerPermission,
+} from '../types';
+import {
+	DatabaseError,
+	FailedMiddlewareError,
+	InputValidationError,
+} from '../errors';
+import type { Request, Response, NextFunction } from 'express';
+
+const deleteUserGroupChangemakerPermission = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void => {
+	const { keycloakOrganizationId, changemakerId, permission } = req.params;
+	if (!isKeycloakId(keycloakOrganizationId)) {
+		next(
+			new InputValidationError(
+				'Invalid keycloakOrganizationId parameter.',
+				isKeycloakId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isId(changemakerId)) {
+		next(
+			new InputValidationError(
+				'Invalid changemakerId parameter.',
+				isId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isPermission(permission)) {
+		next(
+			new InputValidationError(
+				'Invalid permission parameter.',
+				isPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+
+	(async () => {
+		await assertUserGroupChangemakerPermissionExists(
+			keycloakOrganizationId,
+			changemakerId,
+			permission,
+		);
+		await removeUserGroupChangemakerPermission(
+			keycloakOrganizationId,
+			changemakerId,
+			permission,
+		);
+		res.status(204).contentType('application/json').send();
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error deleting item.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const putUserGroupChangemakerPermission = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
+
+	const { keycloakOrganizationId, changemakerId, permission } = req.params;
+	const createdBy = req.user.keycloakUserId;
+
+	if (!isKeycloakId(keycloakOrganizationId)) {
+		next(
+			new InputValidationError(
+				'Invalid keycloakOrganizationId parameter.',
+				isKeycloakId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isId(changemakerId)) {
+		next(
+			new InputValidationError(
+				'Invalid changemakerId parameter.',
+				isId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isPermission(permission)) {
+		next(
+			new InputValidationError(
+				'Invalid permission parameter.',
+				isPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isWritableUserGroupChangemakerPermission(req.body)) {
+		next(
+			new InputValidationError(
+				'Invalid request body.',
+				isWritableUserGroupChangemakerPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+
+	(async () => {
+		const userGroupChangemakerPermission =
+			await createOrUpdateUserGroupChangemakerPermission(db, null, {
+				keycloakOrganizationId,
+				changemakerId,
+				permission,
+				createdBy,
+			});
+		res
+			.status(201)
+			.contentType('application/json')
+			.send(userGroupChangemakerPermission);
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error creating item.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const userGroupChangemakerPermissionsHandlers = {
+	deleteUserGroupChangemakerPermission,
+	putUserGroupChangemakerPermission,
+};
+
+export { userGroupChangemakerPermissionsHandlers };

--- a/src/handlers/userGroupDataProviderPermissionsHandlers.ts
+++ b/src/handlers/userGroupDataProviderPermissionsHandlers.ts
@@ -1,0 +1,156 @@
+import {
+	db,
+	assertUserGroupDataProviderPermissionExists,
+	createOrUpdateUserGroupDataProviderPermission,
+	removeUserGroupDataProviderPermission,
+} from '../database';
+import {
+	isAuthContext,
+	isId,
+	isKeycloakId,
+	isPermission,
+	isShortCode,
+	isTinyPgErrorWithQueryContext,
+	isWritableUserGroupFunderPermission,
+} from '../types';
+import {
+	DatabaseError,
+	FailedMiddlewareError,
+	InputValidationError,
+} from '../errors';
+import type { Request, Response, NextFunction } from 'express';
+
+const deleteUserGroupDataProviderPermission = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void => {
+	const { keycloakOrganizationId, dataProviderShortCode, permission } =
+		req.params;
+	if (!isKeycloakId(keycloakOrganizationId)) {
+		next(
+			new InputValidationError(
+				'Invalid keycloakOrganizationId parameter.',
+				isKeycloakId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isShortCode(dataProviderShortCode)) {
+		next(
+			new InputValidationError(
+				'Invalid dataProviderShortCode parameter.',
+				isId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isPermission(permission)) {
+		next(
+			new InputValidationError(
+				'Invalid permission parameter.',
+				isPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+
+	(async () => {
+		await assertUserGroupDataProviderPermissionExists(
+			keycloakOrganizationId,
+			dataProviderShortCode,
+			permission,
+		);
+		await removeUserGroupDataProviderPermission(
+			keycloakOrganizationId,
+			dataProviderShortCode,
+			permission,
+		);
+		res.status(204).contentType('application/json').send();
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error deleting item.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const putUserGroupDataProviderPermission = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
+
+	const { keycloakOrganizationId, dataProviderShortCode, permission } =
+		req.params;
+	const createdBy = req.user.keycloakUserId;
+
+	if (!isKeycloakId(keycloakOrganizationId)) {
+		next(
+			new InputValidationError(
+				'Invalid keycloakOrganizationId parameter.',
+				isKeycloakId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isShortCode(dataProviderShortCode)) {
+		next(
+			new InputValidationError(
+				'Invalid dataProviderShortCode parameter.',
+				isId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isPermission(permission)) {
+		next(
+			new InputValidationError(
+				'Invalid permission parameter.',
+				isPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isWritableUserGroupFunderPermission(req.body)) {
+		next(
+			new InputValidationError(
+				'Invalid request body.',
+				isWritableUserGroupFunderPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+
+	(async () => {
+		const userGroupFunderPermission =
+			await createOrUpdateUserGroupDataProviderPermission(db, null, {
+				keycloakOrganizationId,
+				dataProviderShortCode,
+				permission,
+				createdBy,
+			});
+		res
+			.status(201)
+			.contentType('application/json')
+			.send(userGroupFunderPermission);
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error creating item.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const userGroupDataProviderPermissionsHandlers = {
+	deleteUserGroupDataProviderPermission,
+	putUserGroupDataProviderPermission,
+};
+
+export { userGroupDataProviderPermissionsHandlers };

--- a/src/handlers/userGroupFunderPermissionsHandlers.ts
+++ b/src/handlers/userGroupFunderPermissionsHandlers.ts
@@ -1,0 +1,154 @@
+import {
+	db,
+	assertUserGroupFunderPermissionExists,
+	createOrUpdateUserGroupFunderPermission,
+	removeUserGroupFunderPermission,
+} from '../database';
+import {
+	isAuthContext,
+	isId,
+	isKeycloakId,
+	isPermission,
+	isShortCode,
+	isTinyPgErrorWithQueryContext,
+	isWritableUserGroupFunderPermission,
+} from '../types';
+import {
+	DatabaseError,
+	FailedMiddlewareError,
+	InputValidationError,
+} from '../errors';
+import type { Request, Response, NextFunction } from 'express';
+
+const deleteUserGroupFunderPermission = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void => {
+	const { keycloakOrganizationId, funderShortCode, permission } = req.params;
+	if (!isKeycloakId(keycloakOrganizationId)) {
+		next(
+			new InputValidationError(
+				'Invalid keycloakOrganizationId parameter.',
+				isKeycloakId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isShortCode(funderShortCode)) {
+		next(
+			new InputValidationError(
+				'Invalid shortCode parameter.',
+				isId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isPermission(permission)) {
+		next(
+			new InputValidationError(
+				'Invalid permission parameter.',
+				isPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+
+	(async () => {
+		await assertUserGroupFunderPermissionExists(
+			keycloakOrganizationId,
+			funderShortCode,
+			permission,
+		);
+		await removeUserGroupFunderPermission(
+			keycloakOrganizationId,
+			funderShortCode,
+			permission,
+		);
+		res.status(204).contentType('application/json').send();
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error deleting item.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const putUserGroupFunderPermission = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
+
+	const { keycloakOrganizationId, funderShortCode, permission } = req.params;
+	const createdBy = req.user.keycloakUserId;
+
+	if (!isKeycloakId(keycloakOrganizationId)) {
+		next(
+			new InputValidationError(
+				'Invalid keycloakOrganizationId parameter.',
+				isKeycloakId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isShortCode(funderShortCode)) {
+		next(
+			new InputValidationError(
+				'Invalid funderShortCode parameter.',
+				isId.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isPermission(permission)) {
+		next(
+			new InputValidationError(
+				'Invalid permission parameter.',
+				isPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+	if (!isWritableUserGroupFunderPermission(req.body)) {
+		next(
+			new InputValidationError(
+				'Invalid request body.',
+				isWritableUserGroupFunderPermission.errors ?? [],
+			),
+		);
+		return;
+	}
+
+	(async () => {
+		const userGroupFunderPermission =
+			await createOrUpdateUserGroupFunderPermission(db, null, {
+				keycloakOrganizationId,
+				funderShortCode,
+				permission,
+				createdBy,
+			});
+		res
+			.status(201)
+			.contentType('application/json')
+			.send(userGroupFunderPermission);
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error creating item.', error));
+			return;
+		}
+		next(error);
+	});
+};
+
+const userGroupFunderPermissionsHandlers = {
+	deleteUserGroupFunderPermission,
+	putUserGroupFunderPermission,
+};
+
+export { userGroupFunderPermissionsHandlers };

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1378,6 +1378,40 @@
 					}
 				},
 				"required": ["id", "", "createdAt"]
+			"UserGroupDataProviderPermission": {
+				"type": "object",
+				"properties": {
+					"permission": {
+						"$ref": "#/components/schemas/Permission",
+						"readOnly": true
+					},
+					"dataProviderShortcode": {
+						"$ref": "#/components/schemas/shortCode",
+						"readOnly": true
+					},
+					"keycloakOrganizationId": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdBy": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"readOnly": true
+					}
+				},
+				"required": [
+					"id",
+					"dataProviderShortcode",
+					"userKeycloakUserId",
+					"createdBy",
+					"createdAt"
+				]
 			}
 		}
 	},
@@ -3475,6 +3509,106 @@
 				}
 			}
 		},
+		"/userGroups/{keycloakOrganizationId}/dataProviders/{dataProviderShortCode}/permissions/{permission}": {
+			"put": {
+				"operationId": "createOrUpdateUserGroupDataProviderPermission",
+				"summary": "Creates or updates a userGroup data provider permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "keycloakOrganizationId",
+						"description": "The keycloak organization id of an organization.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "dataProviderShortCode",
+						"description": "The shortCode of a data provider.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/shortCode"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be granted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "The resulting permission.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UserGroupDataProviderPermission"
+								}
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "deleteUserGroupDataProviderPermission",
+				"summary": "Deletes a userGroup-data-provider permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "keycloakOrganizationId",
+						"description": "The keycloak organization id of an organization.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "dataProviderShortCode",
+						"description": "The shortCode of a data provider on whose data to grant permission.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/shortCode"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be deleted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Confirmation of successful deletion."
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.16.6",
+		"version": "0.16.7",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"
@@ -1378,6 +1378,42 @@
 					}
 				},
 				"required": ["id", "", "createdAt"]
+			},
+			"UserGroupFunderPermission": {
+				"type": "object",
+				"properties": {
+					"permission": {
+						"$ref": "#/components/schemas/Permission",
+						"readOnly": true
+					},
+					"funderShortcode": {
+						"$ref": "#/components/schemas/shortCode",
+						"readOnly": true
+					},
+					"keycloakOrganizationId": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdBy": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"readOnly": true
+					}
+				},
+				"required": [
+					"permission",
+					"funderShortcode",
+					"userKeycloakUserId",
+					"createdBy",
+					"createdAt"
+				]
+			},
 			"UserGroupDataProviderPermission": {
 				"type": "object",
 				"properties": {
@@ -3489,6 +3525,107 @@
 						"required": true,
 						"schema": {
 							"type": "integer"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be deleted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Confirmation of successful deletion."
+					}
+				}
+			}
+		},
+		"/userGroups/{keycloakOrganizationId}/funders/{funderShortCode}/permissions/{permission}": {
+			"put": {
+				"operationId": "createOrUpdateUserGroupFunderPermission",
+				"summary": "Creates or updates a userGroup funder permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "keycloakOrganizationId",
+						"description": "The keycloak organization id of an organization.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "funderShortCode",
+						"description": "The shortCode of a funder.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/shortCode"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be granted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "The resulting permission.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UserGroupFunderPermission"
+								}
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "deleteUserGroupFunderPermission",
+				"summary": "Deletes a userGroup-funder permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "keycloakOrganizationId",
+						"description": "The keycloak organization id of an organization.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "funderShortCode",
+						"description": "The shortCode of a funder.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/shortCode"
 						}
 					},
 					{

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1349,6 +1349,35 @@
 					"createdBy",
 					"createdAt"
 				]
+			},
+			"UserGroupChangemakerPermission": {
+				"type": "object",
+				"properties": {
+					"permission": {
+						"$ref": "#/components/schemas/Permission",
+						"readOnly": true
+					},
+					"changemakerId": {
+						"type": "integer",
+						"readOnly": true
+					},
+					"keycloakOrganizationId": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdBy": {
+						"type": "string",
+						"format": "uuid",
+						"readOnly": true
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "date-time",
+						"readOnly": true
+					}
+				},
+				"required": ["id", "", "createdAt"]
 			}
 		}
 	},
@@ -3344,6 +3373,108 @@
 					}
 				}
 			}
+		},
+		"/userGroups/{keycloakOrganizationId}/changemakers/{changemakerId}/permissions/{permission}": {
+			"put": {
+				"operationId": "createOrUpdateUserGroupChangemakerPermission",
+				"summary": "Creates or updates a userGroup-changemaker permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "keycloakOrganizationId",
+						"description": "The keycloak organization id of an organization.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "changemakerId",
+						"description": "The id of a changemaker.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be granted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "The resulting permission.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UserGroupChangemakerPermission"
+								}
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "deleteUserGroupChangemakerPermission",
+				"summary": "Deletes a userGroup-changemaker permission.",
+				"tags": ["Permissions"],
+				"security": [
+					{
+						"auth": []
+					}
+				],
+				"parameters": [
+					{
+						"name": "keycloakOrganizationId",
+						"description": "The keycloak organization id of an organization.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					{
+						"name": "changemakerId",
+						"description": "The id of a changemaker.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"name": "permission",
+						"description": "The permission to be deleted.",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": ["manage", "edit", "view"]
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Confirmation of successful deletion."
+					}
+				}
+			}
+		},
 		}
 	}
 }

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -14,6 +14,7 @@ import { sourcesRouter } from './sourcesRouter';
 import { tasksRouter } from './tasksRouter';
 import { usersRouter } from './usersRouter';
 import { documentationRouter } from './documentationRouter';
+import { userGroupsRouter } from './userGroupsRouter';
 
 const rootRouter = express.Router();
 
@@ -25,6 +26,7 @@ rootRouter.use('/changemakerProposals', changemakerProposalsRouter);
 rootRouter.use('/dataProviders', dataProvidersRouter);
 rootRouter.use('/funders', fundersRouter);
 rootRouter.use('/opportunities', opportunitiesRouter);
+rootRouter.use('/userGroups', userGroupsRouter);
 rootRouter.use('/platformProviderResponses', platformProviderResponsesRouter);
 rootRouter.use('/presignedPostRequests', presignedPostRequestsRouter);
 rootRouter.use('/proposals', proposalsRouter);

--- a/src/routers/userGroupsRouter.ts
+++ b/src/routers/userGroupsRouter.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import { userGroupChangemakerPermissionsHandlers } from '../handlers/userGroupChangemakerPermissionsHandlers';
+import {
+	requireChangemakerPermission,
+} from '../middleware';
+import { Permission } from '../types';
+
+const userGroupsRouter = express.Router();
+
+userGroupsRouter.put(
+	'/:keycloakOrganizationId/changemakers/:changemakerId/permissions/:permission',
+	requireChangemakerPermission(Permission.MANAGE),
+	userGroupChangemakerPermissionsHandlers.putUserGroupChangemakerPermission,
+);
+userGroupsRouter.delete(
+	'/:keycloakOrganizationId/changemakers/:changemakerId/permissions/:permission',
+	requireChangemakerPermission(Permission.MANAGE),
+	userGroupChangemakerPermissionsHandlers.deleteUserGroupChangemakerPermission,
+);
+
+export { userGroupsRouter };

--- a/src/routers/userGroupsRouter.ts
+++ b/src/routers/userGroupsRouter.ts
@@ -1,7 +1,9 @@
 import express from 'express';
 import { userGroupChangemakerPermissionsHandlers } from '../handlers/userGroupChangemakerPermissionsHandlers';
+import { userGroupDataProviderPermissionsHandlers } from '../handlers/userGroupDataProviderPermissionsHandlers';
 import {
 	requireChangemakerPermission,
+	requireDataProviderPermission,
 } from '../middleware';
 import { Permission } from '../types';
 
@@ -17,5 +19,14 @@ userGroupsRouter.delete(
 	requireChangemakerPermission(Permission.MANAGE),
 	userGroupChangemakerPermissionsHandlers.deleteUserGroupChangemakerPermission,
 );
-
+userGroupsRouter.put(
+	'/:keycloakOrganizationId/dataProviders/:dataProviderShortCode/permissions/:permission',
+	requireDataProviderPermission(Permission.MANAGE),
+	userGroupDataProviderPermissionsHandlers.putUserGroupDataProviderPermission,
+);
+userGroupsRouter.delete(
+	'/:keycloakOrganizationId/dataProviders/:dataProviderShortCode/permissions/:permission',
+	requireDataProviderPermission(Permission.MANAGE),
+	userGroupDataProviderPermissionsHandlers.deleteUserGroupDataProviderPermission,
+);
 export { userGroupsRouter };

--- a/src/routers/userGroupsRouter.ts
+++ b/src/routers/userGroupsRouter.ts
@@ -1,9 +1,11 @@
 import express from 'express';
 import { userGroupChangemakerPermissionsHandlers } from '../handlers/userGroupChangemakerPermissionsHandlers';
+import { userGroupFunderPermissionsHandlers } from '../handlers/userGroupFunderPermissionsHandlers';
 import { userGroupDataProviderPermissionsHandlers } from '../handlers/userGroupDataProviderPermissionsHandlers';
 import {
 	requireChangemakerPermission,
 	requireDataProviderPermission,
+	requireFunderPermission,
 } from '../middleware';
 import { Permission } from '../types';
 
@@ -29,4 +31,15 @@ userGroupsRouter.delete(
 	requireDataProviderPermission(Permission.MANAGE),
 	userGroupDataProviderPermissionsHandlers.deleteUserGroupDataProviderPermission,
 );
+userGroupsRouter.put(
+	'/:keycloakOrganizationId/funders/:funderShortCode/permissions/:permission',
+	requireFunderPermission(Permission.MANAGE),
+	userGroupFunderPermissionsHandlers.putUserGroupFunderPermission,
+);
+userGroupsRouter.delete(
+	'/:keycloakOrganizationId/funders/:funderShortCode/permissions/:permission',
+	requireFunderPermission(Permission.MANAGE),
+	userGroupFunderPermissionsHandlers.deleteUserGroupFunderPermission,
+);
+
 export { userGroupsRouter };

--- a/src/types/UserGroupChangemakerPermission.ts
+++ b/src/types/UserGroupChangemakerPermission.ts
@@ -1,0 +1,41 @@
+import { ajv } from '../ajv';
+import { Permission } from './Permission';
+import type { JSONSchemaType } from 'ajv';
+import type { Writable } from './Writable';
+import type { KeycloakId } from './KeycloakId';
+
+interface UserGroupChangemakerPermission {
+	readonly keycloakOrganizationId: KeycloakId;
+	readonly changemakerId: number;
+	readonly permission: Permission;
+	readonly createdBy: KeycloakId;
+	readonly createdAt: string;
+}
+
+type WritableUserGroupChangemakerPermission =
+	Writable<UserGroupChangemakerPermission>;
+
+type InternallyWritableUserGroupChangemakerPermission =
+	WritableUserGroupChangemakerPermission &
+		Pick<
+			UserGroupChangemakerPermission,
+			'keycloakOrganizationId' | 'changemakerId' | 'permission' | 'createdBy'
+		>;
+
+const writableUserGroupChangemakerPermissionSchema: JSONSchemaType<WritableUserGroupChangemakerPermission> =
+	{
+		type: 'object',
+		properties: {},
+		required: [],
+	};
+
+const isWritableUserGroupChangemakerPermission = ajv.compile(
+	writableUserGroupChangemakerPermissionSchema,
+);
+
+export {
+	InternallyWritableUserGroupChangemakerPermission,
+	UserGroupChangemakerPermission,
+	WritableUserGroupChangemakerPermission,
+	isWritableUserGroupChangemakerPermission,
+};

--- a/src/types/UserGroupDataProviderPermission.ts
+++ b/src/types/UserGroupDataProviderPermission.ts
@@ -1,0 +1,45 @@
+import { ajv } from '../ajv';
+import { Permission } from './Permission';
+import type { JSONSchemaType } from 'ajv';
+import type { Writable } from './Writable';
+import type { ShortCode } from './ShortCode';
+import type { KeycloakId } from './KeycloakId';
+
+interface UserGroupDataProviderPermission {
+	readonly keycloakOrganizationId: KeycloakId;
+	readonly dataProviderShortCode: ShortCode;
+	readonly permission: Permission;
+	readonly createdBy: KeycloakId;
+	readonly createdAt: string;
+}
+
+type WritableUserGroupDataProviderPermission =
+	Writable<UserGroupDataProviderPermission>;
+
+type InternallyWritableUserGroupDataProviderPermission =
+	WritableUserGroupDataProviderPermission &
+		Pick<
+			UserGroupDataProviderPermission,
+			| 'keycloakOrganizationId'
+			| 'dataProviderShortCode'
+			| 'permission'
+			| 'createdBy'
+		>;
+
+const writableUserGroupDataProviderSchema: JSONSchemaType<WritableUserGroupDataProviderPermission> =
+	{
+		type: 'object',
+		properties: {},
+		required: [],
+	};
+
+const isWritableUserGroupDataProviderPermission = ajv.compile(
+	writableUserGroupDataProviderSchema,
+);
+
+export {
+	InternallyWritableUserGroupDataProviderPermission,
+	UserGroupDataProviderPermission,
+	WritableUserGroupDataProviderPermission,
+	isWritableUserGroupDataProviderPermission,
+};

--- a/src/types/UserGroupFunderPermission.ts
+++ b/src/types/UserGroupFunderPermission.ts
@@ -1,0 +1,41 @@
+import { ajv } from '../ajv';
+import { Permission } from './Permission';
+import type { JSONSchemaType } from 'ajv';
+import type { Writable } from './Writable';
+import type { ShortCode } from './ShortCode';
+import type { KeycloakId } from './KeycloakId';
+
+interface UserGroupFunderPermission {
+	readonly keycloakOrganizationId: KeycloakId;
+	readonly funderShortCode: ShortCode;
+	readonly permission: Permission;
+	readonly createdBy: KeycloakId;
+	readonly createdAt: string;
+}
+
+type WritableUserGroupFunderPermission = Writable<UserGroupFunderPermission>;
+
+type InternallyWritableUserGroupFunderPermission =
+	WritableUserGroupFunderPermission &
+		Pick<
+			UserGroupFunderPermission,
+			'keycloakOrganizationId' | 'permission' | 'funderShortCode' | 'createdBy'
+		>;
+
+const writableUserGroupFunderPermissionSchema: JSONSchemaType<WritableUserGroupFunderPermission> =
+	{
+		type: 'object',
+		properties: {},
+		required: [],
+	};
+
+const isWritableUserGroupFunderPermission = ajv.compile(
+	writableUserGroupFunderPermissionSchema,
+);
+
+export {
+	InternallyWritableUserGroupFunderPermission,
+	UserGroupFunderPermission,
+	WritableUserGroupFunderPermission,
+	isWritableUserGroupFunderPermission,
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,4 +38,5 @@ export * from './User';
 export * from './UserChangemakerPermission';
 export * from './UserDataProviderPermission';
 export * from './UserFunderPermission';
+export * from './UserGroupChangemakerPermission';
 export * from './Uuid';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,4 +39,5 @@ export * from './UserChangemakerPermission';
 export * from './UserDataProviderPermission';
 export * from './UserFunderPermission';
 export * from './UserGroupChangemakerPermission';
+export * from './UserGroupDataProviderPermission';
 export * from './Uuid';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,4 +40,5 @@ export * from './UserDataProviderPermission';
 export * from './UserFunderPermission';
 export * from './UserGroupChangemakerPermission';
 export * from './UserGroupDataProviderPermission';
+export * from './UserGroupFunderPermission';
 export * from './Uuid';


### PR DESCRIPTION
Closes #1469 

This PR brings in userGroup Permissions entities, which follow the pattern for existing userPermissions entities. These are meant to allow organizations to provide users with permissions for managing other entities in the pdc.