### PR TITLE
Separate parameters in OpenAPI specification

### DIFF
--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -29,13 +29,7 @@
 				"$ref": "./components/parameters/searchParam.json"
 			},
 			"changemakerParam": {
-				"schema": {
-					"type": "integer"
-				},
-				"in": "query",
-				"name": "changemaker",
-				"required": false,
-				"description": "A reference (ID) to an existing changemaker entity."
+				"$ref": "./components/parameters/changemakerParam.json"
 			},
 			"proposalParam": {
 				"schema": {

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -32,13 +32,7 @@
 				"$ref": "./components/parameters/changemakerParam.json"
 			},
 			"proposalParam": {
-				"schema": {
-					"type": "integer"
-				},
-				"in": "query",
-				"name": "proposal",
-				"required": false,
-				"description": "A reference (ID) to an existing proposal entity."
+				"$ref": "./components/parameters/proposalParam.json"
 			},
 			"createdByParam": {
 				"schema": {

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -20,15 +20,7 @@
 				"$ref": "./components/parameters/keycloakUserIdParam.json"
 			},
 			"pageParam": {
-				"schema": {
-					"type": "integer",
-					"minimum": 1,
-					"default": 1
-				},
-				"in": "query",
-				"name": "_page",
-				"required": false,
-				"description": "The page number being retrieved."
+				"$ref": "./components/parameters/pageParam.json"
 			},
 			"countParam": {
 				"schema": {

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -26,13 +26,7 @@
 				"$ref": "./components/parameters/countParam.json"
 			},
 			"searchParam": {
-				"schema": {
-					"type": "string"
-				},
-				"in": "query",
-				"name": "_content",
-				"required": false,
-				"description": "A web-search formatted string to select specific entities returned."
+				"$ref": "./components/parameters/searchParam.json"
 			},
 			"changemakerParam": {
 				"schema": {

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -17,14 +17,7 @@
 		},
 		"parameters": {
 			"keycloakUserIdParam": {
-				"name": "keycloakUserId",
-				"description": "The Keycloak userId associated with the desired user.",
-				"in": "query",
-				"required": false,
-				"schema": {
-					"type": "string",
-					"format": "uuid"
-				}
+				"$ref": "./components/parameters/keycloakUserIdParam.json"
 			},
 			"pageParam": {
 				"schema": {

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -23,15 +23,7 @@
 				"$ref": "./components/parameters/pageParam.json"
 			},
 			"countParam": {
-				"schema": {
-					"type": "integer",
-					"minimum": 1,
-					"default": 10
-				},
-				"in": "query",
-				"name": "_count",
-				"required": false,
-				"description": "The maximum number of items that should appear per page or request."
+				"$ref": "./components/parameters/countParam.json"
 			},
 			"searchParam": {
 				"schema": {

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -35,21 +35,7 @@
 				"$ref": "./components/parameters/proposalParam.json"
 			},
 			"createdByParam": {
-				"schema": {
-					"oneOf": [
-						{
-							"type": ["string", "null"],
-							"format": "uuid"
-						},
-						{
-							"enum": ["me"]
-						}
-					]
-				},
-				"in": "query",
-				"name": "createdBy",
-				"required": false,
-				"description": "A reference to a user entity, or 'me'."
+				"$ref": "./components/parameters/createdByParam.json"
 			}
 		},
 		"securitySchemes": {

--- a/src/openapi/components/parameters/changemakerParam.json
+++ b/src/openapi/components/parameters/changemakerParam.json
@@ -1,0 +1,9 @@
+{
+	"schema": {
+		"type": "integer"
+	},
+	"in": "query",
+	"name": "changemaker",
+	"required": false,
+	"description": "A reference (ID) to an existing changemaker entity."
+}

--- a/src/openapi/components/parameters/countParam.json
+++ b/src/openapi/components/parameters/countParam.json
@@ -1,0 +1,11 @@
+{
+	"schema": {
+		"type": "integer",
+		"minimum": 1,
+		"default": 10
+	},
+	"in": "query",
+	"name": "_count",
+	"required": false,
+	"description": "The maximum number of items that should appear per page or request."
+}

--- a/src/openapi/components/parameters/createdByParam.json
+++ b/src/openapi/components/parameters/createdByParam.json
@@ -1,0 +1,17 @@
+{
+	"schema": {
+		"oneOf": [
+			{
+				"type": ["string", "null"],
+				"format": "uuid"
+			},
+			{
+				"enum": ["me"]
+			}
+		]
+	},
+	"in": "query",
+	"name": "createdBy",
+	"required": false,
+	"description": "A reference to a user entity, or 'me'."
+}

--- a/src/openapi/components/parameters/keycloakUserIdParam.json
+++ b/src/openapi/components/parameters/keycloakUserIdParam.json
@@ -1,0 +1,10 @@
+{
+	"name": "keycloakUserId",
+	"description": "The Keycloak userId associated with the desired user.",
+	"in": "query",
+	"required": false,
+	"schema": {
+		"type": "string",
+		"format": "uuid"
+	}
+}

--- a/src/openapi/components/parameters/pageParam.json
+++ b/src/openapi/components/parameters/pageParam.json
@@ -1,0 +1,11 @@
+{
+	"schema": {
+		"type": "integer",
+		"minimum": 1,
+		"default": 1
+	},
+	"in": "query",
+	"name": "_page",
+	"required": false,
+	"description": "The page number being retrieved."
+}

--- a/src/openapi/components/parameters/proposalParam.json
+++ b/src/openapi/components/parameters/proposalParam.json
@@ -1,0 +1,9 @@
+{
+	"schema": {
+		"type": "integer"
+	},
+	"in": "query",
+	"name": "proposal",
+	"required": false,
+	"description": "A reference (ID) to an existing proposal entity."
+}

--- a/src/openapi/components/parameters/searchParam.json
+++ b/src/openapi/components/parameters/searchParam.json
@@ -1,0 +1,9 @@
+{
+	"schema": {
+		"type": "string"
+	},
+	"in": "query",
+	"name": "_content",
+	"required": false,
+	"description": "A web-search formatted string to select specific entities returned."
+}


### PR DESCRIPTION
This PR continues our effort to break the OpenAPI documentation in to more granular components, specifically moving on the `parameters` section into individual files.

Related to #1178 