### PR TITLE
Add permissions to `POST /sources`

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -160,11 +160,19 @@ funder, data provider, or other changemaker entirely.
 
 ### Changemaker
 
+#### Edit
+
+- Allows users to create sources for the changemaker.
+
 #### Manage
 
 - Allows users to modify the permissions for the changemaker for other users and user groups.
 
 ### Data Provider
+
+#### Edit
+
+- Allows users to create sources for the data provider.
 
 #### Manage
 
@@ -177,6 +185,7 @@ funder, data provider, or other changemaker entirely.
 - Allows users to create new opportunities for the funder.
 - Allows users to create new application forms for the funder's opportunities.
 - Allows users to create new bulk uploads for the funder.
+- Allows users to create sources for the funder.
 
 #### Manage
 

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -172,12 +172,12 @@ funder, data provider, or other changemaker entirely.
 
 ### Funder
 
-#### Manage
-
-- Allows users to modify the permissions for the funder for other users and user groups.
-
-### Edit
+#### Edit
 
 - Allows users to create new opportunities for the funder.
 - Allows users to create new application forms for the funder's opportunities.
 - Allows users to create new bulk uploads for the funder.
+
+#### Manage
+
+- Allows users to modify the permissions for the funder for other users and user groups.

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -1,4 +1,24 @@
-import type { AuthContext, Permission, ShortCode } from './types';
+import type { AuthContext, Id, Permission, ShortCode } from './types';
+
+const authContextHasChangemakerPermission = (
+	auth: AuthContext,
+	changemakerId: Id,
+	permission: Permission,
+): boolean =>
+	auth.role.isAdministrator ||
+	(auth.user.permissions.changemaker[changemakerId] !== undefined &&
+		auth.user.permissions.changemaker[changemakerId].includes(permission));
+
+const authContextHasDataProviderPermission = (
+	auth: AuthContext,
+	dataProviderShortCode: ShortCode,
+	permission: Permission,
+): boolean =>
+	auth.role.isAdministrator ||
+	(auth.user.permissions.dataProvider[dataProviderShortCode] !== undefined &&
+		auth.user.permissions.dataProvider[dataProviderShortCode].includes(
+			permission,
+		));
 
 const authContextHasFunderPermission = (
 	auth: AuthContext,
@@ -9,4 +29,8 @@ const authContextHasFunderPermission = (
 	(auth.user.permissions.funder[funderShortCode] !== undefined &&
 		auth.user.permissions.funder[funderShortCode].includes(permission));
 
-export { authContextHasFunderPermission };
+export {
+	authContextHasChangemakerPermission,
+	authContextHasDataProviderPermission,
+	authContextHasFunderPermission,
+};

--- a/src/routers/sourcesRouter.ts
+++ b/src/routers/sourcesRouter.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { sourcesHandlers } from '../handlers/sourcesHandlers';
-import { requireAdministratorRole, requireAuthentication } from '../middleware';
+import { requireAuthentication } from '../middleware';
 
 const sourcesRouter = express.Router();
 
@@ -12,6 +12,6 @@ sourcesRouter.get(
 	sourcesHandlers.getSource,
 );
 
-sourcesRouter.post('/', requireAdministratorRole, sourcesHandlers.postSource);
+sourcesRouter.post('/', requireAuthentication, sourcesHandlers.postSource);
 
 export { sourcesRouter };


### PR DESCRIPTION
This PR updates the `POST /sources` endpoint to allow users to create sources for organizations where they have write access.

Related to #1406 