### PR TITLE
Separate OpenApi securitySchemes to files

### DIFF
--- a/src/handlers/__tests__/documentationHandlers.unit.test.ts
+++ b/src/handlers/__tests__/documentationHandlers.unit.test.ts
@@ -23,4 +23,21 @@ describe('documentationHandlers', () => {
 			expect(sendMock).toHaveBeenCalledWith(`{ "foo": "${issuer}" }`);
 		});
 	});
+	describe('getAuthApiSpec', () => {
+		it('should return expanded file content', async () => {
+			jest
+				.spyOn(fs, 'readFile')
+				.mockResolvedValue('{ "foo": "{{AUTH_ISSUER}}" }');
+			const sendMock = jest.fn();
+			await documentationHandlers.getRootApiSpec(
+				{} as Request,
+				{
+					type: () => {},
+					set: () => {},
+					send: sendMock,
+				} as unknown as Response,
+			);
+			expect(sendMock).toHaveBeenCalledWith(`{ "foo": "${issuer}" }`);
+		});
+	});
 });

--- a/src/handlers/documentationHandlers.ts
+++ b/src/handlers/documentationHandlers.ts
@@ -34,4 +34,16 @@ const getRootApiSpec = async (req: Request, res: Response) => {
 	res.send(expandedDocumentation);
 };
 
-export const documentationHandlers = { getRootApiSpec };
+const getAuthApiSpec = async (req: Request, res: Response) => {
+	const expandedDocumentation = await getExpandedDocumentation(
+		'components/securitySchemes/auth.json',
+	);
+	res.type('application/json');
+	res.set(
+		'Content-Length',
+		Buffer.byteLength(expandedDocumentation, 'utf8').toString(),
+	);
+	res.send(expandedDocumentation);
+};
+
+export const documentationHandlers = { getRootApiSpec, getAuthApiSpec };

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -40,20 +40,7 @@
 		},
 		"securitySchemes": {
 			"auth": {
-				"type": "oauth2",
-				"description": "The OAuth 2.0 (and OpenID Connect) Authorization Code flow.",
-				"flows": {
-					"authorizationCode": {
-						"authorizationUrl": "{{AUTH_ISSUER}}/protocol/openid-connect/auth",
-						"tokenUrl": "{{AUTH_ISSUER}}/protocol/openid-connect/token",
-						"refreshUrl": "{{AUTH_ISSUER}}/protocol/openid-connect/token",
-						"scopes": {
-							"openid": "Use OpenID Connect (recommended).",
-							"roles": "Read your roles (recommended).",
-							"profile": "Read your profile (recommended)."
-						}
-					}
-				}
+				"$ref": "./components/securitySchemes/auth.json"
 			}
 		},
 		"schemas": {

--- a/src/openapi/components/securitySchemes/auth.json
+++ b/src/openapi/components/securitySchemes/auth.json
@@ -1,0 +1,16 @@
+{
+	"type": "oauth2",
+	"description": "The OAuth 2.0 (and OpenID Connect) Authorization Code flow.",
+	"flows": {
+		"authorizationCode": {
+			"authorizationUrl": "{{AUTH_ISSUER}}/protocol/openid-connect/auth",
+			"tokenUrl": "{{AUTH_ISSUER}}/protocol/openid-connect/token",
+			"refreshUrl": "{{AUTH_ISSUER}}/protocol/openid-connect/token",
+			"scopes": {
+				"openid": "Use OpenID Connect (recommended).",
+				"roles": "Read your roles (recommended).",
+				"profile": "Read your profile (recommended)."
+			}
+		}
+	}
+}

--- a/src/routers/documentationRouter.ts
+++ b/src/routers/documentationRouter.ts
@@ -31,6 +31,10 @@ documentationRouter.get(
 	'/openapi/api.json',
 	documentationHandlers.getRootApiSpec,
 );
+documentationRouter.get(
+	'/openapi/components/securitySchemes/auth.json',
+	documentationHandlers.getAuthApiSpec,
+);
 documentationRouter.use(
 	'/openapi',
 	express.static(path.join(__dirname, '../openapi')),


### PR DESCRIPTION
This PR moves our sole `securityScheme` to its own file, in line with our effort to have pieces of the specification in separate files.

Related to #1178 