### PR TITLE
Use auth context agent for `createdBy` population

### DIFF
--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../database';
 import { getLogger } from '../logger';
 import { BaseFieldDataType, BaseFieldScope, Permission } from '../types';
-import { expectTimestamp, loadTestUser } from '../test/utils';
+import { expectTimestamp, getAuthContext, loadTestUser } from '../test/utils';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
@@ -107,12 +107,12 @@ describe('/applicationForms', () => {
 		it('returns only application forms that the user is allowed to view', async () => {
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.VIEW,
-				createdBy: systemUser.keycloakUserId,
 			});
 			const otherFunder = await createOrUpdateFunder(db, null, {
 				shortCode: 'otherFunder',
@@ -262,12 +262,12 @@ describe('/applicationForms', () => {
 		it('returns an application form with its fields when the user has read access to the relevant funder', async () => {
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.VIEW,
-				createdBy: systemUser.keycloakUserId,
 			});
 			await createOpportunity(db, null, {
 				title: 'Holiday opportunity 🎄',
@@ -340,18 +340,17 @@ describe('/applicationForms', () => {
 		it('should return 404 when the user does not have read access to the relevant funder', async () => {
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
 			});
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.MANAGE,
-				createdBy: systemUser.keycloakUserId,
 			});
 			await createOpportunity(db, null, {
 				title: 'Holiday opportunity 🎄',
@@ -396,18 +395,17 @@ describe('/applicationForms', () => {
 		it('creates exactly one application form as a user with proper permissions', async () => {
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
 			});
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.VIEW,
-				createdBy: systemUser.keycloakUserId,
 			});
 			await createOpportunity(db, null, {
 				title: 'Tremendous opportunity 👌',
@@ -465,18 +463,17 @@ describe('/applicationForms', () => {
 		it(`returns 401 unauthorized if the user does not have edit permission on the associated opportunity's funder`, async () => {
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.VIEW,
-				createdBy: systemUser.keycloakUserId,
 			});
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.MANAGE,
-				createdBy: systemUser.keycloakUserId,
 			});
 			await createOpportunity(db, null, {
 				title: 'Tremendous opportunity 👌',

--- a/src/__tests__/baseFieldsCopyTasks.int.test.ts
+++ b/src/__tests__/baseFieldsCopyTasks.int.test.ts
@@ -6,7 +6,7 @@ import {
 	createOrUpdateUser,
 	loadTableMetrics,
 } from '../database';
-import { expectTimestamp, loadTestUser } from '../test/utils';
+import { expectTimestamp, getAuthContext, loadTestUser } from '../test/utils';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
@@ -38,20 +38,20 @@ describe('/tasks/baseFieldsCopy', () => {
 
 		it('returns all BaseFieldsCopy Tasks for administrative users', async () => {
 			const testUser = await loadTestUser();
+			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
+			const anotherUserAuthContext = getAuthContext(anotherUser);
 
-			await createBaseFieldsCopyTask(db, null, {
+			await createBaseFieldsCopyTask(db, testUserAuthContext, {
 				pdcApiUrl: MOCK_API_URL,
 				status: TaskStatus.PENDING,
-				createdBy: testUser.keycloakUserId,
 			});
 
-			await createBaseFieldsCopyTask(db, null, {
+			await createBaseFieldsCopyTask(db, anotherUserAuthContext, {
 				pdcApiUrl: MOCK_API_URL,
 				status: TaskStatus.COMPLETED,
-				createdBy: anotherUser.keycloakUserId,
 			});
 
 			await request(app)
@@ -85,12 +85,12 @@ describe('/tasks/baseFieldsCopy', () => {
 
 		it('supports pagination', async () => {
 			const testUser = await loadTestUser();
+			const testUserAuthContext = getAuthContext(testUser);
 			await Array.from(Array(20)).reduce(async (p) => {
 				await p;
-				await createBaseFieldsCopyTask(db, null, {
+				await createBaseFieldsCopyTask(db, testUserAuthContext, {
 					pdcApiUrl: MOCK_API_URL,
 					status: TaskStatus.COMPLETED,
-					createdBy: testUser.keycloakUserId,
 				});
 			}, Promise.resolve());
 

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -11,7 +11,7 @@ import {
 	createOrUpdateUserFunderPermission,
 	createOrUpdateFunder,
 } from '../database';
-import { expectTimestamp, loadTestUser } from '../test/utils';
+import { expectTimestamp, getAuthContext, loadTestUser } from '../test/utils';
 import {
 	mockJwt as authHeader,
 	mockJwtWithoutSub as authHeaderWithNoSub,
@@ -41,6 +41,9 @@ describe('/tasks/bulkUploads', () => {
 
 		it('returns all bulk upload tasks that the user is allowed to view', async () => {
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser();
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const anotherFunder = await createOrUpdateFunder(db, null, {
@@ -48,27 +51,23 @@ describe('/tasks/bulkUploads', () => {
 				name: 'Another Funder',
 				keycloakOrganizationId: null,
 			});
-			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.VIEW,
-				createdBy: systemUser.keycloakUserId,
 			});
-			await createBulkUploadTask(db, null, {
+			await createBulkUploadTask(db, testUserAuthContext, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
-				createdBy: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 			});
-			await createBulkUploadTask(db, null, {
+			await createBulkUploadTask(db, testUserAuthContext, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: TaskStatus.COMPLETED,
-				createdBy: testUser.keycloakUserId,
 				funderShortCode: anotherFunder.shortCode,
 			});
 
@@ -102,23 +101,23 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const testUser = await loadTestUser();
+			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask(db, null, {
+			const anotherUserAuthContext = getAuthContext(anotherUser);
+			await createBulkUploadTask(db, testUserAuthContext, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
-				createdBy: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 			});
-			await createBulkUploadTask(db, null, {
+			await createBulkUploadTask(db, anotherUserAuthContext, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: TaskStatus.COMPLETED,
-				createdBy: anotherUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 			});
 
@@ -165,23 +164,23 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const testUser = await loadTestUser();
+			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask(db, null, {
+			const anotherUserAuthContext = getAuthContext(anotherUser);
+			await createBulkUploadTask(db, testUserAuthContext, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
-				createdBy: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 			});
-			await createBulkUploadTask(db, null, {
+			await createBulkUploadTask(db, anotherUserAuthContext, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: TaskStatus.COMPLETED,
-				createdBy: anotherUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 			});
 
@@ -217,23 +216,23 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const testUser = await loadTestUser();
+			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			});
-			await createBulkUploadTask(db, null, {
+			const anotherUserAuthContext = getAuthContext(anotherUser);
+			await createBulkUploadTask(db, testUserAuthContext, {
 				sourceId: systemSource.id,
 				fileName: 'foo.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-foo',
 				status: TaskStatus.PENDING,
-				createdBy: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 			});
-			await createBulkUploadTask(db, null, {
+			await createBulkUploadTask(db, anotherUserAuthContext, {
 				sourceId: systemSource.id,
 				fileName: 'bar.csv',
 				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: TaskStatus.COMPLETED,
-				createdBy: anotherUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 			});
 
@@ -267,14 +266,14 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const testUser = await loadTestUser();
+			const testUserAuthContext = getAuthContext(testUser);
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
-				await createBulkUploadTask(db, null, {
+				await createBulkUploadTask(db, testUserAuthContext, {
 					sourceId: systemSource.id,
 					fileName: `bar-${i + 1}.csv`,
 					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 					status: TaskStatus.COMPLETED,
-					createdBy: testUser.keycloakUserId,
 					funderShortCode: systemFunder.shortCode,
 				});
 			}, Promise.resolve());
@@ -383,12 +382,12 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
 			});
 
 			const before = await loadTableMetrics('bulk_upload_tasks');
@@ -426,18 +425,17 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.VIEW,
-				createdBy: systemUser.keycloakUserId,
 			});
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.MANAGE,
-				createdBy: systemUser.keycloakUserId,
 			});
 
 			const before = await loadTableMetrics('bulk_upload_tasks');
@@ -468,12 +466,12 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
 			});
 			const result = await request(app)
 				.post('/tasks/bulkUploads')
@@ -494,12 +492,12 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
 			});
 			const result = await request(app)
 				.post('/tasks/bulkUploads')
@@ -521,12 +519,12 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
 			});
 			const result = await request(app)
 				.post('/tasks/bulkUploads')
@@ -548,12 +546,12 @@ describe('/tasks/bulkUploads', () => {
 			const systemSource = await loadSystemSource(db, null);
 			const systemFunder = await loadSystemFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser();
-			await createOrUpdateUserFunderPermission(db, null, {
+			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
 				funderShortCode: systemFunder.shortCode,
 				permission: Permission.EDIT,
-				createdBy: systemUser.keycloakUserId,
 			});
 			const result = await request(app)
 				.post('/tasks/bulkUploads')

--- a/src/database/operations/baseFieldsCopyTasks/createBaseFieldsCopyTask.ts
+++ b/src/database/operations/baseFieldsCopyTasks/createBaseFieldsCopyTask.ts
@@ -8,6 +8,6 @@ const createBaseFieldsCopyTask = generateCreateOrUpdateItemOperation<
 	BaseFieldsCopyTask,
 	InternallyWritableBaseFieldsCopyTask,
 	[]
->('baseFieldsCopyTasks.insertOne', ['status', 'pdcApiUrl', 'createdBy'], []);
+>('baseFieldsCopyTasks.insertOne', ['status', 'pdcApiUrl'], []);
 
 export { createBaseFieldsCopyTask };

--- a/src/database/operations/bulkUploadTasks/createBulkUploadTask.ts
+++ b/src/database/operations/bulkUploadTasks/createBulkUploadTask.ts
@@ -10,14 +10,7 @@ const createBulkUploadTask = generateCreateOrUpdateItemOperation<
 	[]
 >(
 	'bulkUploadTasks.insertOne',
-	[
-		'sourceId',
-		'funderShortCode',
-		'fileName',
-		'sourceKey',
-		'status',
-		'createdBy',
-	],
+	['sourceId', 'funderShortCode', 'fileName', 'sourceKey', 'status'],
 	[],
 );
 

--- a/src/database/operations/proposalVersions/createProposalVersion.ts
+++ b/src/database/operations/proposalVersions/createProposalVersion.ts
@@ -1,16 +1,13 @@
 import { generateCreateOrUpdateItemOperation } from '../generators';
-import type {
-	ProposalVersion,
-	InternallyWritableProposalVersion,
-} from '../../../types';
+import type { ProposalVersion, WritableProposalVersion } from '../../../types';
 
 const createProposalVersion = generateCreateOrUpdateItemOperation<
 	ProposalVersion,
-	InternallyWritableProposalVersion,
+	WritableProposalVersion,
 	[]
 >(
 	'proposalVersions.insertOne',
-	['proposalId', 'applicationFormId', 'sourceId', 'createdBy'],
+	['proposalId', 'applicationFormId', 'sourceId'],
 	[],
 );
 

--- a/src/database/operations/proposals/createProposal.ts
+++ b/src/database/operations/proposals/createProposal.ts
@@ -1,10 +1,10 @@
 import { generateCreateOrUpdateItemOperation } from '../generators';
-import type { Proposal, InternallyWritableProposal } from '../../../types';
+import type { Proposal, WritableProposal } from '../../../types';
 
 const createProposal = generateCreateOrUpdateItemOperation<
 	Proposal,
-	InternallyWritableProposal,
+	WritableProposal,
 	[]
->('proposals.insertOne', ['opportunityId', 'externalId', 'createdBy'], []);
+>('proposals.insertOne', ['opportunityId', 'externalId'], []);
 
 export { createProposal };

--- a/src/database/operations/userChangemakerPermissions/createOrUpdateUserChangemakerPermission.ts
+++ b/src/database/operations/userChangemakerPermissions/createOrUpdateUserChangemakerPermission.ts
@@ -11,7 +11,7 @@ const createOrUpdateUserChangemakerPermission =
 		[]
 	>(
 		'userChangemakerPermissions.insertOrUpdateOne',
-		['userKeycloakUserId', 'permission', 'changemakerId', 'createdBy'],
+		['userKeycloakUserId', 'permission', 'changemakerId'],
 		[],
 	);
 

--- a/src/database/operations/userDataProviderPermissions/createOrUpdateUserDataProviderPermission.ts
+++ b/src/database/operations/userDataProviderPermissions/createOrUpdateUserDataProviderPermission.ts
@@ -11,7 +11,7 @@ const createOrUpdateUserDataProviderPermission =
 		[]
 	>(
 		'userDataProviderPermissions.insertOrUpdateOne',
-		['userKeycloakUserId', 'permission', 'dataProviderShortCode', 'createdBy'],
+		['userKeycloakUserId', 'permission', 'dataProviderShortCode'],
 		[],
 	);
 

--- a/src/database/operations/userFunderPermissions/createOrUpdateUserFunderPermission.ts
+++ b/src/database/operations/userFunderPermissions/createOrUpdateUserFunderPermission.ts
@@ -10,7 +10,7 @@ const createOrUpdateUserFunderPermission = generateCreateOrUpdateItemOperation<
 	[]
 >(
 	'userFunderPermissions.insertOrUpdateOne',
-	['userKeycloakUserId', 'permission', 'funderShortCode', 'createdBy'],
+	['userKeycloakUserId', 'permission', 'funderShortCode'],
 	[],
 );
 

--- a/src/database/operations/userGroupChangemakerPermissions/createOrUpdateUserGroupChangemakerPermission.ts
+++ b/src/database/operations/userGroupChangemakerPermissions/createOrUpdateUserGroupChangemakerPermission.ts
@@ -11,7 +11,7 @@ const createOrUpdateUserGroupChangemakerPermission =
 		[]
 	>(
 		'userGroupChangemakerPermissions.insertOrUpdateOne',
-		['keycloakOrganizationId', 'permission', 'changemakerId', 'createdBy'],
+		['keycloakOrganizationId', 'permission', 'changemakerId'],
 		[],
 	);
 

--- a/src/database/operations/userGroupDataProviderPermissions/createOrUpdateUserGroupDataProviderPermission.ts
+++ b/src/database/operations/userGroupDataProviderPermissions/createOrUpdateUserGroupDataProviderPermission.ts
@@ -11,12 +11,7 @@ const createOrUpdateUserGroupDataProviderPermission =
 		[]
 	>(
 		'userGroupDataProviderPermissions.insertOrUpdateOne',
-		[
-			'keycloakOrganizationId',
-			'permission',
-			'dataProviderShortCode',
-			'createdBy',
-		],
+		['keycloakOrganizationId', 'permission', 'dataProviderShortCode'],
 		[],
 	);
 

--- a/src/database/operations/userGroupFunderPermissions/createOrUpdateUserGroupFunderPermission.ts
+++ b/src/database/operations/userGroupFunderPermissions/createOrUpdateUserGroupFunderPermission.ts
@@ -11,7 +11,7 @@ const createOrUpdateUserGroupFunderPermission =
 		[]
 	>(
 		'userGroupFunderPermissions.insertOrUpdateOne',
-		['keycloakOrganizationId', 'permission', 'funderShortCode', 'createdBy'],
+		['keycloakOrganizationId', 'permission', 'funderShortCode'],
 		[],
 	);
 

--- a/src/database/operations/users/__tests__/loadUserByKeycloakUserId.int.test.ts
+++ b/src/database/operations/users/__tests__/loadUserByKeycloakUserId.int.test.ts
@@ -15,12 +15,13 @@ import {
 } from '../..';
 import { db } from '../../../db';
 import { Permission, stringToKeycloakId } from '../../../../types';
-import { expectTimestamp } from '../../../../test/utils';
+import { expectTimestamp, getAuthContext } from '../../../../test/utils';
 
 describe('loadUserByKeycloakUserId', () => {
 	it('should populate roles correctly based on direct permissions as well as user groups permissions', async () => {
-		const ephemeralExpiration = new Date(Date.now() + 3600000).toISOString();
 		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const ephemeralExpiration = new Date(Date.now() + 3600000).toISOString();
 		const user = await createOrUpdateUser(db, null, {
 			keycloakUserId: '42db47e1-0612-4a41-9092-7928491b1fad',
 		});
@@ -73,88 +74,92 @@ describe('loadUserByKeycloakUserId', () => {
 		});
 
 		// Assign EDIT and VIEW via direct permissions
-		await createOrUpdateUserChangemakerPermission(db, null, {
+		await createOrUpdateUserChangemakerPermission(db, systemUserAuthContext, {
 			userKeycloakUserId: user.keycloakUserId,
 			changemakerId: changemaker.id,
 			permission: Permission.EDIT,
-			createdBy: systemUser.keycloakUserId,
 		});
-		await createOrUpdateUserChangemakerPermission(db, null, {
+		await createOrUpdateUserChangemakerPermission(db, systemUserAuthContext, {
 			userKeycloakUserId: user.keycloakUserId,
 			changemakerId: changemaker.id,
 			permission: Permission.VIEW,
-			createdBy: systemUser.keycloakUserId,
 		});
-		await createOrUpdateUserFunderPermission(db, null, {
+		await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 			userKeycloakUserId: user.keycloakUserId,
 			funderShortCode: funder.shortCode,
 			permission: Permission.EDIT,
-			createdBy: systemUser.keycloakUserId,
 		});
-		await createOrUpdateUserFunderPermission(db, null, {
+		await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 			userKeycloakUserId: user.keycloakUserId,
 			funderShortCode: funder.shortCode,
 			permission: Permission.VIEW,
-			createdBy: systemUser.keycloakUserId,
 		});
-		await createOrUpdateUserDataProviderPermission(db, null, {
+		await createOrUpdateUserDataProviderPermission(db, systemUserAuthContext, {
 			userKeycloakUserId: user.keycloakUserId,
 			dataProviderShortCode: dataProvider.shortCode,
 			permission: Permission.EDIT,
-			createdBy: systemUser.keycloakUserId,
 		});
-		await createOrUpdateUserDataProviderPermission(db, null, {
+		await createOrUpdateUserDataProviderPermission(db, systemUserAuthContext, {
 			userKeycloakUserId: user.keycloakUserId,
 			dataProviderShortCode: dataProvider.shortCode,
 			permission: Permission.VIEW,
-			createdBy: systemUser.keycloakUserId,
 		});
 
 		// Assign MANAGE and VIEW via group permissions
-		await createOrUpdateUserGroupChangemakerPermission(db, null, {
-			keycloakOrganizationId: stringToKeycloakId(
-				changemakerKeycloakOrganizationId,
-			),
-			changemakerId: changemaker.id,
-			permission: Permission.MANAGE,
-			createdBy: systemUser.keycloakUserId,
-		});
-		await createOrUpdateUserGroupChangemakerPermission(db, null, {
-			keycloakOrganizationId: stringToKeycloakId(
-				changemakerKeycloakOrganizationId,
-			),
-			changemakerId: changemaker.id,
-			permission: Permission.VIEW,
-			createdBy: systemUser.keycloakUserId,
-		});
-		await createOrUpdateUserGroupFunderPermission(db, null, {
+		await createOrUpdateUserGroupChangemakerPermission(
+			db,
+			systemUserAuthContext,
+			{
+				keycloakOrganizationId: stringToKeycloakId(
+					changemakerKeycloakOrganizationId,
+				),
+				changemakerId: changemaker.id,
+				permission: Permission.MANAGE,
+			},
+		);
+		await createOrUpdateUserGroupChangemakerPermission(
+			db,
+			systemUserAuthContext,
+			{
+				keycloakOrganizationId: stringToKeycloakId(
+					changemakerKeycloakOrganizationId,
+				),
+				changemakerId: changemaker.id,
+				permission: Permission.VIEW,
+			},
+		);
+		await createOrUpdateUserGroupFunderPermission(db, systemUserAuthContext, {
 			keycloakOrganizationId: stringToKeycloakId(funderKeycloakOrganizationId),
 			funderShortCode: funder.shortCode,
 			permission: Permission.MANAGE,
-			createdBy: systemUser.keycloakUserId,
 		});
-		await createOrUpdateUserGroupFunderPermission(db, null, {
+		await createOrUpdateUserGroupFunderPermission(db, systemUserAuthContext, {
 			keycloakOrganizationId: stringToKeycloakId(funderKeycloakOrganizationId),
 			funderShortCode: funder.shortCode,
 			permission: Permission.VIEW,
-			createdBy: systemUser.keycloakUserId,
 		});
-		await createOrUpdateUserGroupDataProviderPermission(db, null, {
-			keycloakOrganizationId: stringToKeycloakId(
-				dataProviderKeycloakOrganizationId,
-			),
-			dataProviderShortCode: dataProvider.shortCode,
-			permission: Permission.MANAGE,
-			createdBy: systemUser.keycloakUserId,
-		});
-		await createOrUpdateUserGroupDataProviderPermission(db, null, {
-			keycloakOrganizationId: stringToKeycloakId(
-				dataProviderKeycloakOrganizationId,
-			),
-			dataProviderShortCode: dataProvider.shortCode,
-			permission: Permission.VIEW,
-			createdBy: systemUser.keycloakUserId,
-		});
+		await createOrUpdateUserGroupDataProviderPermission(
+			db,
+			systemUserAuthContext,
+			{
+				keycloakOrganizationId: stringToKeycloakId(
+					dataProviderKeycloakOrganizationId,
+				),
+				dataProviderShortCode: dataProvider.shortCode,
+				permission: Permission.MANAGE,
+			},
+		);
+		await createOrUpdateUserGroupDataProviderPermission(
+			db,
+			systemUserAuthContext,
+			{
+				keycloakOrganizationId: stringToKeycloakId(
+					dataProviderKeycloakOrganizationId,
+				),
+				dataProviderShortCode: dataProvider.shortCode,
+				permission: Permission.VIEW,
+			},
+		);
 
 		const populatedUser = await loadUserByKeycloakUserId(
 			db,
@@ -193,6 +198,7 @@ describe('loadUserByKeycloakUserId', () => {
 
 	it('should not populate roles for expired group associations', async () => {
 		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
 		const user = await createOrUpdateUser(db, null, {
 			keycloakUserId: '42db47e1-0612-4a41-9092-7928491b1fad',
 		});
@@ -245,28 +251,33 @@ describe('loadUserByKeycloakUserId', () => {
 		});
 
 		// Assign VIEW via group permissions
-		await createOrUpdateUserGroupChangemakerPermission(db, null, {
-			keycloakOrganizationId: stringToKeycloakId(
-				changemakerKeycloakOrganizationId,
-			),
-			changemakerId: changemaker.id,
-			permission: Permission.VIEW,
-			createdBy: systemUser.keycloakUserId,
-		});
-		await createOrUpdateUserGroupFunderPermission(db, null, {
+		await createOrUpdateUserGroupChangemakerPermission(
+			db,
+			systemUserAuthContext,
+			{
+				keycloakOrganizationId: stringToKeycloakId(
+					changemakerKeycloakOrganizationId,
+				),
+				changemakerId: changemaker.id,
+				permission: Permission.VIEW,
+			},
+		);
+		await createOrUpdateUserGroupFunderPermission(db, systemUserAuthContext, {
 			keycloakOrganizationId: stringToKeycloakId(funderKeycloakOrganizationId),
 			funderShortCode: funder.shortCode,
 			permission: Permission.VIEW,
-			createdBy: systemUser.keycloakUserId,
 		});
-		await createOrUpdateUserGroupDataProviderPermission(db, null, {
-			keycloakOrganizationId: stringToKeycloakId(
-				dataProviderKeycloakOrganizationId,
-			),
-			dataProviderShortCode: dataProvider.shortCode,
-			permission: Permission.VIEW,
-			createdBy: systemUser.keycloakUserId,
-		});
+		await createOrUpdateUserGroupDataProviderPermission(
+			db,
+			systemUserAuthContext,
+			{
+				keycloakOrganizationId: stringToKeycloakId(
+					dataProviderKeycloakOrganizationId,
+				),
+				dataProviderShortCode: dataProvider.shortCode,
+				permission: Permission.VIEW,
+			},
+		);
 
 		const populatedUser = await loadUserByKeycloakUserId(
 			db,

--- a/src/database/queries/baseFieldsCopyTasks/insertOne.sql
+++ b/src/database/queries/baseFieldsCopyTasks/insertOne.sql
@@ -6,6 +6,6 @@ INSERT INTO base_fields_copy_tasks (
 VALUES (
 	:status,
 	:pdcApiUrl,
-	:createdBy
+	:authContextKeycloakUserId
 )
 RETURNING base_fields_copy_task_to_json(base_fields_copy_tasks) AS object;

--- a/src/database/queries/bulkUploadTasks/insertOne.sql
+++ b/src/database/queries/bulkUploadTasks/insertOne.sql
@@ -12,6 +12,6 @@ VALUES (
 	:fileName,
 	:sourceKey,
 	:status,
-	:createdBy
+	:authContextKeycloakUserId
 )
 RETURNING bulk_upload_task_to_json(bulk_upload_tasks) AS object;

--- a/src/database/queries/proposalVersions/insertOne.sql
+++ b/src/database/queries/proposalVersions/insertOne.sql
@@ -8,7 +8,7 @@ INSERT INTO proposal_versions (
 	:proposalId,
 	:applicationFormId,
 	:sourceId,
-	:createdBy,
+	:authContextKeycloakUserId,
 	coalesce(
 		(
 			SELECT max(pv.version) + 1

--- a/src/database/queries/proposals/insertOne.sql
+++ b/src/database/queries/proposals/insertOne.sql
@@ -5,6 +5,6 @@ INSERT INTO proposals (
 ) VALUES (
 	:externalId,
 	:opportunityId,
-	:createdBy
+	:authContextKeycloakUserId
 )
 RETURNING proposal_to_json(proposals) AS object;

--- a/src/database/queries/userChangemakerPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userChangemakerPermissions/insertOrUpdateOne.sql
@@ -8,7 +8,7 @@ INSERT INTO user_changemaker_permissions (
 	:userKeycloakUserId,
 	:permission::permission_t,
 	:changemakerId,
-	:createdBy,
+	:authContextKeycloakUserId,
 	null
 )
 ON CONFLICT (user_keycloak_user_id, permission, changemaker_id) DO UPDATE

--- a/src/database/queries/userDataProviderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userDataProviderPermissions/insertOrUpdateOne.sql
@@ -8,7 +8,7 @@ INSERT INTO user_data_provider_permissions (
 	:userKeycloakUserId,
 	:permission::permission_t,
 	:dataProviderShortCode,
-	:createdBy,
+	:authContextKeycloakUserId,
 	null
 )
 ON CONFLICT (

--- a/src/database/queries/userFunderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userFunderPermissions/insertOrUpdateOne.sql
@@ -8,7 +8,7 @@ INSERT INTO user_funder_permissions (
 	:userKeycloakUserId,
 	:permission::permission_t,
 	:funderShortCode,
-	:createdBy,
+	:authContextKeycloakUserId,
 	NULL
 )
 ON CONFLICT (user_keycloak_user_id, permission, funder_short_code) DO UPDATE

--- a/src/database/queries/userGroupChangemakerPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userGroupChangemakerPermissions/insertOrUpdateOne.sql
@@ -8,7 +8,7 @@ INSERT INTO user_group_changemaker_permissions (
 	:keycloakOrganizationId,
 	:permission,
 	:changemakerId,
-	:createdBy,
+	:authContextKeycloakUserId,
 	null
 )
 ON CONFLICT (keycloak_organization_id, permission, changemaker_id) DO UPDATE

--- a/src/database/queries/userGroupDataProviderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userGroupDataProviderPermissions/insertOrUpdateOne.sql
@@ -8,7 +8,7 @@ INSERT INTO user_group_data_provider_permissions (
 	:keycloakOrganizationId,
 	:permission,
 	:dataProviderShortCode,
-	:createdBy,
+	:authContextKeycloakUserId,
 	null
 )
 ON CONFLICT (

--- a/src/database/queries/userGroupFunderPermissions/insertOrUpdateOne.sql
+++ b/src/database/queries/userGroupFunderPermissions/insertOrUpdateOne.sql
@@ -8,7 +8,7 @@ INSERT INTO user_group_funder_permissions (
 	:keycloakOrganizationId,
 	:permission,
 	:funderShortCode,
-	:createdBy,
+	:authContextKeycloakUserId,
 	NULL
 )
 ON CONFLICT (keycloak_organization_id, permission, funder_short_code) DO UPDATE

--- a/src/handlers/baseFieldsCopyTasksHandlers.ts
+++ b/src/handlers/baseFieldsCopyTasksHandlers.ts
@@ -30,11 +30,9 @@ const postBaseFieldsCopyTask = async (req: Request, res: Response) => {
 	}
 
 	const { pdcApiUrl } = req.body;
-	const createdBy = req.user.keycloakUserId;
-	const baseFieldsCopyTask = await createBaseFieldsCopyTask(db, null, {
+	const baseFieldsCopyTask = await createBaseFieldsCopyTask(db, req, {
 		pdcApiUrl,
 		status: TaskStatus.PENDING,
-		createdBy,
 	});
 
 	await addCopyBaseFieldsJob({

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -134,7 +134,6 @@ const postProposalVersion = async (req: Request, res: Response) => {
 	}
 
 	const { sourceId, fieldValues, proposalId, applicationFormId } = req.body;
-	const createdBy = req.user.keycloakUserId;
 
 	try {
 		const proposal = await loadProposal(db, req, proposalId);
@@ -166,7 +165,6 @@ const postProposalVersion = async (req: Request, res: Response) => {
 				proposalId,
 				applicationFormId,
 				sourceId,
-				createdBy,
 			});
 			const proposalFieldValues = await Promise.all(
 				fieldValues.map(async (fieldValue) => {

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -69,7 +69,6 @@ const postProposal = async (req: Request, res: Response) => {
 	}
 
 	const { externalId, opportunityId } = req.body;
-	const createdBy = req.user.keycloakUserId;
 
 	try {
 		const opportunity = await loadOpportunity(db, req, opportunityId);
@@ -84,10 +83,9 @@ const postProposal = async (req: Request, res: Response) => {
 				'You do not have write permissions on the funder associated with this opportunity.',
 			);
 		}
-		const proposal = await createProposal(db, null, {
+		const proposal = await createProposal(db, req, {
 			opportunityId,
 			externalId,
-			createdBy,
 		});
 		res.status(201).contentType('application/json').send(proposal);
 	} catch (error: unknown) {

--- a/src/handlers/userChangemakerPermissionsHandlers.ts
+++ b/src/handlers/userChangemakerPermissionsHandlers.ts
@@ -50,7 +50,6 @@ const putUserChangemakerPermission = async (req: Request, res: Response) => {
 	}
 
 	const { userKeycloakUserId, changemakerId, permission } = req.params;
-	const createdBy = req.user.keycloakUserId;
 
 	if (!isKeycloakId(userKeycloakUserId)) {
 		throw new InputValidationError(
@@ -78,11 +77,10 @@ const putUserChangemakerPermission = async (req: Request, res: Response) => {
 	}
 
 	const userChangemakerPermission =
-		await createOrUpdateUserChangemakerPermission(db, null, {
+		await createOrUpdateUserChangemakerPermission(db, req, {
 			userKeycloakUserId,
 			changemakerId,
 			permission,
-			createdBy,
 		});
 	res
 		.status(201)

--- a/src/handlers/userDataProviderPermissionsHandlers.ts
+++ b/src/handlers/userDataProviderPermissionsHandlers.ts
@@ -54,7 +54,6 @@ const putUserDataProviderPermission = async (req: Request, res: Response) => {
 	}
 
 	const { userKeycloakUserId, dataProviderShortCode, permission } = req.params;
-	const createdBy = req.user.keycloakUserId;
 
 	if (!isKeycloakId(userKeycloakUserId)) {
 		throw new InputValidationError(
@@ -83,12 +82,11 @@ const putUserDataProviderPermission = async (req: Request, res: Response) => {
 
 	const userFunderPermission = await createOrUpdateUserDataProviderPermission(
 		db,
-		null,
+		req,
 		{
 			userKeycloakUserId,
 			dataProviderShortCode,
 			permission,
-			createdBy,
 		},
 	);
 	res.status(201).contentType('application/json').send(userFunderPermission);

--- a/src/handlers/userFunderPermissionsHandlers.ts
+++ b/src/handlers/userFunderPermissionsHandlers.ts
@@ -51,7 +51,6 @@ const putUserFunderPermission = async (req: Request, res: Response) => {
 	}
 
 	const { userKeycloakUserId, funderShortCode, permission } = req.params;
-	const createdBy = req.user.keycloakUserId;
 
 	if (!isKeycloakId(userKeycloakUserId)) {
 		throw new InputValidationError(
@@ -80,12 +79,11 @@ const putUserFunderPermission = async (req: Request, res: Response) => {
 
 	const userFunderPermission = await createOrUpdateUserFunderPermission(
 		db,
-		null,
+		req,
 		{
 			userKeycloakUserId,
 			funderShortCode,
 			permission,
-			createdBy,
 		},
 	);
 	res.status(201).contentType('application/json').send(userFunderPermission);

--- a/src/handlers/userGroupChangemakerPermissionsHandlers.ts
+++ b/src/handlers/userGroupChangemakerPermissionsHandlers.ts
@@ -57,7 +57,6 @@ const putUserGroupChangemakerPermission = async (
 	}
 
 	const { keycloakOrganizationId, changemakerId, permission } = req.params;
-	const createdBy = req.user.keycloakUserId;
 
 	if (!isKeycloakId(keycloakOrganizationId)) {
 		throw new InputValidationError(
@@ -85,11 +84,10 @@ const putUserGroupChangemakerPermission = async (
 	}
 
 	const userGroupChangemakerPermission =
-		await createOrUpdateUserGroupChangemakerPermission(db, null, {
+		await createOrUpdateUserGroupChangemakerPermission(db, req, {
 			keycloakOrganizationId,
 			changemakerId,
 			permission,
-			createdBy,
 		});
 	res
 		.status(201)

--- a/src/handlers/userGroupDataProviderPermissionsHandlers.ts
+++ b/src/handlers/userGroupDataProviderPermissionsHandlers.ts
@@ -59,7 +59,6 @@ const putUserGroupDataProviderPermission = async (
 
 	const { keycloakOrganizationId, dataProviderShortCode, permission } =
 		req.params;
-	const createdBy = req.user.keycloakUserId;
 
 	if (!isKeycloakId(keycloakOrganizationId)) {
 		throw new InputValidationError(
@@ -87,11 +86,10 @@ const putUserGroupDataProviderPermission = async (
 	}
 
 	const userGroupFunderPermission =
-		await createOrUpdateUserGroupDataProviderPermission(db, null, {
+		await createOrUpdateUserGroupDataProviderPermission(db, req, {
 			keycloakOrganizationId,
 			dataProviderShortCode,
 			permission,
-			createdBy,
 		});
 	res
 		.status(201)

--- a/src/handlers/userGroupFunderPermissionsHandlers.ts
+++ b/src/handlers/userGroupFunderPermissionsHandlers.ts
@@ -51,7 +51,6 @@ const putUserGroupFunderPermission = async (req: Request, res: Response) => {
 	}
 
 	const { keycloakOrganizationId, funderShortCode, permission } = req.params;
-	const createdBy = req.user.keycloakUserId;
 
 	if (!isKeycloakId(keycloakOrganizationId)) {
 		throw new InputValidationError(
@@ -79,11 +78,10 @@ const putUserGroupFunderPermission = async (req: Request, res: Response) => {
 	}
 
 	const userGroupFunderPermission =
-		await createOrUpdateUserGroupFunderPermission(db, null, {
+		await createOrUpdateUserGroupFunderPermission(db, req, {
 			keycloakOrganizationId,
 			funderShortCode,
 			permission,
-			createdBy,
 		});
 	res
 		.status(201)

--- a/src/tasks/__tests__/copyBaseFields.int.test.ts
+++ b/src/tasks/__tests__/copyBaseFields.int.test.ts
@@ -17,22 +17,22 @@ import {
 	TaskStatus,
 	BaseFieldDataType,
 	BaseFieldScope,
+	AuthContext,
 } from '../../types';
-import { expectTimestamp } from '../../test/utils';
+import { expectTimestamp, getAuthContext } from '../../test/utils';
 
 const MOCK_API_URL = 'https://example.com';
 
 const createTestBaseFieldsCopyTask = async (
+	authContext: AuthContext,
 	overrideValues?: Partial<InternallyWritableBaseFieldsCopyTask>,
 ): Promise<BaseFieldsCopyTask> => {
-	const systemUser = await loadSystemUser(db, null);
 	const defaultValues = {
 		pdcApiUrl: MOCK_API_URL,
 		status: TaskStatus.PENDING,
 		statusUpdatedAt: new Date(Date.now()).toISOString(),
-		createdBy: systemUser.keycloakUserId,
 	};
-	return createBaseFieldsCopyTask(db, null, {
+	return createBaseFieldsCopyTask(db, authContext, {
 		...defaultValues,
 		...overrideValues,
 	});
@@ -170,9 +170,14 @@ describe('copyBaseFields', () => {
 	});
 
 	it('should not process or modify processing status if the task is not PENDING', async () => {
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.IN_PROGRESS,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.IN_PROGRESS,
+			},
+		);
 		const request = nock(MOCK_API_URL)
 			.get('/baseFields')
 			.reply(200, mockBaseFields);
@@ -193,9 +198,14 @@ describe('copyBaseFields', () => {
 	});
 
 	it('should fail if the remote url is unavailable', async () => {
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 		const request = nock(MOCK_API_URL)
 			.get('/baseFields')
 			.reply(404, 'page not found');
@@ -216,9 +226,14 @@ describe('copyBaseFields', () => {
 	});
 
 	it('should fail if the remote url is available, but sends back invalid basefield data', async () => {
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 		const request = nock(MOCK_API_URL)
 			.get('/baseFields')
 			.reply(200, [
@@ -248,9 +263,14 @@ describe('copyBaseFields', () => {
 	it('should not insert any remote basefields if there are no basefields in the remote instance', async () => {
 		const before = await loadTableMetrics('base_fields');
 
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 		const request = nock(MOCK_API_URL).get('/baseFields').reply(200, []);
 
 		await copyBaseFields(
@@ -275,9 +295,14 @@ describe('copyBaseFields', () => {
 	it('should insert all remote basefields to an empty local database', async () => {
 		const before = await loadTableMetrics('base_fields');
 
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 		const request = nock(MOCK_API_URL)
 			.get('/baseFields')
 			.reply(200, [mockFirstNameBaseField]);
@@ -340,9 +365,14 @@ describe('copyBaseFields', () => {
 
 		const before = await loadTableMetrics('base_fields');
 
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 		const request = nock(MOCK_API_URL)
 			.get('/baseFields')
 			.reply(200, mockBaseFields);
@@ -396,9 +426,14 @@ describe('copyBaseFields', () => {
 
 		const before = await loadTableMetrics('base_fields');
 
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 		const request = nock(MOCK_API_URL)
 			.get('/baseFields')
 			.reply(200, [mockRemoteBaseField]);
@@ -458,9 +493,14 @@ describe('copyBaseFields', () => {
 
 		const before = await loadTableMetrics('base_fields');
 
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 		const request = nock(MOCK_API_URL)
 			.get('/baseFields')
 			.reply(200, [mockRemoteBaseField, mockFirstNameBaseField]);
@@ -546,9 +586,14 @@ describe('copyBaseFields', () => {
 			.get('/baseFields')
 			.reply(200, [mockFirstNameBaseFieldWithNoLocalizations]);
 
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 
 		await copyBaseFields(
 			{ baseFieldsCopyTaskId: baseFieldsCopyTask.id },
@@ -606,9 +651,14 @@ describe('copyBaseFields', () => {
 			.get('/baseFields')
 			.reply(200, [mockFirstNameBaseField]);
 
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 
 		await copyBaseFields(
 			{ baseFieldsCopyTaskId: baseFieldsCopyTask.id },
@@ -663,9 +713,14 @@ describe('copyBaseFields', () => {
 	it('should insert all valid remote basefields into the database, and have status set as completed', async () => {
 		const before = await loadTableMetrics('base_fields');
 
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 		const request = nock(MOCK_API_URL)
 			.get('/baseFields')
 			.reply(200, mockBaseFields);
@@ -700,9 +755,14 @@ describe('copyBaseFields', () => {
 
 		const before = await loadTableMetrics('base_fields');
 
-		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask({
-			status: TaskStatus.PENDING,
-		});
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const baseFieldsCopyTask = await createTestBaseFieldsCopyTask(
+			systemUserAuthContext,
+			{
+				status: TaskStatus.PENDING,
+			},
+		);
 		const request = nock(MOCK_API_URL)
 			.get('/baseFields')
 			.reply(200, [mockFirstNameBaseField]);

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,5 +1,5 @@
 import { db, createOrUpdateUser, loadUserByKeycloakUserId } from '../database';
-import { stringToKeycloakId } from '../types';
+import { stringToKeycloakId, User } from '../types';
 
 export const isoTimestampPattern =
 	/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?(Z|(\+|-)\d{2}:\d{2})$/;
@@ -33,12 +33,15 @@ export const createTestUser = async () =>
 export const loadTestUser = async () =>
 	loadUserByKeycloakUserId(db, null, getTestUserKeycloakUserId());
 
-export const getTestAuthContext = async () => ({
-	user: await loadTestUser(),
+export const getAuthContext = (user: User, isAdministrator = false) => ({
+	user,
 	role: {
-		isAdministrator: true,
+		isAdministrator,
 	},
 });
+
+export const getTestAuthContext = async () =>
+	getAuthContext(await loadTestUser(), true);
 
 export const NO_OFFSET = 0;
 

--- a/src/types/BaseFieldsCopyTask.ts
+++ b/src/types/BaseFieldsCopyTask.ts
@@ -16,7 +16,7 @@ interface BaseFieldsCopyTask {
 type WritableBaseFieldsCopyTask = Writable<BaseFieldsCopyTask>;
 
 type InternallyWritableBaseFieldsCopyTask = WritableBaseFieldsCopyTask &
-	Pick<BaseFieldsCopyTask, 'status' | 'createdBy'>;
+	Pick<BaseFieldsCopyTask, 'status'>;
 
 const writableBaseFieldsCopyTaskSchema: JSONSchemaType<WritableBaseFieldsCopyTask> =
 	{

--- a/src/types/BulkUploadTask.ts
+++ b/src/types/BulkUploadTask.ts
@@ -25,7 +25,7 @@ interface BulkUploadTask {
 type WritableBulkUploadTask = Writable<BulkUploadTask>;
 
 type InternallyWritableBulkUploadTask = WritableBulkUploadTask &
-	Pick<BulkUploadTask, 'status' | 'fileSize' | 'createdBy'>;
+	Pick<BulkUploadTask, 'status' | 'fileSize'>;
 
 const writableBulkUploadTaskSchema: JSONSchemaType<WritableBulkUploadTask> = {
 	type: 'object',

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -15,9 +15,6 @@ interface Proposal {
 
 type WritableProposal = Writable<Proposal>;
 
-type InternallyWritableProposal = WritableProposal &
-	Pick<Proposal, 'createdBy'>;
-
 const writableProposalSchema: JSONSchemaType<WritableProposal> = {
 	type: 'object',
 	properties: {
@@ -36,7 +33,6 @@ const isWritableProposal = ajv.compile(writableProposalSchema);
 
 export {
 	isWritableProposal,
-	InternallyWritableProposal,
 	Proposal,
 	WritableProposal,
 	writableProposalSchema,

--- a/src/types/ProposalVersion.ts
+++ b/src/types/ProposalVersion.ts
@@ -23,9 +23,6 @@ interface ProposalVersion {
 
 type WritableProposalVersion = Writable<ProposalVersion>;
 
-type InternallyWritableProposalVersion = WritableProposalVersion &
-	Pick<ProposalVersion, 'createdBy'>;
-
 type WritableProposalVersionWithFieldValues = WritableProposalVersion & {
 	fieldValues: WritableProposalFieldValueWithProposalVersionContext[];
 };
@@ -56,8 +53,8 @@ const isWritableProposalVersionWithFieldValues = ajv.compile(
 );
 
 export {
-	InternallyWritableProposalVersion,
 	ProposalVersion,
+	WritableProposalVersion,
 	WritableProposalVersionWithFieldValues,
 	isWritableProposalVersionWithFieldValues,
 };

--- a/src/types/UserChangemakerPermission.ts
+++ b/src/types/UserChangemakerPermission.ts
@@ -18,7 +18,7 @@ type InternallyWritableUserChangemakerPermission =
 	WritableUserChangemakerPermission &
 		Pick<
 			UserChangemakerPermission,
-			'userKeycloakUserId' | 'permission' | 'changemakerId' | 'createdBy'
+			'userKeycloakUserId' | 'permission' | 'changemakerId'
 		>;
 
 const writableUserChangemakerPermissionSchema: JSONSchemaType<WritableUserChangemakerPermission> =

--- a/src/types/UserDataProviderPermission.ts
+++ b/src/types/UserDataProviderPermission.ts
@@ -19,10 +19,7 @@ type InternallyWritableUserDataProviderPermission =
 	WritableUserDataProviderPermission &
 		Pick<
 			UserDataProviderPermission,
-			| 'userKeycloakUserId'
-			| 'permission'
-			| 'dataProviderShortCode'
-			| 'createdBy'
+			'userKeycloakUserId' | 'permission' | 'dataProviderShortCode'
 		>;
 
 const writableUserDataProviderSchema: JSONSchemaType<WritableUserDataProviderPermission> =

--- a/src/types/UserFunderPermission.ts
+++ b/src/types/UserFunderPermission.ts
@@ -18,7 +18,7 @@ type WritableUserFunderPermission = Writable<UserFunderPermission>;
 type InternallyWritableUserFunderPermission = WritableUserFunderPermission &
 	Pick<
 		UserFunderPermission,
-		'userKeycloakUserId' | 'permission' | 'funderShortCode' | 'createdBy'
+		'userKeycloakUserId' | 'permission' | 'funderShortCode'
 	>;
 
 const writableUserFunderPermissionSchema: JSONSchemaType<WritableUserFunderPermission> =

--- a/src/types/UserGroupChangemakerPermission.ts
+++ b/src/types/UserGroupChangemakerPermission.ts
@@ -19,7 +19,7 @@ type InternallyWritableUserGroupChangemakerPermission =
 	WritableUserGroupChangemakerPermission &
 		Pick<
 			UserGroupChangemakerPermission,
-			'keycloakOrganizationId' | 'changemakerId' | 'permission' | 'createdBy'
+			'keycloakOrganizationId' | 'changemakerId' | 'permission'
 		>;
 
 const writableUserGroupChangemakerPermissionSchema: JSONSchemaType<WritableUserGroupChangemakerPermission> =

--- a/src/types/UserGroupDataProviderPermission.ts
+++ b/src/types/UserGroupDataProviderPermission.ts
@@ -20,10 +20,7 @@ type InternallyWritableUserGroupDataProviderPermission =
 	WritableUserGroupDataProviderPermission &
 		Pick<
 			UserGroupDataProviderPermission,
-			| 'keycloakOrganizationId'
-			| 'dataProviderShortCode'
-			| 'permission'
-			| 'createdBy'
+			'keycloakOrganizationId' | 'dataProviderShortCode' | 'permission'
 		>;
 
 const writableUserGroupDataProviderSchema: JSONSchemaType<WritableUserGroupDataProviderPermission> =

--- a/src/types/UserGroupFunderPermission.ts
+++ b/src/types/UserGroupFunderPermission.ts
@@ -19,7 +19,7 @@ type InternallyWritableUserGroupFunderPermission =
 	WritableUserGroupFunderPermission &
 		Pick<
 			UserGroupFunderPermission,
-			'keycloakOrganizationId' | 'permission' | 'funderShortCode' | 'createdBy'
+			'keycloakOrganizationId' | 'permission' | 'funderShortCode'
 		>;
 
 const writableUserGroupFunderPermissionSchema: JSONSchemaType<WritableUserGroupFunderPermission> =


### PR DESCRIPTION
This PR updates all of our `createdBy` attributes to be populated using the user ID of the agent's auth context.

The only "wonky" aspect of this change is task runners need to generate a fake auth context based on the user ID associated with the task; in future we might consider somehow passing a true auth context to the task runner, but for now this seemed like a reasonable (and reasonably contained) approach.

Resolves #1479