### PR TITLE
Add permissions to POST /proposalVersions

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -188,6 +188,7 @@ funder, data provider, or other changemaker entirely.
 - Allows users to create sources for the funder.
 - Allows users to create new proposals for the funder's opportunities.
 - Allows users to create new changemaker relationships with proposals for the funder's opportunities.
+- Allows users to create new proposal versions for proposals responding to the funder's opportunities.
 
 #### Manage
 


### PR DESCRIPTION
This PR adds a check that limits creation of new proposal versions to those with write access to the funders who sponsored the opportunity.

In future we may add additional permissions (e.g. changemakers associated with the proposal).

Related to #1406 