### PR TITLE
Convert `Promise.all` calls to new `allNoLeaks`

### DIFF
--- a/src/promises/__tests__/allNoLeaks.unit.test.ts
+++ b/src/promises/__tests__/allNoLeaks.unit.test.ts
@@ -1,0 +1,69 @@
+import { fail } from 'assert';
+import { allNoLeaks } from '../allNoLeaks';
+
+describe('allNoLeaks', () => {
+	it('should throw an error after companion long-duration `Promise` completes', async () => {
+		let longTaskCompleted = false;
+		const longTask: Promise<void> = new Promise((resolve) => {
+			setTimeout(() => {
+				longTaskCompleted = true;
+				resolve();
+			}, 50);
+		});
+		const errorMessageToThrow = "errored, y'all!";
+		const errorTask = Promise.reject(new Error(errorMessageToThrow));
+		try {
+			// Substitute `Promise.all` here and the test fails, demonstrating the purpose of allNoLeaks.
+			await allNoLeaks([longTask, errorTask]);
+			fail('Expected an error to be thrown');
+		} catch (error) {
+			expect(longTaskCompleted).toBe(true);
+			expect(error).toEqual(new Error(errorMessageToThrow));
+		}
+	});
+
+	it('should throw an error with object reason', async () => {
+		const errorReasonToThrow = { weird: 'object' };
+		const errorTask = Promise.reject(errorReasonToThrow);
+		try {
+			await allNoLeaks([errorTask]);
+			fail('Expected an error to be thrown');
+		} catch (error) {
+			expect(error).toEqual(
+				new Error(
+					'An unexpected error occurred while awaiting all tasks: {"weird":"object"}',
+				),
+			);
+		}
+	});
+
+	it('should throw an error with array reason', async () => {
+		const errorReasonToThrow = [2025, 5, 8];
+		const errorTask = Promise.reject(errorReasonToThrow);
+		try {
+			await allNoLeaks([errorTask]);
+			fail('Expected an error to be thrown');
+		} catch (error) {
+			expect(error).toEqual(
+				new Error(
+					'An unexpected error occurred while awaiting all tasks: [2025,5,8]',
+				),
+			);
+		}
+	});
+
+	it('should throw an error with string reason', async () => {
+		const errorReasonToThrow = 'I am a string';
+		const errorTask = Promise.reject(errorReasonToThrow);
+		try {
+			await allNoLeaks([errorTask]);
+			fail('Expected an error to be thrown');
+		} catch (error) {
+			expect(error).toEqual(
+				new Error(
+					'An unexpected error occurred while awaiting all tasks: "I am a string"',
+				),
+			);
+		}
+	});
+});

--- a/src/promises/allNoLeaks.ts
+++ b/src/promises/allNoLeaks.ts
@@ -1,0 +1,30 @@
+// Inspired by https://stackoverflow.com/questions/64928212/how-to-use-promise-allsettled-with-typescript#69451755
+const isRejected = (result: PromiseSettledResult<unknown>) =>
+	result.status === 'rejected';
+const isFulfilled = <T>(result: PromiseSettledResult<T>) =>
+	result.status === 'fulfilled';
+
+const getErrorFromReason = (reason: unknown): Error => {
+	if (reason instanceof Error) {
+		return reason;
+	}
+	return new Error(
+		`An unexpected error occurred while awaiting all tasks: ${JSON.stringify(reason)}`,
+	);
+};
+
+/**
+ * Returns results of given `Promise`s or throws an `Error` if any `Promise` rejects.
+ * `Promise.all` has a simple API but it leaks execution after one `Promise` rejects.
+ * `Promise.allSettled` does not leak execution but its API is awkward.
+ * Here we offer a simplified `Promise.all`-like API wrapping `Promise.allSettled` functionality.
+ * Use this function in place of `Promise.all` in almost all circumstances.
+ */
+export const allNoLeaks = async <T>(values: Promise<T>[]) => {
+	const settled = await Promise.allSettled(values);
+	const rejectedTask = settled.find(isRejected);
+	if (rejectedTask !== undefined) {
+		throw getErrorFromReason(rejectedTask.reason);
+	}
+	return settled.filter(isFulfilled)?.map((e) => e.value);
+};

--- a/src/promises/index.ts
+++ b/src/promises/index.ts
@@ -1,0 +1,1 @@
+export * from './allNoLeaks';

--- a/src/tasks/processBulkUploadTask.ts
+++ b/src/tasks/processBulkUploadTask.ts
@@ -27,6 +27,7 @@ import {
 } from '../database/operations';
 import { TaskStatus, isProcessBulkUploadJobPayload } from '../types';
 import { fieldValueIsValid } from '../fieldValidation';
+import { allNoLeaks } from '../promises';
 import type { Readable } from 'stream';
 import type { GetObjectCommandOutput } from '@aws-sdk/client-s3';
 import type { JobHelpers, Logger } from 'graphile-worker';
@@ -171,7 +172,7 @@ const createApplicationFormFieldsForBulkUploadTask = async (
 ): Promise<ApplicationFormField[]> => {
 	const shortCodes = await loadShortCodesFromBulkUploadTaskCsv(csvPath);
 	const baseFields = await loadBaseFields();
-	const applicationFormFields = await Promise.all(
+	const applicationFormFields = await allNoLeaks(
 		shortCodes.map(async (shortCode, index) => {
 			const baseField = baseFields.find(
 				(candidateBaseField) => candidateBaseField.shortCode === shortCode,
@@ -372,7 +373,7 @@ export const processBulkUploadTask = async (
 				}
 			}
 
-			await Promise.all(
+			await allNoLeaks(
 				record.map<Promise<ProposalFieldValue>>(async (fieldValue, index) => {
 					const applicationFormField = applicationFormFields[index];
 					if (applicationFormField === undefined) {


### PR DESCRIPTION
This avoids deadlock during the test named 'Returns 409 Conflict if a
provided application form field ID does not exist'. The reason is that
`DROP SCHEMA` during teardown can be reached before another `Promise`
passed to `Promise.all` resolves when one `Promise` passed to
`Promise.all` rejects with an error. By using `Promise.allSettled` no
`Promise` will continue execution (be pending) following the call to
`await Promise.allSettled`. But `Promise.allSettled` has a cumbersome
API compared to `Promise.all`. Something like `Promise.all` that does
not reject until all `Promise` objects have either rejected or
resolved resolves (pun intended) the issue. It is OK to throw any
error associated with a rejected `Promise`, similar to the semantics
of `Promise.all`. Therefore a new function `allNoLeaks` is introduced
to wrap the tedious bits of `Promise.allSettled` while providing the
convenience of a `Promise.all`-like API but with no leaked `Promise`.

While the above case brought the issue to light, there are many other
calls to `Promise.all` where similar race conditions obtain. So the
new function is used in place of `Promise.all` everywhere else too.

Furthermore, the problem case of a call to `Promise.all` had only two
`Promise` objects sent and has been replaced with simple `await`s on
each function in sequence.

Issue https://github.com/PhilanthropyDataCommons/service/issues/1631: Deadlock detected