### PR TITLE
Add permissions to `GET` `/opportunities` endpoints

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -207,3 +207,4 @@ funder, data provider, or other changemaker entirely.
 - Allows users to view the changemaker associations with any proposals associated with the funder's opportunities.
 - Allows users to view proposals associated with the funder's opportunities
 - Allows users to view proposal versions associated with the funder's opportunities
+- Allows users to view the funder's opportunities

--- a/src/database/queries/opportunities/selectById.sql
+++ b/src/database/queries/opportunities/selectById.sql
@@ -1,3 +1,10 @@
-SELECT opportunity_to_json(opportunities) AS object
+SELECT opportunity_to_json(opportunities.*) AS object
 FROM opportunities
-WHERE id = :opportunityId;
+WHERE
+	opportunities.id = :opportunityId
+	AND has_funder_permission(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		opportunities.funder_short_code,
+		'view'
+	);

--- a/src/database/queries/opportunities/selectWithPagination.sql
+++ b/src/database/queries/opportunities/selectWithPagination.sql
@@ -1,4 +1,11 @@
 SELECT opportunity_to_json(opportunities.*) AS object
 FROM opportunities
+WHERE
+	has_funder_permission(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		funder_short_code,
+		'view'
+	)
 ORDER BY id
 LIMIT :limit OFFSET :offset;

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -99,7 +99,7 @@ const postApplicationForms = (
 	}
 	const { fields, opportunityId } = req.body;
 	(async () => {
-		const opportunity = await loadOpportunity(db, null, opportunityId);
+		const opportunity = await loadOpportunity(db, req, opportunityId);
 		if (
 			!authContextHasFunderPermission(
 				req,

--- a/src/handlers/changemakerProposalsHandlers.ts
+++ b/src/handlers/changemakerProposalsHandlers.ts
@@ -85,7 +85,7 @@ const postChangemakerProposal = (
 
 	(async () => {
 		const proposal = await loadProposal(db, req, proposalId);
-		const opportunity = await loadOpportunity(db, null, proposal.opportunityId);
+		const opportunity = await loadOpportunity(db, req, proposal.opportunityId);
 		if (
 			!authContextHasFunderPermission(
 				req,

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -47,12 +47,16 @@ const getOpportunity = (
 	res: Response,
 	next: NextFunction,
 ): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
 	const { opportunityId } = req.params;
 	if (!isId(opportunityId)) {
 		next(new InputValidationError('Invalid id parameter.', isId.errors ?? []));
 		return;
 	}
-	loadOpportunity(db, null, opportunityId)
+	loadOpportunity(db, req, opportunityId)
 		.then((opportunity) => {
 			res.status(200).contentType('application/json').send(opportunity);
 		})

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -27,9 +27,13 @@ const getOpportunities = (
 	res: Response,
 	next: NextFunction,
 ): void => {
+	if (!isAuthContext(req)) {
+		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		return;
+	}
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
-	loadOpportunityBundle(db, null, limit, offset)
+	loadOpportunityBundle(db, req, limit, offset)
 		.then((opportunityBundle) => {
 			res.status(200).contentType('application/json').send(opportunityBundle);
 		})

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -110,7 +110,7 @@ const postProposal = (
 	const createdBy = req.user.keycloakUserId;
 
 	(async () => {
-		const opportunity = await loadOpportunity(db, null, opportunityId);
+		const opportunity = await loadOpportunity(db, req, opportunityId);
 		if (
 			!authContextHasFunderPermission(
 				req,

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -398,7 +398,7 @@ describe('processBulkUploadTask', () => {
 
 		const {
 			entries: [opportunity],
-		} = await loadOpportunityBundle(db, null, NO_LIMIT, NO_OFFSET);
+		} = await loadOpportunityBundle(db, testAuthContext, NO_LIMIT, NO_OFFSET);
 		if (opportunity === undefined) {
 			throw new Error('The opportunity was not created');
 		}


### PR DESCRIPTION
This PR limits access to opportunities to those who have view access on the related funder.

Related to #1406
