### PR TITLE
Add permissions to `POST /proposals`

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -186,6 +186,7 @@ funder, data provider, or other changemaker entirely.
 - Allows users to create new application forms for the funder's opportunities.
 - Allows users to create new bulk uploads for the funder.
 - Allows users to create sources for the funder.
+- Allows users to create new proposals for the funder's opportunities.
 
 #### Manage
 

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -106,21 +106,20 @@ const postProposal = (
 	const { externalId, opportunityId } = req.body;
 	const createdBy = req.user.keycloakUserId;
 
-	createProposal(db, null, {
-		opportunityId,
-		externalId,
-		createdBy,
-	})
-		.then((proposal) => {
-			res.status(201).contentType('application/json').send(proposal);
-		})
-		.catch((error: unknown) => {
-			if (isTinyPgErrorWithQueryContext(error)) {
-				next(new DatabaseError('Error creating proposal.', error));
-				return;
-			}
-			next(error);
+	(async () => {
+		const proposal = await createProposal(db, null, {
+			opportunityId,
+			externalId,
+			createdBy,
 		});
+		res.status(201).contentType('application/json').send(proposal);
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error creating proposal.', error));
+			return;
+		}
+		next(error);
+	});
 };
 
 export const proposalsHandlers = {


### PR DESCRIPTION
This PR adds permission checks to the `POST /proposals` endpoint so that only users with write permissions on a proposal's opportunity's funder is able to create new proposals in response to the opportunity.

Related to #1406 