### PR TITLE
Add permissions to GET `/proposalVersions` endpoints

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -172,6 +172,7 @@ funder, data provider, or other changemaker entirely.
 
 - Allows users to view the proposal associations with the changemaker.
 - Allows users to view proposals associated with the changemaker.
+- Allows users to view proposal versions associated with the changemaker.
 
 ### Data Provider
 
@@ -205,3 +206,4 @@ funder, data provider, or other changemaker entirely.
 - Allows users to view the bulk uploads associated with the funder.
 - Allows users to view the changemaker associations with any proposals associated with the funder's opportunities.
 - Allows users to view proposals associated with the funder's opportunities
+- Allows users to view proposal versions associated with the funder's opportunities

--- a/src/database/queries/proposalVersions/selectById.sql
+++ b/src/database/queries/proposalVersions/selectById.sql
@@ -1,3 +1,31 @@
 SELECT proposal_version_to_json(proposal_versions.*) AS object
 FROM proposal_versions
-WHERE id = :proposalVersionId;
+WHERE
+	proposal_versions.id = :proposalVersionId
+	AND (
+		EXISTS (
+			SELECT 1
+			FROM proposals
+				INNER JOIN opportunities ON proposals.opportunity_id = opportunities.id
+			WHERE
+				proposals.id = proposal_versions.proposal_id
+				AND has_funder_permission(
+					:authContextKeycloakUserId,
+					:authContextIsAdministrator,
+					opportunities.funder_short_code,
+					'view'
+				)
+		)
+		OR EXISTS (
+			SELECT 1
+			FROM changemakers_proposals
+			WHERE
+				changemakers_proposals.proposal_id = proposal_versions.proposal_id
+				AND has_changemaker_permission(
+					:authContextKeycloakUserId,
+					:authContextIsAdministrator,
+					changemakers_proposals.changemaker_id,
+					'view'
+				)
+		)
+	);

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -251,6 +251,10 @@ const getProposalVersion = (
 	res: Response,
 	next: NextFunction,
 ): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
 	const { proposalVersionId } = req.params;
 	if (!isId(proposalVersionId)) {
 		next(
@@ -258,7 +262,7 @@ const getProposalVersion = (
 		);
 		return;
 	}
-	loadProposalVersion(db, null, proposalVersionId)
+	loadProposalVersion(db, req, proposalVersionId)
 		.then((item) => {
 			res.status(200).contentType('application/json').send(item);
 		})


### PR DESCRIPTION
This PR adds permission checks when loading a proposal version.

Related to #1406 