### PR TITLE
Audit generated SQL function calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	},
 	"type": "commonjs",
 	"devDependencies": {
+		"@jest/globals": "^29.7.0",
 		"@redocly/cli": "^1.34.2",
 		"@tsconfig/node22": "^22.0.1",
 		"@types/cors": "^2.8.17",

--- a/src/__tests__/dbOperationAuditLogs.int.test.ts
+++ b/src/__tests__/dbOperationAuditLogs.int.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from '@jest/globals';
+import { db } from '../database/db';
+import { createDbOperationAuditLog } from '../database/operations/dbOperationAuditLogs/createDbOperationAuditLog';
+import { loadUnifiedAuditLogBundle } from '../database/operations/unifiedAuditLogs';
+import {
+	expectTimestamp,
+	getTestAuthContext,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../test/utils';
+
+describe('db operation audit logs appear', () => {
+	test('direct call to createDbOperationAuditLog appears', async () => {
+		const authContext = await getTestAuthContext(false);
+		const administratorAuthContext = await getTestAuthContext(true);
+		const queryParameters = {
+			keyOne: 'Value 1 of Pretend query 5099',
+			keyTwo: 'Value 2 of Pretend query 5099',
+		};
+		await createDbOperationAuditLog(db, authContext, {
+			queryName: 'Pretend query 5099',
+			queryParameters,
+		});
+		const unifiedAuditLogsViewRows = await loadUnifiedAuditLogBundle(
+			db,
+			administratorAuthContext,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
+		expect(unifiedAuditLogsViewRows.entries).toContainEqual({
+			statementTimestamp: expectTimestamp,
+			userKeycloakUserId: authContext.user.keycloakUserId,
+			userIsAdministrator: false,
+			pid: expect.any(Number),
+			auditLevel: 2,
+			operation: 'Called query Pretend query 5099',
+			details: queryParameters,
+		});
+	});
+});

--- a/src/database/initialization/unified_audit_log_to_json.sql
+++ b/src/database/initialization/unified_audit_log_to_json.sql
@@ -1,0 +1,18 @@
+SELECT drop_function('unified_audit_log_to_json');
+
+CREATE FUNCTION unified_audit_log_to_json(
+	unified_audit_log unified_audit_logs
+)
+RETURNS jsonb AS $$
+BEGIN
+	RETURN jsonb_build_object(
+		'statementTimestamp', unified_audit_log.action_tstamp_stm,
+		'userKeycloakUserId', unified_audit_log.user_keycloak_user_id,
+		'userIsAdministrator', unified_audit_log.user_is_administrator,
+		'pid', unified_audit_log.pid,
+		'auditLevel', unified_audit_log.level,
+		'operation', unified_audit_log.operation,
+		'details', unified_audit_log.details
+	);
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/migrations/0058-create-db-operation-audit-logs.sql
+++ b/src/database/migrations/0058-create-db-operation-audit-logs.sql
@@ -1,0 +1,107 @@
+CREATE TABLE db_operation_audit_logs (
+	action_tstamp_stm timestamp with time zone NOT NULL
+	DEFAULT statement_timestamp(),
+	user_keycloak_user_id uuid REFERENCES users (keycloak_user_id),
+	user_is_administrator boolean,
+	pid integer NOT NULL DEFAULT pg_backend_pid(),
+	query_name text NOT NULL,
+	query_parameters jsonb
+);
+CREATE INDEX db_operation_audit_logs_action_tstamp_stm_idx
+ON db_operation_audit_logs (action_tstamp_stm);
+CREATE INDEX db_operation_audit_logs_action_user_keycloak_user_id_idx
+ON db_operation_audit_logs (user_keycloak_user_id);
+COMMENT ON TABLE db_operation_audit_logs IS
+'Audit log of calls to database-query functions made in the PDC service.';
+COMMENT ON COLUMN db_operation_audit_logs.action_tstamp_stm IS
+'The time at which the statement causing the `INSERT` to this row began. Can '
+'be used for temporal correlation with rows in lower-level audit_logs table. '
+'The audit_logs row will precede this row temporally.';
+COMMENT ON COLUMN db_operation_audit_logs.user_keycloak_user_id IS
+'The user ID, if available, that caused the function call. This will often be '
+'duplicated in the query_parameters but querying by user is here anticipated.';
+COMMENT ON COLUMN db_operation_audit_logs.pid IS
+'Session ID aka connection ID aka backend process ID used. Can be used for '
+'session correlation with rows in lower-level audit_logs table.';
+COMMENT ON COLUMN db_operation_audit_logs.query_name IS
+'The name of the PDC application query called.';
+COMMENT ON COLUMN db_operation_audit_logs.query_parameters IS
+'Key-value (parameter-argument) pairs passed to the query.';
+
+CREATE VIEW unified_audit_logs (
+	action_tstamp_stm,
+	user_keycloak_user_id,
+	user_is_administrator,
+	pid,
+	level,
+	operation,
+	details
+)
+AS SELECT
+	action_tstamp_stm,
+	user_keycloak_user_id,
+	user_is_administrator,
+	pid,
+	level,
+	operation,
+	details
+FROM (
+	SELECT
+		event_id,
+		action_tstamp_stm,
+		NULL::uuid AS user_keycloak_user_id,
+		NULL::boolean AS user_is_administrator,
+		pid,
+		'1'::smallint AS level,
+		CASE
+			WHEN action = 'I' THEN 'INSERT INTO ' || table_name
+			WHEN action = 'U' THEN 'UPDATE ' || table_name
+			WHEN action = 'T' THEN 'TRUNCATE ' || table_name
+			WHEN action = 'D' THEN 'DELETE FROM ' || table_name
+			WHEN action = 'A' THEN 'Begin auditing ' || table_name
+			WHEN action = 'S' THEN 'Stop auditing ' || table_name
+			ELSE action || ' ' || table_name
+		END
+		AS operation,
+		CASE
+			-- 'U' is a special snowflake where a diff from row_data is provided.
+			WHEN action = 'U' THEN changed_fields
+			ELSE row_data
+		END
+		AS details
+	FROM audit_logs
+	-- Filter out updates that did not actually change anything.
+	WHERE action != 'U' OR changed_fields IS NOT NULL
+	UNION ALL
+	SELECT
+		NULL AS event_id,
+		action_tstamp_stm,
+		user_keycloak_user_id,
+		user_is_administrator,
+		pid,
+		'2'::smallint AS level,
+		'Called query ' || query_name AS operation,
+		query_parameters AS details
+	FROM db_operation_audit_logs
+) AS unified
+-- Often the level 1 items begin share statement timestamps so use event_id too
+ORDER BY action_tstamp_stm, event_id;
+
+COMMENT ON VIEW unified_audit_logs IS
+'A unified, simplified view into multiple levels of audit logs.';
+COMMENT ON COLUMN unified_audit_logs.action_tstamp_stm IS
+'The time at which the SQL statement of the operation began.';
+COMMENT ON COLUMN unified_audit_logs.user_keycloak_user_id IS
+'When available, the Keycloak UUID of the user that caused the action. '
+'Not available below level 2 and only sometimes at level 2.';
+COMMENT ON COLUMN unified_audit_logs.user_is_administrator IS
+'When available, whether the user that caused the action is an administrator. '
+'Not available below level 2 and only sometimes at level 2.';
+COMMENT ON COLUMN unified_audit_logs.pid IS
+'Session ID aka connection ID aka backend process ID used.';
+COMMENT ON COLUMN unified_audit_logs.level IS
+'The level of audit logging. 1 for database triggers, 2 for PDC queries.';
+COMMENT ON COLUMN unified_audit_logs.operation IS
+'A human-readable description of what happened. Varies by level.';
+COMMENT ON COLUMN unified_audit_logs.details IS
+'Detailed JSON map with the row values (level 1) or arguments (level 2).';

--- a/src/database/operations/dbOperationAuditLogs/createDbOperationAuditLog.ts
+++ b/src/database/operations/dbOperationAuditLogs/createDbOperationAuditLog.ts
@@ -1,0 +1,18 @@
+import TinyPg from 'tinypg';
+import { AuthContext } from '../../../types';
+
+export const createDbOperationAuditLog = async (
+	db: TinyPg,
+	authContext: AuthContext | null,
+	createValues: {
+		queryName: string;
+		queryParameters: object;
+	},
+): Promise<void> => {
+	await db.sql('dbOperationAuditLogs.insertOne', {
+		authContextKeycloakUserId: authContext?.user?.keycloakUserId,
+		authContextIsAdministrator: authContext?.role?.isAdministrator,
+		queryName: createValues.queryName,
+		queryParameters: createValues.queryParameters,
+	});
+};

--- a/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
+++ b/src/database/operations/generators/generateCreateOrUpdateItemOperation.ts
@@ -1,3 +1,4 @@
+import { createDbOperationAuditLog } from '../dbOperationAuditLogs/createDbOperationAuditLog';
 import { NoDataReturnedError } from '../../../errors/NoDataReturnedError';
 import {
 	getIsAdministratorFromAuthContext,
@@ -67,6 +68,11 @@ const generateCreateOrUpdateItemOperation =
 			throw new NoDataReturnedError(
 				'The database did not return a query result.',
 			);
+		} else {
+			await createDbOperationAuditLog(db, authContext, {
+				queryName,
+				queryParameters,
+			});
 		}
 		return object;
 	};

--- a/src/database/operations/generators/generateLoadBundleOperation.ts
+++ b/src/database/operations/generators/generateLoadBundleOperation.ts
@@ -1,3 +1,4 @@
+import { createDbOperationAuditLog } from '../dbOperationAuditLogs/createDbOperationAuditLog';
 import { loadTableMetrics } from '../generic/loadTableMetrics';
 import {
 	getIsAdministratorFromAuthContext,
@@ -44,6 +45,10 @@ const generateLoadBundleOperation = <T, P extends [...args: unknown[]]>(
 		const result = await db.sql<JsonResultSet<T>>(queryName, queryParameters);
 		const entries = result.rows.map((row) => row.object);
 		const metrics = await loadTableMetrics(tableName);
+		await createDbOperationAuditLog(db, authContext, {
+			queryName,
+			queryParameters,
+		});
 		return {
 			entries,
 			total: metrics.count,

--- a/src/database/operations/generators/generateLoadItemOperation.ts
+++ b/src/database/operations/generators/generateLoadItemOperation.ts
@@ -1,3 +1,4 @@
+import { createDbOperationAuditLog } from '../dbOperationAuditLogs/createDbOperationAuditLog';
 import { NotFoundError } from '../../../errors';
 import {
 	getIsAdministratorFromAuthContext,
@@ -50,6 +51,11 @@ const generateLoadItemOperation =
 			throw new NotFoundError(`Entity not found`, {
 				entityType,
 				lookupValues: queryParameters,
+			});
+		} else {
+			await createDbOperationAuditLog(db, authContext, {
+				queryName,
+				queryParameters,
 			});
 		}
 		return object;

--- a/src/database/operations/generators/generateRemoveItemOperation.ts
+++ b/src/database/operations/generators/generateRemoveItemOperation.ts
@@ -1,3 +1,4 @@
+import { createDbOperationAuditLog } from '../dbOperationAuditLogs/createDbOperationAuditLog';
 import { NotFoundError } from '../../../errors';
 import {
 	getIsAdministratorFromAuthContext,
@@ -54,6 +55,11 @@ const generateRemoveItemOperation =
 					lookupValues: queryParameters,
 				},
 			);
+		} else {
+			await createDbOperationAuditLog(db, authContext, {
+				queryName,
+				queryParameters,
+			});
 		}
 		return object;
 	};

--- a/src/database/operations/unifiedAuditLogs/index.ts
+++ b/src/database/operations/unifiedAuditLogs/index.ts
@@ -1,0 +1,1 @@
+export * from './loadUnifiedAuditLogBundle';

--- a/src/database/operations/unifiedAuditLogs/loadUnifiedAuditLogBundle.ts
+++ b/src/database/operations/unifiedAuditLogs/loadUnifiedAuditLogBundle.ts
@@ -1,0 +1,9 @@
+import { generateLoadBundleOperation } from '../generators';
+import type { UnifiedAuditLog } from '../../../types';
+
+const loadUnifiedAuditLogBundle = generateLoadBundleOperation<
+	UnifiedAuditLog,
+	[]
+>('unifiedAuditLogs.selectWithPagination', 'unified_audit_logs', []);
+
+export { loadUnifiedAuditLogBundle };

--- a/src/database/queries/dbOperationAuditLogs/insertOne.sql
+++ b/src/database/queries/dbOperationAuditLogs/insertOne.sql
@@ -1,0 +1,11 @@
+INSERT INTO db_operation_audit_logs (
+	user_keycloak_user_id,
+	user_is_administrator,
+	query_name,
+	query_parameters
+) VALUES (
+	:authContextKeycloakUserId,
+	:authContextIsAdministrator,
+	:queryName,
+	:queryParameters
+);

--- a/src/database/queries/unifiedAuditLogs/selectWithPagination.sql
+++ b/src/database/queries/unifiedAuditLogs/selectWithPagination.sql
@@ -1,0 +1,4 @@
+SELECT unified_audit_log_to_json(unified_audit_logs.*) AS object
+FROM unified_audit_logs
+ORDER BY unified_audit_logs.action_tstamp_stm DESC
+LIMIT :limit OFFSET :offset;

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -40,8 +40,8 @@ export const getAuthContext = (user: User, isAdministrator = false) => ({
 	},
 });
 
-export const getTestAuthContext = async () =>
-	getAuthContext(await loadTestUser(), true);
+export const getTestAuthContext = async (isAdministrator = true) =>
+	getAuthContext(await loadTestUser(), isAdministrator);
 
 export const NO_OFFSET = 0;
 

--- a/src/types/UnifiedAuditLog.ts
+++ b/src/types/UnifiedAuditLog.ts
@@ -1,0 +1,13 @@
+import { KeycloakId } from './KeycloakId';
+
+interface UnifiedAuditLog {
+	readonly statementTimestamp: string;
+	readonly userKeycloakId: KeycloakId | null;
+	readonly userIsAdministrator: boolean | null;
+	readonly pid: number;
+	readonly auditLevel: number;
+	readonly operation: string;
+	readonly details: object | null;
+}
+
+export { UnifiedAuditLog };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,7 @@ export * from './Source';
 export * from './TableMetrics';
 export * from './TaskStatus';
 export * from './TinyPgErrorWithQueryContext';
+export * from './UnifiedAuditLog';
 export * from './User';
 export * from './UserChangemakerPermission';
 export * from './UserDataProviderPermission';


### PR DESCRIPTION
Database triggers provide a low-level audit trail that is available
regardless of whether a data change was made by the application or by
a user manually logged into the database, for example, via `psql`. The
triggers can be referred to as "level 1" and were implemented in pull
request https://github.com/PhilanthropyDataCommons/service/pull/1607. The SQL function call logging implemented in this
commit can be referred to as "level 2" audit logs.

The low-level audit rows are in `audit_logs`. This change extends the
audit capabilities with a new table `db_operations_audit_logs` and
causes inserts to that table whenever various generated SQL function
calls succeed.

The design of the new table is related to the original such that a
view, also added here as `unified_audit_logs`, can provide friendlier
access to all the audit logs of all levels. The `unified_audit_logs`
view can in future (and now does) select relevant columns, filter out
extraneous rows, and expand short text codes into human-readable form.

Issue https://github.com/PhilanthropyDataCommons/service/issues/1612 Implement audit logging (application query level, 2 of 3)