### PR TITLE
Add permission check for BulkUploadTask creation

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -180,3 +180,4 @@ funder, data provider, or other changemaker entirely.
 
 - Allows users to create new opportunities for the funder.
 - Allows users to create new application forms for the funder's opportunities.
+- Allows users to create new bulk uploads for the funder.

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -5,7 +5,8 @@ const authContextHasFunderPermission = (
 	funderShortCode: ShortCode,
 	permission: Permission,
 ): boolean =>
-	auth.user.permissions.funder[funderShortCode] !== undefined &&
-	auth.user.permissions.funder[funderShortCode].includes(permission);
+	auth.role.isAdministrator ||
+	(auth.user.permissions.funder[funderShortCode] !== undefined &&
+		auth.user.permissions.funder[funderShortCode].includes(permission));
 
 export { authContextHasFunderPermission };


### PR DESCRIPTION
This PR adds permission checks to the `POST /tasks/bulkUploads` endpoint.

This also corrects a bug where administrators were not automatically considered as having all permissions for funder authorization checks.

Related to #1406