### PR TITLE
Modify currency field validation to accept but not require commas

### DIFF
--- a/src/__tests__/fieldValidation.unit.test.ts
+++ b/src/__tests__/fieldValidation.unit.test.ts
@@ -86,6 +86,9 @@ describe('field value validation against BaseFieldDataType', () => {
 		expect(
 			fieldValueIsValid('1000000.00 CAD', BaseFieldDataType.CURRENCY),
 		).toBe(true);
+		expect(
+			fieldValueIsValid('1,000,000.00 USD', BaseFieldDataType.CURRENCY),
+		).toBe(true);
 		expect(fieldValueIsValid('7.00 USD', BaseFieldDataType.CURRENCY)).toBe(
 			true,
 		);
@@ -97,14 +100,14 @@ describe('field value validation against BaseFieldDataType', () => {
 		expect(fieldValueIsValid('1000000.00', BaseFieldDataType.CURRENCY)).toBe(
 			false,
 		);
+		expect(fieldValueIsValid('1.000.000.00', BaseFieldDataType.CURRENCY)).toBe(
+			false,
+		);
 		expect(
 			fieldValueIsValid(
 				'1000000.00 NOTAREALCURRENCYTAG',
 				BaseFieldDataType.CURRENCY,
 			),
-		).toBe(false);
-		expect(
-			fieldValueIsValid('1,000,000.00 USD', BaseFieldDataType.CURRENCY),
 		).toBe(false);
 		expect(fieldValueIsValid('1000.001 USD', BaseFieldDataType.CURRENCY)).toBe(
 			false,

--- a/src/fieldValidation.ts
+++ b/src/fieldValidation.ts
@@ -36,14 +36,21 @@ const isCurrencyWithCodeString = (value: string) => {
 	if (!currency || !code) {
 		return false;
 	}
-
+	const currencyValidatorFields = {
+		require_symbol: false,
+		allow_negatives: false,
+		require_decimal: true,
+	};
 	return (
-		validator.isCurrency(currency, {
-			require_symbol: false,
-			allow_negatives: false,
-			thousands_separator: '',
-			require_decimal: true,
-		}) && validator.isISO4217(code)
+		(validator.isCurrency(currency, {
+			...currencyValidatorFields,
+			thousands_separator: ',',
+		}) ||
+			validator.isCurrency(currency, {
+				...currencyValidatorFields,
+				thousands_separator: '',
+			})) &&
+		validator.isISO4217(code)
 	);
 };
 


### PR DESCRIPTION
This commit modifies the currency validator function to accept currency values with or without commas as thousands separators.  Since the validator package's currency validator function does not allow for multiple values for the thousands separator, we're instead taking the OR of two currency validations, one that expects commas and one that does not

Closes #1577 