### PR TITLE
Add permissions to GET /applicationForms

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -193,3 +193,7 @@ funder, data provider, or other changemaker entirely.
 #### Manage
 
 - Allows users to modify the permissions for the funder for other users and user groups.
+
+#### View
+
+- Allows users to view the application forms associated with the funder's opportunities.

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -99,6 +99,12 @@ describe('/applicationForms', () => {
 				total: 3,
 			});
 		});
+	});
+
+	describe('GET /:applicationFormId', () => {
+		it('requires authentication', async () => {
+			await request(app).get('/applicationForms/6').expect(401);
+		});
 
 		it('returns an application form with its fields', async () => {
 			const systemFunder = await loadSystemFunder(db, null);

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -229,7 +229,7 @@ describe('/proposalVersions', () => {
 			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
-				.set(authHeader)
+				.set(authHeaderWithAdminRole)
 				.send({
 					proposalId: 1,
 					applicationFormId: 1,
@@ -349,7 +349,7 @@ describe('/proposalVersions', () => {
 			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
-				.set(authHeader)
+				.set(authHeaderWithAdminRole)
 				.send({
 					proposalId: 2,
 					applicationFormId: 1,
@@ -387,7 +387,7 @@ describe('/proposalVersions', () => {
 			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
-				.set(authHeader)
+				.set(authHeaderWithAdminRole)
 				.send({
 					proposalId: 1,
 					applicationFormId: 1,
@@ -427,7 +427,7 @@ describe('/proposalVersions', () => {
 			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
-				.set(authHeader)
+				.set(authHeaderWithAdminRole)
 				.send({
 					proposalId: 1,
 					applicationFormId: 2,
@@ -478,7 +478,7 @@ describe('/proposalVersions', () => {
 			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
-				.set(authHeader)
+				.set(authHeaderWithAdminRole)
 				.send({
 					proposalId: 1,
 					applicationFormId: 2,
@@ -524,7 +524,7 @@ describe('/proposalVersions', () => {
 			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
-				.set(authHeader)
+				.set(authHeaderWithAdminRole)
 				.send({
 					proposalId: 1,
 					sourceId: systemSource.id,
@@ -591,7 +591,7 @@ describe('/proposalVersions', () => {
 			const result = await request(app)
 				.post('/proposalVersions')
 				.type('application/json')
-				.set(authHeader)
+				.set(authHeaderWithAdminRole)
 				.send({
 					proposalId: 1,
 					sourceId: systemSource.id,

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -199,14 +199,7 @@ describe('/proposalVersions', () => {
 		it('creates exactly the number of provided field values', async () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
-			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
-				userKeycloakUserId: testUser.keycloakUserId,
-				funderShortCode: systemFunder.shortCode,
-				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
-			});
 			await createOpportunity(db, null, {
 				title: '🔥',
 				funderShortCode: systemFunder.shortCode,
@@ -340,14 +333,7 @@ describe('/proposalVersions', () => {
 		it('returns 409 Conflict when the provided proposal does not exist', async () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
-			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
-				userKeycloakUserId: testUser.keycloakUserId,
-				funderShortCode: systemFunder.shortCode,
-				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
-			});
 			await createOpportunity(db, null, {
 				title: '🔥',
 				funderShortCode: systemFunder.shortCode,
@@ -385,14 +371,7 @@ describe('/proposalVersions', () => {
 
 		it('returns 409 conflict when the provided source does not exist', async () => {
 			const systemFunder = await loadSystemFunder(db, null);
-			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
-				userKeycloakUserId: testUser.keycloakUserId,
-				funderShortCode: systemFunder.shortCode,
-				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
-			});
 			await createOpportunity(db, null, {
 				title: '🔥',
 				funderShortCode: systemFunder.shortCode,
@@ -430,14 +409,7 @@ describe('/proposalVersions', () => {
 		it('Returns 409 Conflict if the provided application form does not exist', async () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
-			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
-				userKeycloakUserId: testUser.keycloakUserId,
-				funderShortCode: systemFunder.shortCode,
-				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
-			});
 			await createOpportunity(db, null, {
 				title: '🔥',
 				funderShortCode: systemFunder.shortCode,
@@ -481,14 +453,7 @@ describe('/proposalVersions', () => {
 		it('Returns 409 Conflict if the provided application form ID is not associated with the proposal opportunity', async () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
-			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
-				userKeycloakUserId: testUser.keycloakUserId,
-				funderShortCode: systemFunder.shortCode,
-				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
-			});
 			await createOpportunity(db, null, {
 				title: '🔥',
 				funderShortCode: systemFunder.shortCode,
@@ -541,14 +506,7 @@ describe('/proposalVersions', () => {
 		it('Returns 409 Conflict if a provided application form field ID does not exist', async () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
-			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
-				userKeycloakUserId: testUser.keycloakUserId,
-				funderShortCode: systemFunder.shortCode,
-				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
-			});
 			await createOpportunity(db, null, {
 				title: '🔥',
 				funderShortCode: systemFunder.shortCode,
@@ -599,14 +557,7 @@ describe('/proposalVersions', () => {
 		it('Returns 409 Conflict if a provided application form field ID is not associated with the supplied application form ID', async () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
-			const systemUser = await loadSystemUser(db, null);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
-				userKeycloakUserId: testUser.keycloakUserId,
-				funderShortCode: systemFunder.shortCode,
-				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
-			});
 			await createOpportunity(db, null, {
 				title: '🔥',
 				funderShortCode: systemFunder.shortCode,

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -152,7 +152,7 @@ describe('/proposalVersions', () => {
 			expect(after.count).toEqual(1);
 		});
 
-		it('creates exactly one proposal version for a user with write permissions on the funder', async () => {
+		it('creates exactly one proposal version for a user with read and write permissions on the funder', async () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
@@ -161,6 +161,12 @@ describe('/proposalVersions', () => {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.EDIT,
+				createdBy: systemUser.keycloakUserId,
+			});
+			await createOrUpdateUserFunderPermission(db, null, {
+				userKeycloakUserId: testUser.keycloakUserId,
+				funderShortCode: systemFunder.shortCode,
+				permission: Permission.VIEW,
 				createdBy: systemUser.keycloakUserId,
 			});
 			await createOpportunity(db, null, {

--- a/src/database/initialization/has_funder_permission.sql
+++ b/src/database/initialization/has_funder_permission.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE FUNCTION has_funder_permission(
+	user_keycloak_user_id uuid,
+	user_is_admin boolean,
+	funder_short_code short_code_t,
+	permission permission_t
+) RETURNS boolean AS $$
+DECLARE
+	has_permission boolean;
+BEGIN
+	-- If the user is an administrator, they have all permissions
+	IF user_is_admin THEN
+		RETURN TRUE;
+	END IF;
+
+	-- Check if the user has the specified permission on the specified funder
+	SELECT EXISTS (
+		SELECT 1
+		FROM user_funder_permissions
+		WHERE user_funder_permissions.user_keycloak_user_id = has_funder_permission.user_keycloak_user_id
+			AND user_funder_permissions.funder_short_code = has_funder_permission.funder_short_code
+			AND user_funder_permissions.permission = has_funder_permission.permission
+	) OR EXISTS (
+		SELECT 1
+		FROM ephemeral_user_group_associations
+		JOIN user_group_funder_permissions
+			ON user_group_funder_permissions.keycloak_organization_id = ephemeral_user_group_associations.user_group_keycloak_organization_id
+		WHERE ephemeral_user_group_associations.user_keycloak_user_id = has_funder_permission.user_keycloak_user_id
+			AND user_group_funder_permissions.funder_short_code = has_funder_permission.funder_short_code
+			AND user_group_funder_permissions.permission = has_funder_permission.permission
+	) INTO has_permission;
+
+	RETURN has_permission;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/queries/applicationForms/selectById.sql
+++ b/src/database/queries/applicationForms/selectById.sql
@@ -1,3 +1,11 @@
-SELECT application_form_to_json(application_forms) AS object
+SELECT application_form_to_json(application_forms.*) AS object
 FROM application_forms
-WHERE id = :applicationFormId;
+	INNER JOIN opportunities ON application_forms.opportunity_id = opportunities.id
+WHERE
+	application_forms.id = :applicationFormId
+	AND has_funder_permission(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		opportunities.funder_short_code,
+		'view'
+	);

--- a/src/database/queries/applicationForms/selectWithPagination.sql
+++ b/src/database/queries/applicationForms/selectWithPagination.sql
@@ -1,4 +1,12 @@
-SELECT application_form_to_json(application_forms) AS object
+SELECT application_form_to_json(application_forms.*) AS object
 FROM application_forms
-ORDER BY id
+	INNER JOIN opportunities ON application_forms.opportunity_id = opportunities.id
+WHERE
+	has_funder_permission(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		opportunities.funder_short_code,
+		'view'
+	)
+ORDER BY application_forms.id
 LIMIT :limit OFFSET :offset;

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -51,7 +51,7 @@ const getApplicationForm = (
 	res: Response,
 	next: NextFunction,
 ): void => {
-	const { id: applicationFormId } = req.params;
+	const { applicationFormId } = req.params;
 	if (!isId(applicationFormId)) {
 		next(new InputValidationError('Invalid request.', isId.errors ?? []));
 		return;

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -51,12 +51,17 @@ const getApplicationForm = (
 	res: Response,
 	next: NextFunction,
 ): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
+
 	const { applicationFormId } = req.params;
 	if (!isId(applicationFormId)) {
 		next(new InputValidationError('Invalid request.', isId.errors ?? []));
 		return;
 	}
-	loadApplicationForm(db, null, applicationFormId)
+	loadApplicationForm(db, req, applicationFormId)
 		.then((applicationForm) => {
 			res.status(200).contentType('application/json').send(applicationForm);
 		})

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -31,9 +31,13 @@ const getApplicationForms = (
 	res: Response,
 	next: NextFunction,
 ): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
-	loadApplicationFormBundle(db, null, limit, offset)
+	loadApplicationFormBundle(db, req, limit, offset)
 		.then((applicationForms) => {
 			res.status(200).contentType('application/json').send(applicationForms);
 		})

--- a/src/routers/applicationFormsRouter.ts
+++ b/src/routers/applicationFormsRouter.ts
@@ -5,7 +5,7 @@ import { requireAuthentication } from '../middleware';
 const applicationFormsRouter = express.Router();
 
 applicationFormsRouter.get(
-	'/:id',
+	'/:applicationFormId',
 	requireAuthentication,
 	applicationFormsHandlers.getApplicationForm,
 );

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -395,7 +395,7 @@ describe('processBulkUploadTask', () => {
 			entries: [applicationForm],
 		} = await loadApplicationFormBundle(db, null, NO_LIMIT, NO_OFFSET);
 		if (applicationForm === undefined) {
-			fail('The application form was not created');
+			throw new Error('The application form was not created');
 		}
 		expect(applicationForm).toMatchObject({
 			opportunityId: opportunity.id,

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -23,7 +23,12 @@ import {
 	TaskStatus,
 	Proposal,
 } from '../../types';
-import { expectTimestamp, NO_LIMIT, NO_OFFSET } from '../../test/utils';
+import {
+	expectTimestamp,
+	getTestAuthContext,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../../test/utils';
 import type {
 	BulkUploadTask,
 	InternallyWritableBulkUploadTask,
@@ -360,6 +365,7 @@ describe('processBulkUploadTask', () => {
 
 	it('should download, process, and resolve the bulk upload if the sourceKey is accessible and contains a valid CSV bulk upload', async () => {
 		await createTestBaseFields();
+		const testAuthContext = await getTestAuthContext();
 		const systemSource = await loadSystemSource(db, null);
 		const systemUser = await loadSystemUser(db, null);
 		const sourceKey = TEST_UNPROCESSED_SOURCE_KEY;
@@ -393,7 +399,12 @@ describe('processBulkUploadTask', () => {
 
 		const {
 			entries: [applicationForm],
-		} = await loadApplicationFormBundle(db, null, NO_LIMIT, NO_OFFSET);
+		} = await loadApplicationFormBundle(
+			db,
+			testAuthContext,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
 		if (applicationForm === undefined) {
 			throw new Error('The application form was not created');
 		}

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -33,6 +33,13 @@ export const createTestUser = async () =>
 export const loadTestUser = async () =>
 	loadUserByKeycloakUserId(db, null, getTestUserKeycloakUserId());
 
+export const getTestAuthContext = async () => ({
+	user: await loadTestUser(),
+	role: {
+		isAdministrator: true,
+	},
+});
+
 export const NO_OFFSET = 0;
 
 export const NO_LIMIT = undefined;


### PR DESCRIPTION
This PR adds our first permission checks for viewing data.  Specifically we are now limiting access to loading application forms so that only users with `view` access to a given funder can view that funder's opportunities' application forms.

Right now I'm implementing edit and view as completely distinct permissions, which creates some potentially un-intuitive situations (e.g. getting edit permission alone is not enough to create things, you need both edit and view because you need to be able to view the related items).

We can add additional permission cases in a future dev cycle; starting more restrictive and deciding as a group to become more permissive seems like a safer decision.

Related to #1406 