### PR TITLE
Move to asynchronous route handlers

### DIFF
--- a/src/handlers/dataProvidersHandlers.ts
+++ b/src/handlers/dataProvidersHandlers.ts
@@ -5,109 +5,65 @@ import {
 	loadDataProviderBundle,
 	loadDataProvider,
 } from '../database';
-import {
-	isAuthContext,
-	isTinyPgErrorWithQueryContext,
-	isWritableDataProvider,
-} from '../types';
-import {
-	DatabaseError,
-	FailedMiddlewareError,
-	InputValidationError,
-} from '../errors';
+import { isAuthContext, isWritableDataProvider } from '../types';
+import { FailedMiddlewareError, InputValidationError } from '../errors';
 import { extractPaginationParameters } from '../queryParameters';
 import { isShortCode } from '../types/ShortCode';
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response } from 'express';
 
-const getDataProviders = (
-	req: Request,
-	res: Response,
-	next: NextFunction,
-): void => {
+const getDataProviders = async (req: Request, res: Response) => {
 	if (!isAuthContext(req)) {
-		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
 		return;
 	}
 	const paginationParameters = extractPaginationParameters(req);
-	(async () => {
-		const { offset, limit } = getLimitValues(paginationParameters);
-		const bundle = await loadDataProviderBundle(db, req, limit, offset);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	const dataProviderBundle = await loadDataProviderBundle(
+		db,
+		req,
+		limit,
+		offset,
+	);
 
-		res.status(200).contentType('application/json').send(bundle);
-	})().catch((error: unknown) => {
-		if (isTinyPgErrorWithQueryContext(error)) {
-			next(new DatabaseError('Error retrieving items.', error));
-			return;
-		}
-		next(error);
-	});
+	res.status(200).contentType('application/json').send(dataProviderBundle);
 };
 
-const getDataProvider = (
-	req: Request,
-	res: Response,
-	next: NextFunction,
-): void => {
+const getDataProvider = async (req: Request, res: Response) => {
 	const { dataProviderShortCode } = req.params;
 	if (!isShortCode(dataProviderShortCode)) {
-		next(
-			new InputValidationError('Invalid short code.', isShortCode.errors ?? []),
+		throw new InputValidationError(
+			'Invalid short code.',
+			isShortCode.errors ?? [],
 		);
-		return;
 	}
-	loadDataProvider(db, null, dataProviderShortCode)
-		.then((item) => {
-			res.status(200).contentType('application/json').send(item);
-		})
-		.catch((error: unknown) => {
-			if (isTinyPgErrorWithQueryContext(error)) {
-				next(new DatabaseError('Error retrieving item.', error));
-				return;
-			}
-			next(error);
-		});
+	const dataProvider = await loadDataProvider(db, null, dataProviderShortCode);
+	res.status(200).contentType('application/json').send(dataProvider);
 };
 
-const putDataProvider = (
-	req: Request,
-	res: Response,
-	next: NextFunction,
-): void => {
+const putDataProvider = async (req: Request, res: Response) => {
 	if (!isAuthContext(req)) {
-		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
-		return;
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
 	}
 	const shortCode = req.params.dataProviderShortCode;
 	if (!isShortCode(shortCode)) {
-		next(
-			new InputValidationError('Invalid short code.', isShortCode.errors ?? []),
+		throw new InputValidationError(
+			'Invalid short code.',
+			isShortCode.errors ?? [],
 		);
-		return;
 	}
 	if (!isWritableDataProvider(req.body)) {
-		next(
-			new InputValidationError(
-				'Invalid request body.',
-				isWritableDataProvider.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid request body.',
+			isWritableDataProvider.errors ?? [],
 		);
-		return;
 	}
 	const { name, keycloakOrganizationId } = req.body;
-	(async () => {
-		const dataProvider = await createOrUpdateDataProvider(db, null, {
-			shortCode,
-			name,
-			keycloakOrganizationId,
-		});
-		res.status(201).contentType('application/json').send(dataProvider);
-	})().catch((error: unknown) => {
-		if (isTinyPgErrorWithQueryContext(error)) {
-			next(new DatabaseError('Error creating item.', error));
-			return;
-		}
-		next(error);
+	const dataProvider = await createOrUpdateDataProvider(db, null, {
+		shortCode,
+		name,
+		keycloakOrganizationId,
 	});
+	res.status(201).contentType('application/json').send(dataProvider);
 };
 
 export const dataProviderHandlers = {

--- a/src/handlers/userDataProviderPermissionsHandlers.ts
+++ b/src/handlers/userDataProviderPermissionsHandlers.ts
@@ -10,140 +10,92 @@ import {
 	isKeycloakId,
 	isPermission,
 	isShortCode,
-	isTinyPgErrorWithQueryContext,
 	isWritableUserFunderPermission,
 } from '../types';
-import {
-	DatabaseError,
-	FailedMiddlewareError,
-	InputValidationError,
-} from '../errors';
-import type { Request, Response, NextFunction } from 'express';
+import { FailedMiddlewareError, InputValidationError } from '../errors';
+import type { Request, Response } from 'express';
 
-const deleteUserDataProviderPermission = (
+const deleteUserDataProviderPermission = async (
 	req: Request,
 	res: Response,
-	next: NextFunction,
-): void => {
+) => {
 	const { userKeycloakUserId, dataProviderShortCode, permission } = req.params;
 	if (!isKeycloakId(userKeycloakUserId)) {
-		next(
-			new InputValidationError(
-				'Invalid userKeycloakUserId parameter.',
-				isKeycloakId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid userKeycloakUserId parameter.',
+			isKeycloakId.errors ?? [],
 		);
-		return;
 	}
 	if (!isShortCode(dataProviderShortCode)) {
-		next(
-			new InputValidationError(
-				'Invalid dataProviderShortCode parameter.',
-				isId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid dataProviderShortCode parameter.',
+			isId.errors ?? [],
 		);
-		return;
 	}
 	if (!isPermission(permission)) {
-		next(
-			new InputValidationError(
-				'Invalid permission parameter.',
-				isPermission.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid permission parameter.',
+			isPermission.errors ?? [],
 		);
-		return;
 	}
 
-	(async () => {
-		await assertUserDataProviderPermissionExists(
-			userKeycloakUserId,
-			dataProviderShortCode,
-			permission,
-		);
-		await removeUserDataProviderPermission(
-			userKeycloakUserId,
-			dataProviderShortCode,
-			permission,
-		);
-		res.status(204).contentType('application/json').send();
-	})().catch((error: unknown) => {
-		if (isTinyPgErrorWithQueryContext(error)) {
-			next(new DatabaseError('Error deleting item.', error));
-			return;
-		}
-		next(error);
-	});
+	await assertUserDataProviderPermissionExists(
+		userKeycloakUserId,
+		dataProviderShortCode,
+		permission,
+	);
+	await removeUserDataProviderPermission(
+		userKeycloakUserId,
+		dataProviderShortCode,
+		permission,
+	);
+	res.status(204).contentType('application/json').send();
 };
 
-const putUserDataProviderPermission = (
-	req: Request,
-	res: Response,
-	next: NextFunction,
-): void => {
+const putUserDataProviderPermission = async (req: Request, res: Response) => {
 	if (!isAuthContext(req)) {
-		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
-		return;
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
 	}
 
 	const { userKeycloakUserId, dataProviderShortCode, permission } = req.params;
 	const createdBy = req.user.keycloakUserId;
 
 	if (!isKeycloakId(userKeycloakUserId)) {
-		next(
-			new InputValidationError(
-				'Invalid userKeycloakUserId parameter.',
-				isKeycloakId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid userKeycloakUserId parameter.',
+			isKeycloakId.errors ?? [],
 		);
-		return;
 	}
 	if (!isShortCode(dataProviderShortCode)) {
-		next(
-			new InputValidationError(
-				'Invalid dataProviderShortCode parameter.',
-				isId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid dataProviderShortCode parameter.',
+			isId.errors ?? [],
 		);
-		return;
 	}
 	if (!isPermission(permission)) {
-		next(
-			new InputValidationError(
-				'Invalid permission parameter.',
-				isPermission.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid permission parameter.',
+			isPermission.errors ?? [],
 		);
-		return;
 	}
 	if (!isWritableUserFunderPermission(req.body)) {
-		next(
-			new InputValidationError(
-				'Invalid request body.',
-				isWritableUserFunderPermission.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid request body.',
+			isWritableUserFunderPermission.errors ?? [],
 		);
-		return;
 	}
 
-	(async () => {
-		const userFunderPermission = await createOrUpdateUserDataProviderPermission(
-			db,
-			null,
-			{
-				userKeycloakUserId,
-				dataProviderShortCode,
-				permission,
-				createdBy,
-			},
-		);
-		res.status(201).contentType('application/json').send(userFunderPermission);
-	})().catch((error: unknown) => {
-		if (isTinyPgErrorWithQueryContext(error)) {
-			next(new DatabaseError('Error creating item.', error));
-			return;
-		}
-		next(error);
-	});
+	const userFunderPermission = await createOrUpdateUserDataProviderPermission(
+		db,
+		null,
+		{
+			userKeycloakUserId,
+			dataProviderShortCode,
+			permission,
+			createdBy,
+		},
+	);
+	res.status(201).contentType('application/json').send(userFunderPermission);
 };
 
 const userDataProviderPermissionsHandlers = {

--- a/src/handlers/userFunderPermissionsHandlers.ts
+++ b/src/handlers/userFunderPermissionsHandlers.ts
@@ -10,140 +10,89 @@ import {
 	isKeycloakId,
 	isPermission,
 	isShortCode,
-	isTinyPgErrorWithQueryContext,
 	isWritableUserFunderPermission,
 } from '../types';
-import {
-	DatabaseError,
-	FailedMiddlewareError,
-	InputValidationError,
-} from '../errors';
-import type { Request, Response, NextFunction } from 'express';
+import { FailedMiddlewareError, InputValidationError } from '../errors';
+import type { Request, Response } from 'express';
 
-const deleteUserFunderPermission = (
-	req: Request,
-	res: Response,
-	next: NextFunction,
-): void => {
+const deleteUserFunderPermission = async (req: Request, res: Response) => {
 	const { userKeycloakUserId, funderShortCode, permission } = req.params;
 	if (!isKeycloakId(userKeycloakUserId)) {
-		next(
-			new InputValidationError(
-				'Invalid userKeycloakUserId parameter.',
-				isKeycloakId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid userKeycloakUserId parameter.',
+			isKeycloakId.errors ?? [],
 		);
-		return;
 	}
 	if (!isShortCode(funderShortCode)) {
-		next(
-			new InputValidationError(
-				'Invalid shortCode parameter.',
-				isId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid shortCode parameter.',
+			isId.errors ?? [],
 		);
-		return;
 	}
 	if (!isPermission(permission)) {
-		next(
-			new InputValidationError(
-				'Invalid permission parameter.',
-				isPermission.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid permission parameter.',
+			isPermission.errors ?? [],
 		);
-		return;
 	}
 
-	(async () => {
-		await assertUserFunderPermissionExists(
-			userKeycloakUserId,
-			funderShortCode,
-			permission,
-		);
-		await removeUserFunderPermission(
-			userKeycloakUserId,
-			funderShortCode,
-			permission,
-		);
-		res.status(204).contentType('application/json').send();
-	})().catch((error: unknown) => {
-		if (isTinyPgErrorWithQueryContext(error)) {
-			next(new DatabaseError('Error deleting item.', error));
-			return;
-		}
-		next(error);
-	});
+	await assertUserFunderPermissionExists(
+		userKeycloakUserId,
+		funderShortCode,
+		permission,
+	);
+	await removeUserFunderPermission(
+		userKeycloakUserId,
+		funderShortCode,
+		permission,
+	);
+	res.status(204).contentType('application/json').send();
 };
 
-const putUserFunderPermission = (
-	req: Request,
-	res: Response,
-	next: NextFunction,
-): void => {
+const putUserFunderPermission = async (req: Request, res: Response) => {
 	if (!isAuthContext(req)) {
-		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
-		return;
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
 	}
 
 	const { userKeycloakUserId, funderShortCode, permission } = req.params;
 	const createdBy = req.user.keycloakUserId;
 
 	if (!isKeycloakId(userKeycloakUserId)) {
-		next(
-			new InputValidationError(
-				'Invalid userKeycloakUserId parameter.',
-				isKeycloakId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid userKeycloakUserId parameter.',
+			isKeycloakId.errors ?? [],
 		);
-		return;
 	}
 	if (!isShortCode(funderShortCode)) {
-		next(
-			new InputValidationError(
-				'Invalid funderShortCode parameter.',
-				isId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid funderShortCode parameter.',
+			isId.errors ?? [],
 		);
-		return;
 	}
 	if (!isPermission(permission)) {
-		next(
-			new InputValidationError(
-				'Invalid permission parameter.',
-				isPermission.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid permission parameter.',
+			isPermission.errors ?? [],
 		);
-		return;
 	}
 	if (!isWritableUserFunderPermission(req.body)) {
-		next(
-			new InputValidationError(
-				'Invalid request body.',
-				isWritableUserFunderPermission.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid request body.',
+			isWritableUserFunderPermission.errors ?? [],
 		);
-		return;
 	}
 
-	(async () => {
-		const userFunderPermission = await createOrUpdateUserFunderPermission(
-			db,
-			null,
-			{
-				userKeycloakUserId,
-				funderShortCode,
-				permission,
-				createdBy,
-			},
-		);
-		res.status(201).contentType('application/json').send(userFunderPermission);
-	})().catch((error: unknown) => {
-		if (isTinyPgErrorWithQueryContext(error)) {
-			next(new DatabaseError('Error creating item.', error));
-			return;
-		}
-		next(error);
-	});
+	const userFunderPermission = await createOrUpdateUserFunderPermission(
+		db,
+		null,
+		{
+			userKeycloakUserId,
+			funderShortCode,
+			permission,
+			createdBy,
+		},
+	);
+	res.status(201).contentType('application/json').send(userFunderPermission);
 };
 
 const userFunderPermissionsHandlers = {

--- a/src/handlers/userGroupFunderPermissionsHandlers.ts
+++ b/src/handlers/userGroupFunderPermissionsHandlers.ts
@@ -10,140 +10,89 @@ import {
 	isKeycloakId,
 	isPermission,
 	isShortCode,
-	isTinyPgErrorWithQueryContext,
 	isWritableUserGroupFunderPermission,
 } from '../types';
-import {
-	DatabaseError,
-	FailedMiddlewareError,
-	InputValidationError,
-} from '../errors';
-import type { Request, Response, NextFunction } from 'express';
+import { FailedMiddlewareError, InputValidationError } from '../errors';
+import type { Request, Response } from 'express';
 
-const deleteUserGroupFunderPermission = (
-	req: Request,
-	res: Response,
-	next: NextFunction,
-): void => {
+const deleteUserGroupFunderPermission = async (req: Request, res: Response) => {
 	const { keycloakOrganizationId, funderShortCode, permission } = req.params;
 	if (!isKeycloakId(keycloakOrganizationId)) {
-		next(
-			new InputValidationError(
-				'Invalid keycloakOrganizationId parameter.',
-				isKeycloakId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid keycloakOrganizationId parameter.',
+			isKeycloakId.errors ?? [],
 		);
-		return;
 	}
 	if (!isShortCode(funderShortCode)) {
-		next(
-			new InputValidationError(
-				'Invalid shortCode parameter.',
-				isId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid shortCode parameter.',
+			isId.errors ?? [],
 		);
-		return;
 	}
 	if (!isPermission(permission)) {
-		next(
-			new InputValidationError(
-				'Invalid permission parameter.',
-				isPermission.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid permission parameter.',
+			isPermission.errors ?? [],
 		);
-		return;
 	}
 
-	(async () => {
-		await assertUserGroupFunderPermissionExists(
-			keycloakOrganizationId,
-			funderShortCode,
-			permission,
-		);
-		await removeUserGroupFunderPermission(
-			keycloakOrganizationId,
-			funderShortCode,
-			permission,
-		);
-		res.status(204).contentType('application/json').send();
-	})().catch((error: unknown) => {
-		if (isTinyPgErrorWithQueryContext(error)) {
-			next(new DatabaseError('Error deleting item.', error));
-			return;
-		}
-		next(error);
-	});
+	await assertUserGroupFunderPermissionExists(
+		keycloakOrganizationId,
+		funderShortCode,
+		permission,
+	);
+	await removeUserGroupFunderPermission(
+		keycloakOrganizationId,
+		funderShortCode,
+		permission,
+	);
+	res.status(204).contentType('application/json').send();
 };
 
-const putUserGroupFunderPermission = (
-	req: Request,
-	res: Response,
-	next: NextFunction,
-): void => {
+const putUserGroupFunderPermission = async (req: Request, res: Response) => {
 	if (!isAuthContext(req)) {
-		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
-		return;
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
 	}
 
 	const { keycloakOrganizationId, funderShortCode, permission } = req.params;
 	const createdBy = req.user.keycloakUserId;
 
 	if (!isKeycloakId(keycloakOrganizationId)) {
-		next(
-			new InputValidationError(
-				'Invalid keycloakOrganizationId parameter.',
-				isKeycloakId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid keycloakOrganizationId parameter.',
+			isKeycloakId.errors ?? [],
 		);
-		return;
 	}
 	if (!isShortCode(funderShortCode)) {
-		next(
-			new InputValidationError(
-				'Invalid funderShortCode parameter.',
-				isId.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid funderShortCode parameter.',
+			isId.errors ?? [],
 		);
-		return;
 	}
 	if (!isPermission(permission)) {
-		next(
-			new InputValidationError(
-				'Invalid permission parameter.',
-				isPermission.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid permission parameter.',
+			isPermission.errors ?? [],
 		);
-		return;
 	}
 	if (!isWritableUserGroupFunderPermission(req.body)) {
-		next(
-			new InputValidationError(
-				'Invalid request body.',
-				isWritableUserGroupFunderPermission.errors ?? [],
-			),
+		throw new InputValidationError(
+			'Invalid request body.',
+			isWritableUserGroupFunderPermission.errors ?? [],
 		);
-		return;
 	}
 
-	(async () => {
-		const userGroupFunderPermission =
-			await createOrUpdateUserGroupFunderPermission(db, null, {
-				keycloakOrganizationId,
-				funderShortCode,
-				permission,
-				createdBy,
-			});
-		res
-			.status(201)
-			.contentType('application/json')
-			.send(userGroupFunderPermission);
-	})().catch((error: unknown) => {
-		if (isTinyPgErrorWithQueryContext(error)) {
-			next(new DatabaseError('Error creating item.', error));
-			return;
-		}
-		next(error);
-	});
+	const userGroupFunderPermission =
+		await createOrUpdateUserGroupFunderPermission(db, null, {
+			keycloakOrganizationId,
+			funderShortCode,
+			permission,
+			createdBy,
+		});
+	res
+		.status(201)
+		.contentType('application/json')
+		.send(userGroupFunderPermission);
 };
 
 const userGroupFunderPermissionsHandlers = {

--- a/src/handlers/usersHandlers.ts
+++ b/src/handlers/usersHandlers.ts
@@ -1,38 +1,30 @@
 import { db, getLimitValues, loadUserBundle } from '../database';
-import { isAuthContext, isTinyPgErrorWithQueryContext } from '../types';
-import { DatabaseError, FailedMiddlewareError } from '../errors';
+import { isAuthContext } from '../types';
+import { FailedMiddlewareError } from '../errors';
 import {
 	extractKeycloakUserIdParameters,
 	extractPaginationParameters,
 } from '../queryParameters';
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response } from 'express';
 
-const getUsers = (req: Request, res: Response, next: NextFunction): void => {
+const getUsers = async (req: Request, res: Response) => {
 	if (!isAuthContext(req)) {
-		next(new FailedMiddlewareError('Unexpected lack of auth context.'));
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
 		return;
 	}
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
 	const { keycloakUserId } = extractKeycloakUserIdParameters(req);
 
-	(async () => {
-		const userBundle = await loadUserBundle(
-			db,
-			req,
-			keycloakUserId,
-			limit,
-			offset,
-		);
+	const userBundle = await loadUserBundle(
+		db,
+		req,
+		keycloakUserId,
+		limit,
+		offset,
+	);
 
-		res.status(200).contentType('application/json').send(userBundle);
-	})().catch((error: unknown) => {
-		if (isTinyPgErrorWithQueryContext(error)) {
-			next(new DatabaseError('Error retrieving users.', error));
-			return;
-		}
-		next(error);
-	});
+	res.status(200).contentType('application/json').send(userBundle);
 };
 
 const usersHandlers = {


### PR DESCRIPTION
This PR moves our handlers to be async, which Express 5 supports!

There should be no logical changes, just code cleanup and a minor refactor to consolidate the handling of psql errors.

Specifically what changed is:

1. Removed all calls to `next` and replaced them with `throw`
2. Moved the boilerplate logic that translated psql errors to DatabaseErrors into the error handler middleware (this really should have just been done regardless of async handlers honestly).
3. Made all handlers async -- which allowed the removal of internal anonymous async functions.

Resolves #700