### PR TITLE
Remove fp-ts dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
 				"csv-parse": "^5.6.0",
 				"express": "^5.1.0",
 				"express-jwt": "^8.5.1",
-				"fp-ts": "^2.16.9",
 				"graphile-worker": "^0.16.6",
 				"jwks-rsa": "^3.2.0",
 				"language-tags": "^1.0.9",
@@ -7331,7 +7330,8 @@
 			"version": "2.16.9",
 			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.9.tgz",
 			"integrity": "sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fresh": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
 		"csv-parse": "^5.6.0",
 		"express": "^5.1.0",
 		"express-jwt": "^8.5.1",
-		"fp-ts": "^2.16.9",
 		"graphile-worker": "^0.16.6",
 		"jwks-rsa": "^3.2.0",
 		"language-tags": "^1.0.9",


### PR DESCRIPTION
This PR removes an unused dependency.  I apparently had added it when adding the newtypes, and suspect it was accidentally included / was something I looked into but didn't end up using.