### PR TITLE
Separate OpenAPI responses

### DIFF
--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -12,7 +12,7 @@
 	"components": {
 		"responses": {
 			"NotFound": {
-				"description": "The specified resource was not found"
+				"$ref": "./components/responses/NotFound.json"
 			}
 		},
 		"parameters": {

--- a/src/openapi/components/responses/NotFound.json
+++ b/src/openapi/components/responses/NotFound.json
@@ -1,0 +1,3 @@
+{
+	"description": "The specified resource was not found"
+}


### PR DESCRIPTION
This PR separates our lonely `NotFound` response into its own file.  This may seem silly but it eventually we'll need this when we move routes to their own files too.

Related to #1178 