### PR TITLE
Add permissions to proposal changemaker post

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -187,6 +187,7 @@ funder, data provider, or other changemaker entirely.
 - Allows users to create new bulk uploads for the funder.
 - Allows users to create sources for the funder.
 - Allows users to create new proposals for the funder's opportunities.
+- Allows users to create new changemaker relationships with proposals for the funder's opportunities.
 
 #### Manage
 

--- a/src/handlers/changemakerProposalsHandlers.ts
+++ b/src/handlers/changemakerProposalsHandlers.ts
@@ -63,17 +63,20 @@ const postChangemakerProposal = (
 		return;
 	}
 
-	createChangemakerProposal(db, null, req.body)
-		.then((changemakerProposal) => {
-			res.status(201).contentType('application/json').send(changemakerProposal);
-		})
-		.catch((error: unknown) => {
-			if (isTinyPgErrorWithQueryContext(error)) {
-				next(new DatabaseError('Error creating changemaker proposal.', error));
-				return;
-			}
-			next(error);
-		});
+	(async () => {
+		const changemakerProposal = await createChangemakerProposal(
+			db,
+			null,
+			req.body,
+		);
+		res.status(201).contentType('application/json').send(changemakerProposal);
+	})().catch((error: unknown) => {
+		if (isTinyPgErrorWithQueryContext(error)) {
+			next(new DatabaseError('Error creating changemaker proposal.', error));
+			return;
+		}
+		next(error);
+	});
 };
 
 export const changemakerProposalsHandlers = {

--- a/src/handlers/changemakerProposalsHandlers.ts
+++ b/src/handlers/changemakerProposalsHandlers.ts
@@ -3,17 +3,28 @@ import {
 	createChangemakerProposal,
 	getLimitValues,
 	loadChangemakerProposalBundle,
+	loadProposal,
+	loadOpportunity,
 } from '../database';
 import {
+	isAuthContext,
 	isTinyPgErrorWithQueryContext,
 	isWritableChangemakerProposal,
+	Permission,
 } from '../types';
-import { DatabaseError, InputValidationError } from '../errors';
+import {
+	DatabaseError,
+	FailedMiddlewareError,
+	InputValidationError,
+	NotFoundError,
+	UnprocessableEntityError,
+} from '../errors';
 import {
 	extractChangemakerParameters,
 	extractProposalParameters,
 	extractPaginationParameters,
 } from '../queryParameters';
+import { authContextHasFunderPermission } from '../authorization';
 import type { Request, Response, NextFunction } from 'express';
 
 const getChangemakerProposals = (
@@ -53,6 +64,10 @@ const postChangemakerProposal = (
 	res: Response,
 	next: NextFunction,
 ): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
 	if (!isWritableChangemakerProposal(req.body)) {
 		next(
 			new InputValidationError(
@@ -62,17 +77,38 @@ const postChangemakerProposal = (
 		);
 		return;
 	}
+	const { proposalId, changemakerId } = req.body;
 
 	(async () => {
-		const changemakerProposal = await createChangemakerProposal(
-			db,
-			null,
-			req.body,
-		);
+		const proposal = await loadProposal(db, null, proposalId);
+		const opportunity = await loadOpportunity(db, null, proposal.opportunityId);
+		if (
+			!authContextHasFunderPermission(
+				req,
+				opportunity.funderShortCode,
+				Permission.EDIT,
+			)
+		) {
+			throw new UnprocessableEntityError(
+				'You do not have write permissions on the funder associated with this proposal.',
+			);
+		}
+		const changemakerProposal = await createChangemakerProposal(db, null, {
+			changemakerId,
+			proposalId,
+		});
 		res.status(201).contentType('application/json').send(changemakerProposal);
 	})().catch((error: unknown) => {
 		if (isTinyPgErrorWithQueryContext(error)) {
 			next(new DatabaseError('Error creating changemaker proposal.', error));
+			return;
+		}
+		if (error instanceof NotFoundError) {
+			next(
+				new UnprocessableEntityError(
+					`related ${error.details.entityType} not found.`,
+				),
+			);
 			return;
 		}
 		next(error);


### PR DESCRIPTION
This PR adds permission checks to the `POST /changemakerProposals` endpoint.  Prior to this there were no checks and any authenticated user could associate any proposal with any changemaker.

Now only users with edit permissions on the funder associated with the proposal's opportunity can make those associations.

Related to #1406 