### PR TITLE
Add unique constraint on source label and fkeys

### DIFF
--- a/src/database/migrations/0053-alter-sources.sql
+++ b/src/database/migrations/0053-alter-sources.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sources
+ADD UNIQUE (label, changemaker_id),
+ADD UNIQUE (label, funder_short_code),
+ADD UNIQUE (label, data_provider_short_code);


### PR DESCRIPTION
This PR adds unique constraints on a sources label and it's potential foreign keys to other entities (organization, dataProvider, funder). Notably, it does allow for two sources to exist with the same label so long as they are related to a distinct entity.

Closes #1455 