### PR TITLE
Document the `Source` entity

### DIFF
--- a/src/openapi/components/schemas/Source.json
+++ b/src/openapi/components/schemas/Source.json
@@ -2,6 +2,7 @@
 	"allOf": [
 		{
 			"type": "object",
+			"description": "A labeled dataset from the changemaker, funder, or data provider that adds data to the PDC. The Source is intended to be the 'last hop' prior to entering the PDC, not the ultimate origin of the data.",
 			"properties": {
 				"id": {
 					"type": "integer",
@@ -9,10 +10,12 @@
 				},
 				"label": {
 					"type": "string",
-					"example": "A Source"
+					"description": "A description of the dataset from the changemaker, funder, or data provider that adds the data to the PDC.",
+					"example": "The 2025 Survey of Changemakers by the Good Foundation"
 				},
 				"relatedEntityId": {
-					"type": "integer"
+					"type": "integer",
+					"description": "The changemaker, funder, or data provider that adds data to the PDC."
 				},
 				"createdAt": {
 					"type": "string",


### PR DESCRIPTION
A data source could be thought of as the changemaker, data provider, or funder. The PDC allows one more level of grouping beyond those entities: a Source with a label. It is expected to be not ultimate but last-hop. Without this commit the intent of the Source entity is not clear but with this commit it is a bit clearer.

Fixes #1733 Document the difference between Source label and Source
    entity

Fixes #1251 Document that "Source" is "last hop" and not "original"