### PR TITLE
Ensure transaction is complete before responding

### DIFF
--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -163,7 +163,7 @@ const postProposalVersion = async (req: Request, res: Response) => {
 			),
 			assertSourceExists(sourceId),
 		]);
-		await db.transaction(async (transactionDb) => {
+		const finalProposalVersion = await db.transaction(async (transactionDb) => {
 			const proposalVersion = await createProposalVersion(transactionDb, req, {
 				proposalId,
 				applicationFormId,
@@ -194,14 +194,12 @@ const postProposalVersion = async (req: Request, res: Response) => {
 					return proposalFieldValue;
 				}),
 			);
-			res
-				.status(201)
-				.contentType('application/json')
-				.send({
-					...proposalVersion,
-					fieldValues: proposalFieldValues,
-				});
+			return {
+				...proposalVersion,
+				fieldValues: proposalFieldValues,
+			};
 		});
+		res.status(201).contentType('application/json').send(finalProposalVersion);
 	} catch (error: unknown) {
 		if (error instanceof NotFoundError) {
 			if (error.details.entityType === 'Source') {


### PR DESCRIPTION
This PR fixes a bug where a handler was resolving inside of a transaction; this could have meant double-responses in the event of a failed transaction, but more immediately it was resulting in intermittent test failures as the test would sometimes load data from the pre-transaction data state.

Resolves #1550 