### PR TITLE
Add permissions to opportunities

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -175,3 +175,7 @@ funder, data provider, or other changemaker entirely.
 #### Manage
 
 - Allows users to modify the permissions for the funder for other users and user groups.
+
+### Edit
+
+- Allows users to create new opportunities for the funder.

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -155,3 +155,23 @@ PDC interprets this as "Grant members of the group
 to changemaker `42`." It may not be the case that changemaker 42 is the group
 mentioned here, it may be that group `06e80ea0-32b7-4716-b031-95d701a88a2` is a
 funder, data provider, or other changemaker entirely.
+
+## Permission Descriptions
+
+### Changemaker
+
+#### Manage
+
+- Allows users to modify the permissions for the changemaker for other users and user groups.
+
+### Data Provider
+
+#### Manage
+
+- Allows users to modify the permissions for the data provider for other users and user groups.
+
+### Funder
+
+#### Manage
+
+- Allows users to modify the permissions for the funder for other users and user groups.

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -1,0 +1,11 @@
+import type { AuthContext, Permission, ShortCode } from './types';
+
+const authContextHasFunderPermission = (
+	auth: AuthContext,
+	funderShortCode: ShortCode,
+	permission: Permission,
+): boolean =>
+	auth.user.permissions.funder[funderShortCode] !== undefined &&
+	auth.user.permissions.funder[funderShortCode].includes(permission);
+
+export { authContextHasFunderPermission };


### PR DESCRIPTION
This PR adds a permission check to the `POST /opportunities` endpoint so that a user cannot create an opportunity without edit permission on the related funder.

Related to #1406 