### PR TITLE
Add funder collaboratives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The required fields associated with `UserGroupChangemakerPermission`, `UserGroupDataProviderPermission`, and `UserGroupFunderPermission` are now correctly documented.
 - The various opportunity permission endpoints are now correctly documented.
 
+## 0.22.0 2025-07-22
+
+- Funders now have a `isCollaborative` attribute.
+- Added `FunderCollaborativeMember` entity type to represent collaborators on Funders, which extend funder permissions to other funder collaborators.
+- Added `FunderCollaborativeInvitation` entity type to represent invitations to collaborate on a funder.
+
 ## 0.21.0 2025-07-16
 
 ### Added

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -128,6 +128,7 @@ describe('/applicationForms', () => {
 				shortCode: 'otherFunder',
 				name: 'Other Funder',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOpportunity(db, null, {
 				title: 'Tremendous opportunity 👌',

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -55,6 +55,7 @@ describe('/tasks/bulkUploads', () => {
 				shortCode: 'anotherFunder',
 				name: 'Another Funder',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,

--- a/src/__tests__/changemakerProposals.int.test.ts
+++ b/src/__tests__/changemakerProposals.int.test.ts
@@ -50,6 +50,7 @@ describe('/changemakerProposals', () => {
 				name: 'Visible Funder',
 				shortCode: 'visibleFunder',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const visibleChangemaker = await createChangemaker(db, null, {
 				taxId: '11-1111111',

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -103,6 +103,7 @@ const setupTestContext = async () => {
 		shortCode: 'funder_5393',
 		name: 'Funder 5393',
 		keycloakOrganizationId: null,
+		isCollaborative: false,
 	});
 	const firstFunderOpportunity = await createOpportunity(db, null, {
 		title: `${firstFunder.name} opportunity`,

--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -6,12 +6,67 @@ import {
 	loadFunder,
 	loadTableMetrics,
 	loadSystemFunder,
+	createOrUpdateFunderCollaborativeMember,
 } from '../database';
+import { getAuthContext, loadTestUser } from '../test/utils';
 import { expectArray, expectTimestamp } from '../test/asymettricMatchers';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as adminUserAuthHeader,
 } from '../test/mockJwt';
+
+const createTestFunders = async ({
+	theFundFund,
+	theFoundationFoundation,
+	theFundersWhoFund,
+	theFundingFathers,
+	theFunnyFunders,
+	theFungibleFund,
+}: {
+	theFundFund: boolean;
+	theFoundationFoundation: boolean;
+	theFundersWhoFund: boolean;
+	theFundingFathers: boolean;
+	theFunnyFunders: boolean;
+	theFungibleFund: boolean;
+}) => {
+	await createOrUpdateFunder(db, null, {
+		shortCode: 'theFundFund',
+		name: 'The Fund Fund',
+		keycloakOrganizationId: null,
+		isCollaborative: theFundFund,
+	});
+	await createOrUpdateFunder(db, null, {
+		shortCode: 'theFoundationFoundation',
+		name: 'The Foundation Foundation',
+		keycloakOrganizationId: null,
+		isCollaborative: theFoundationFoundation,
+	});
+	await createOrUpdateFunder(db, null, {
+		shortCode: 'theFundersWhoFund',
+		name: 'The Funders Who Fund',
+		keycloakOrganizationId: null,
+		isCollaborative: theFundersWhoFund,
+	});
+	await createOrUpdateFunder(db, null, {
+		shortCode: 'theFundingFathers',
+		name: 'The Funding Fathers',
+		keycloakOrganizationId: null,
+		isCollaborative: theFundingFathers,
+	});
+	await createOrUpdateFunder(db, null, {
+		shortCode: 'theFunnyFunders',
+		name: 'The Funny Funders',
+		keycloakOrganizationId: null,
+		isCollaborative: theFunnyFunders,
+	});
+	await createOrUpdateFunder(db, null, {
+		shortCode: 'theFungibleFund',
+		name: 'The Fungible Fund',
+		keycloakOrganizationId: null,
+		isCollaborative: theFungibleFund,
+	});
+};
 
 const agent = request.agent(app);
 
@@ -27,11 +82,13 @@ describe('/funders', () => {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateFunder(db, null, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 
 			const response = await agent.get('/funders').set(authHeader).expect(200);
@@ -42,12 +99,14 @@ describe('/funders', () => {
 						createdAt: expectTimestamp(),
 						name: 'The Foundation Foundation',
 						keycloakOrganizationId: null,
+						isCollaborative: false,
 					},
 					{
 						shortCode: 'theFundFund',
 						createdAt: expectTimestamp(),
 						name: 'The Fund Fund',
 						keycloakOrganizationId: null,
+						isCollaborative: false,
 					},
 					systemFunder,
 				],
@@ -66,11 +125,13 @@ describe('/funders', () => {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateFunder(db, null, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: '0de87edc-be40-11ef-8249-0312f1b87538',
+				isCollaborative: false,
 			});
 
 			const response = await agent
@@ -82,6 +143,7 @@ describe('/funders', () => {
 				createdAt: expectTimestamp(),
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: '0de87edc-be40-11ef-8249-0312f1b87538',
+				isCollaborative: false,
 			});
 		});
 
@@ -90,6 +152,7 @@ describe('/funders', () => {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await agent.get('/funders/foo').set(authHeader).expect(404);
 		});
@@ -110,13 +173,14 @@ describe('/funders', () => {
 				.put('/funders/firework')
 				.type('application/json')
 				.set(adminUserAuthHeader)
-				.send({ name: '🎆' })
+				.send({ name: '🎆', isCollaborative: false })
 				.expect(201);
 			const after = await loadTableMetrics('funders');
 			expect(result.body).toMatchObject({
 				shortCode: 'firework',
 				name: '🎆',
 				createdAt: expectTimestamp(),
+				isCollaborative: false,
 			});
 			expect(after.count).toEqual(before.count + 1);
 		});
@@ -126,7 +190,7 @@ describe('/funders', () => {
 				.put('/funders/Firework_-foo42')
 				.type('application/json')
 				.set(adminUserAuthHeader)
-				.send({ name: '🎆' })
+				.send({ name: '🎆', isCollaborative: false })
 				.expect(201);
 		});
 
@@ -135,18 +199,20 @@ describe('/funders', () => {
 				shortCode: 'firework',
 				name: 'boring text-based firework',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const anotherFunderBefore = await createOrUpdateFunder(db, null, {
 				shortCode: 'anotherFirework',
 				name: 'another boring text based firework',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const before = await loadTableMetrics('data_providers');
 			const result = await agent
 				.put('/funders/firework')
 				.type('application/json')
 				.set(adminUserAuthHeader)
-				.send({ name: '🎆' })
+				.send({ name: '🎆', isCollaborative: false })
 				.expect(201);
 			const after = await loadTableMetrics('data_providers');
 			const anotherFunderAfter = await loadFunder(db, null, 'anotherFirework');
@@ -155,6 +221,7 @@ describe('/funders', () => {
 				name: '🎆',
 				keycloakOrganizationId: null,
 				createdAt: expectTimestamp(),
+				isCollaborative: false,
 			});
 			expect(after.count).toEqual(before.count);
 			expect(anotherFunderAfter).toEqual(anotherFunderBefore);
@@ -183,6 +250,324 @@ describe('/funders', () => {
 				.expect(400);
 			const after = await loadTableMetrics('funders');
 			expect(after.count).toEqual(before.count);
+		});
+	});
+	describe('/funders/:funderShortCode/members', () => {
+		describe('GET /', () => {
+			it('requires authentication', async () => {
+				await agent.get('/funders/foo/members').expect(401);
+			});
+
+			it('throws a 400 error if the funder short code is invalid', async () => {
+				await agent
+					.get('/funders/!!!!!!!/members')
+					.set(adminUserAuthHeader)
+					.expect(400);
+			});
+
+			it('returns all members of a collaborative funder', async () => {
+				const testUser = await loadTestUser();
+				const testUserAuthContext = getAuthContext(testUser);
+
+				await createTestFunders({
+					theFundFund: true,
+					theFoundationFoundation: false,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+
+				await createOrUpdateFunderCollaborativeMember(db, testUserAuthContext, {
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFoundationFoundation',
+				});
+				await createOrUpdateFunderCollaborativeMember(db, testUserAuthContext, {
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFundersWhoFund',
+				});
+				await createOrUpdateFunderCollaborativeMember(db, testUserAuthContext, {
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFundingFathers',
+				});
+				const response = await agent
+					.get('/funders/theFundFund/members')
+					.set(adminUserAuthHeader)
+					.expect(200);
+				expect(response.body).toEqual({
+					entries: [
+						{
+							funderCollaborativeShortCode: 'theFundFund',
+							memberFunderShortCode: 'theFundingFathers',
+							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
+						},
+						{
+							funderCollaborativeShortCode: 'theFundFund',
+							memberFunderShortCode: 'theFundersWhoFund',
+							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
+						},
+						{
+							funderCollaborativeShortCode: 'theFundFund',
+							memberFunderShortCode: 'theFoundationFoundation',
+							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
+						},
+					],
+					total: 3,
+				});
+			});
+		});
+
+		describe('GET /funders/:funderShortCode/members/:memberFunderShortCode', () => {
+			it('requires authentication', async () => {
+				await agent
+					.get('/funders/theFundFund/members/theFoundationFoundation')
+					.expect(401);
+			});
+
+			it('throws a 400 error if the funder short code is invalid', async () => {
+				await agent
+					.get('/funders/!!!!!!!/members/theFoundationFoundation')
+					.set(adminUserAuthHeader)
+					.expect(400);
+			});
+
+			it('throws a 400 error if the member funder short code is invalid', async () => {
+				await agent
+					.get('/funders/theFundFund/members/!!!!!!!')
+					.set(adminUserAuthHeader)
+					.expect(400);
+			});
+
+			it('requires MANAGE permission on the funder', async () => {
+				await createTestFunders({
+					theFundFund: true,
+					theFoundationFoundation: false,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+				const result = await agent
+					.get('/funders/theFundFund/members/theFoundationFoundation')
+					.set(authHeader)
+					.expect(401);
+				expect(result.body).toMatchObject({
+					message:
+						'Authenticated user does not have permission to perform this action.',
+					details: expectArray(),
+				});
+			});
+
+			it('returns exactly one funder collaborative member selected by short code', async () => {
+				const testUser = await loadTestUser();
+				const testUserAuthContext = getAuthContext(testUser);
+				await createTestFunders({
+					theFundFund: true,
+					theFoundationFoundation: false,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+				await createOrUpdateUserFunderPermission(db, testUserAuthContext, {
+					userKeycloakUserId: testUser.keycloakUserId,
+					funderShortCode: 'theFundFund',
+					permission: Permission.MANAGE,
+				});
+				await createOrUpdateFunderCollaborativeMember(db, testUserAuthContext, {
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFoundationFoundation',
+				});
+
+				const response = await agent
+					.get('/funders/theFundFund/members/theFoundationFoundation')
+					.set(authHeader)
+					.expect(200);
+
+				expect(response.body).toMatchObject({
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFoundationFoundation',
+					createdAt: expectTimestamp(),
+					createdBy: testUser.keycloakUserId,
+				});
+			});
+			it('throws a 404 when the funder collaborative member does not exist', async () => {
+				const testUser = await loadTestUser();
+				const testUserAuthContext = getAuthContext(testUser);
+				await createTestFunders({
+					theFundFund: true,
+					theFoundationFoundation: false,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+				await createOrUpdateUserFunderPermission(db, testUserAuthContext, {
+					userKeycloakUserId: testUser.keycloakUserId,
+					funderShortCode: 'theFundFund',
+					permission: Permission.MANAGE,
+				});
+				const response = await agent
+					.get('/funders/theFundFund/members/theFoundationFoundation')
+					.set(authHeader)
+					.expect(404);
+				expect(response.body).toMatchObject({
+					name: 'NotFoundError',
+					details: expectArray(),
+				});
+			});
+		});
+		describe('POST /funders/:funderShortCode/members/:memberFunderShortCode', () => {
+			it('requires authentication', async () => {
+				await agent
+					.post('/funders/theFundFund/members/theFoundationFoundation')
+					.expect(401);
+			});
+
+			it('requires administrator role', async () => {
+				await agent
+					.post('/funders/theFundFund/members/theFoundationFoundation')
+					.set(authHeader)
+					.expect(401);
+			});
+
+			it('throws a 400 error if the funder short code is invalid', async () => {
+				await agent
+					.post('/funders/!!!!!!!/members/theFoundationFoundation')
+					.set(adminUserAuthHeader)
+					.expect(400);
+			});
+
+			it('throws a 400 error if the member funder short code is invalid', async () => {
+				await agent
+					.post('/funders/theFundFund/members/!!!!!!!')
+					.set(adminUserAuthHeader)
+					.expect(400);
+			});
+
+			it('creates and returns exactly one funder collaborative member', async () => {
+				const adminUser = await loadTestUser();
+				await createTestFunders({
+					theFundFund: true,
+					theFoundationFoundation: false,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+				const response = await agent
+					.post('/funders/theFundFund/members/theFoundationFoundation')
+					.set(adminUserAuthHeader)
+					.expect(201);
+				expect(response.body).toMatchObject({
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFoundationFoundation',
+					createdAt: expectTimestamp(),
+					createdBy: adminUser.keycloakUserId,
+				});
+			});
+
+			it('returns 400 when the funder is not collaborative', async () => {
+				await createTestFunders({
+					theFundFund: false,
+					theFoundationFoundation: false,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+				const response = await agent
+					.post('/funders/theFundFund/members/theFoundationFoundation')
+					.set(adminUserAuthHeader)
+					.expect(400);
+				expect(response.body).toMatchObject({
+					name: 'DatabaseError',
+					details: expectArray(),
+				});
+			});
+		});
+
+		describe('DELETE /funders/:funderShortCode/members/:memberFunderShortCode', () => {
+			it('requires authentication', async () => {
+				await agent
+					.delete('/funders/theFundFund/members/theFoundationFoundation')
+					.expect(401);
+			});
+
+			it('requires administrator role', async () => {
+				await agent
+					.delete('/funders/theFundFund/members/theFoundationFoundation')
+					.set(authHeader)
+					.expect(401);
+			});
+
+			it('throws a 400 error if the funder short code is invalid', async () => {
+				await agent
+					.delete('/funders/!!!!!!!/members/theFoundationFoundation')
+					.set(adminUserAuthHeader)
+					.expect(400);
+			});
+
+			it('throws a 400 error if the member funder short code is invalid', async () => {
+				await agent
+					.delete('/funders/theFundFund/members/!!!!!!!')
+					.set(adminUserAuthHeader)
+					.expect(400);
+			});
+
+			it('deletes and returns exactly one funder collaborative member', async () => {
+				const adminUser = await loadTestUser();
+				const adminUserAuthContext = getAuthContext(adminUser);
+
+				await createTestFunders({
+					theFundFund: true,
+					theFoundationFoundation: false,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+
+				await createOrUpdateFunderCollaborativeMember(
+					db,
+					adminUserAuthContext,
+					{
+						funderCollaborativeShortCode: 'theFundFund',
+						memberFunderShortCode: 'theFoundationFoundation',
+					},
+				);
+				const response = await agent
+					.delete('/funders/theFundFund/members/theFoundationFoundation')
+					.set(adminUserAuthHeader)
+					.expect(200);
+				expect(response.body).toMatchObject({
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFoundationFoundation',
+					createdAt: expectTimestamp(),
+					createdBy: adminUser.keycloakUserId,
+				});
+				const getResponse = await agent
+					.get('/funders/theFundFund/members/theFoundationFoundation')
+					.set(adminUserAuthHeader)
+					.expect(404);
+				expect(getResponse.body).toMatchObject({
+					name: 'NotFoundError',
+					details: expectArray(),
+				});
+			});
+			it('throws a 404 when the funder collaborative member does not exist', async () => {
+				const response = await agent
+					.delete('/funders/theFundFund/members/theFoundationFoundation')
+					.set(adminUserAuthHeader)
+					.expect(404);
+				expect(response.body).toMatchObject({
+					name: 'NotFoundError',
+					details: expectArray(),
+				});
+			});
 		});
 	});
 });

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -77,6 +77,7 @@ describe('/opportunities', () => {
 				name: 'another funder',
 				shortCode: 'anotherFunder',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,

--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -68,16 +68,19 @@ describe('/organizations', () => {
 				name: 'Funder Organization does not exist in Keycloak or has not been linked.',
 				shortCode: 'unexpectedfunderone',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const expectedFunder = await createOrUpdateFunder(db, null, {
 				name: 'Change, Inc.',
 				shortCode: 'changeinc',
 				keycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await createOrUpdateFunder(db, null, {
 				name: 'Funder Organization is linked but I am not the one that should be returned.',
 				shortCode: 'unexpectedfundertwo',
 				keycloakOrganizationId: '75b4198f-dd88-4a6c-8259-fe4d725af125',
+				isCollaborative: false,
 			});
 
 			const response = await agent
@@ -105,11 +108,13 @@ describe('/organizations', () => {
 				name: 'Unlinked funder one.',
 				shortCode: 'unlinkedfunderone',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const expectedFunder = await createOrUpdateFunder(db, null, {
 				name: 'Funderdome',
 				shortCode: 'funderdome',
 				keycloakOrganizationId,
+				isCollaborative: false,
 			});
 			const authContext = await getTestAuthContext(false);
 			// Grant myself view access to this organization
@@ -124,6 +129,7 @@ describe('/organizations', () => {
 				name: 'Decoy funder, unexpected because I lack view access to this org',
 				shortCode: 'decoyfunderunexpected',
 				keycloakOrganizationId: keycloakOrganizationIdLackingPerm,
+				isCollaborative: false,
 			});
 
 			// I have view access to this org

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -89,6 +89,7 @@ describe('/proposals', () => {
 				name: 'Visible Funder',
 				shortCode: 'visibleFunder',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const visibleChangemaker = await createChangemaker(db, null, {
 				name: 'Visible Changemaker',
@@ -201,6 +202,7 @@ describe('/proposals', () => {
 				name: 'Test Funder',
 				shortCode: 'testFunder',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const systemFunder = await loadSystemFunder(db, null);
 			await createTestBaseFields();

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -216,6 +216,7 @@ describe('/sources', () => {
 				shortCode: 'exampleFunder',
 				name: 'Example Funder',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createSource(db, null, {
 				label: 'Example Corp',
@@ -319,6 +320,7 @@ describe('/sources', () => {
 				shortCode: 'foo',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const before = await loadTableMetrics('sources');
 			const result = await agent
@@ -350,6 +352,7 @@ describe('/sources', () => {
 				shortCode: 'foo',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
@@ -385,6 +388,7 @@ describe('/sources', () => {
 				shortCode: 'foo',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,

--- a/src/__tests__/userFunderPermissions.int.test.ts
+++ b/src/__tests__/userFunderPermissions.int.test.ts
@@ -25,6 +25,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await request(app)
 				.put(
@@ -40,6 +41,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 
 			await request(app)
@@ -89,6 +91,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 
 			const response = await request(app)
@@ -114,6 +117,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserFunderPermission(db, testUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
@@ -145,6 +149,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserFunderPermission(db, systemUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
@@ -176,6 +181,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await request(app)
 				.delete(
@@ -191,6 +197,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await request(app)
 				.delete(
@@ -237,6 +244,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await request(app)
 				.delete(
@@ -254,6 +262,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserFunderPermission(db, testUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
@@ -283,6 +292,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserFunderPermission(db, testUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,
@@ -328,6 +338,7 @@ describe('/users/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserFunderPermission(db, testUserAuthContext, {
 				userKeycloakUserId: testUser.keycloakUserId,

--- a/src/__tests__/userGroupFunderPermissions.int.test.ts
+++ b/src/__tests__/userGroupFunderPermissions.int.test.ts
@@ -27,6 +27,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await request(app)
 				.put(
@@ -43,6 +44,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await request(app)
 				.put(
@@ -70,6 +72,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 
 			await request(app)
@@ -88,6 +91,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 
 			await request(app)
@@ -107,6 +111,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 
 			const response = await request(app)
@@ -134,6 +139,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await request(app)
 				.delete(
@@ -150,6 +156,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await request(app)
 				.delete(
@@ -177,6 +184,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await request(app)
 				.delete(
@@ -194,6 +202,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await request(app)
 				.delete(
@@ -211,6 +220,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await request(app)
 				.delete(
@@ -230,6 +240,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserGroupFunderPermission(db, testUserAuthContext, {
 				keycloakOrganizationId: mockKeycloakOrganizationId,
@@ -261,6 +272,7 @@ describe('/userGroups/funders/:funderShortcode/permissions/:permission', () => {
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: mockKeycloakOrganizationId,
+				isCollaborative: false,
 			});
 			await createOrUpdateUserGroupFunderPermission(db, testUserAuthContext, {
 				keycloakOrganizationId: mockKeycloakOrganizationId,

--- a/src/__tests__/userOpportunityPermissions.int.test.ts
+++ b/src/__tests__/userOpportunityPermissions.int.test.ts
@@ -219,6 +219,7 @@ describe('/users/opportunities/:opportunityId/permissions/:opportunityPermission
 				shortCode: 'ExampleInc',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const opportunity = await createOpportunity(db, null, {
 				title: 'Test Opportunity',

--- a/src/__tests__/users.int.test.ts
+++ b/src/__tests__/users.int.test.ts
@@ -79,6 +79,7 @@ describe('/users', () => {
 				name: 'Test Funder',
 				shortCode: 'testFunder',
 				keycloakOrganizationId: null,
+				isCollaborative: false,
 			});
 			const changemaker = await createChangemaker(db, null, {
 				name: 'Test Changemaker',

--- a/src/database/initialization/funder_collaborative_invitation_to_json.sql
+++ b/src/database/initialization/funder_collaborative_invitation_to_json.sql
@@ -1,0 +1,16 @@
+SELECT drop_function('funder_collaborative_invitation_to_json');
+
+CREATE FUNCTION funder_collaborative_invitation_to_json(
+	funder_collaborative_invitation funder_collaborative_invitations
+)
+RETURNS jsonb AS $$
+BEGIN
+  RETURN jsonb_build_object(
+    'funderCollaborativeShortCode', funder_collaborative_invitation.funder_collaborative_short_code,
+    'invitedFunderShortCode', funder_collaborative_invitation.invited_funder_short_code,
+    'invitationStatus', funder_collaborative_invitation.invitation_status,
+    'createdBy', funder_collaborative_invitation.created_by,
+    'createdAt', funder_collaborative_invitation.created_at
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/initialization/funder_collaborative_member_to_json.sql
+++ b/src/database/initialization/funder_collaborative_member_to_json.sql
@@ -1,0 +1,15 @@
+SELECT drop_function('funder_collaborative_member_to_json');
+
+CREATE FUNCTION funder_collaborative_member_to_json(
+	funder_collaborative_member funder_collaborative_members
+)
+RETURNS jsonb AS $$
+BEGIN
+  RETURN jsonb_build_object(
+    'funderCollaborativeShortCode', funder_collaborative_member.funder_collaborative_short_code,
+    'memberFunderShortCode', funder_collaborative_member.member_funder_short_code,
+    'createdBy', funder_collaborative_member.created_by,
+    'createdAt', funder_collaborative_member.created_at
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/initialization/funder_to_json.sql
+++ b/src/database/initialization/funder_to_json.sql
@@ -7,7 +7,8 @@ BEGIN
     'shortCode', funder.short_code,
     'name', funder.name,
     'keycloakOrganizationId', funder.keycloak_organization_id,
-    'createdAt', funder.created_at
+    'createdAt', funder.created_at,
+    'isCollaborative', funder.is_collaborative
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/src/database/migrations/0067-add-funder-collaborative-members.sql
+++ b/src/database/migrations/0067-add-funder-collaborative-members.sql
@@ -1,0 +1,78 @@
+ALTER TABLE funders ADD COLUMN is_collaborative boolean NOT NULL DEFAULT false;
+CREATE TABLE funder_collaborative_members (
+	funder_collaborative_short_code short_code_t NOT NULL
+	REFERENCES funders (short_code) ON DELETE CASCADE,
+	member_funder_short_code short_code_t NOT NULL
+	REFERENCES funders (short_code) ON DELETE CASCADE,
+	-- If the user that created this happens to be deleted,
+	-- we still don't want to delete this.
+	created_by uuid REFERENCES users (keycloak_user_id)
+	ON DELETE SET NULL,
+	created_at timestamp with time zone NOT NULL DEFAULT now(),
+	not_after timestamp with time zone DEFAULT null,
+	PRIMARY KEY (funder_collaborative_short_code, member_funder_short_code),
+	CONSTRAINT no_self_membership CHECK (
+		funder_collaborative_short_code != member_funder_short_code
+	)
+
+);
+
+CREATE OR REPLACE FUNCTION prevent_inserting_non_collaborative_funder()
+RETURNS trigger AS $$
+DECLARE
+    forbidden BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+			SELECT 1
+				FROM funders
+				WHERE funders.short_code = NEW.funder_collaborative_short_code
+					AND funders.is_collaborative = false
+		) INTO forbidden;
+
+    IF forbidden THEN
+        RAISE EXCEPTION 'Non-collaborative funder %', NEW.funder_collaborative_short_code
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION prevent_inserting_collaborative_member_funder()
+RETURNS trigger AS $$
+DECLARE
+    forbidden BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+			SELECT 1
+				FROM funders
+				WHERE funders.short_code = NEW.member_funder_short_code
+					AND funders.is_collaborative = true
+		) INTO forbidden;
+
+    IF forbidden THEN
+        RAISE EXCEPTION 'Collaborative funder cannot be a member of another collaborative %', NEW.funder_collaborative_short_code
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER check_funder_is_non_collaborative
+BEFORE INSERT ON funder_collaborative_members
+FOR EACH ROW
+EXECUTE FUNCTION prevent_inserting_non_collaborative_funder();
+
+CREATE TRIGGER check_member_funder_is_collaborative
+BEFORE INSERT ON funder_collaborative_members
+FOR EACH ROW
+EXECUTE FUNCTION prevent_inserting_collaborative_member_funder();
+
+SELECT audit_table('funder_collaborative_members');
+
+COMMENT ON COLUMN funders.is_collaborative IS
+'To help the application prevent recursive collaboratives, a'
+'funder must be either a collaborative or not a collaborative.';

--- a/src/database/migrations/0068-add-funder-collaborative-invitations.sql
+++ b/src/database/migrations/0068-add-funder-collaborative-invitations.sql
@@ -1,0 +1,95 @@
+CREATE TYPE invitation_status_t AS ENUM (
+	'pending', 'accepted', 'rejected'
+);
+CREATE TABLE funder_collaborative_invitations (
+	funder_collaborative_short_code short_code_t NOT NULL
+	REFERENCES funders (short_code) ON DELETE CASCADE,
+	invited_funder_short_code short_code_t NOT NULL
+	REFERENCES funders (short_code) ON DELETE CASCADE,
+	invitation_status invitation_status_t NOT NULL,
+	created_by uuid REFERENCES users (keycloak_user_id)
+	ON DELETE SET NULL,
+	created_at timestamp with time zone NOT NULL DEFAULT now(),
+	not_after timestamp with time zone DEFAULT NULL,
+	PRIMARY KEY (funder_collaborative_short_code, invited_funder_short_code),
+	CONSTRAINT no_self_invitation CHECK (
+		funder_collaborative_short_code != invited_funder_short_code
+	)
+);
+
+CREATE OR REPLACE FUNCTION
+prevent_inserting_non_collaborative_funder_collaborative()
+RETURNS trigger AS $$
+DECLARE
+    forbidden BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+			SELECT 1
+				FROM funders
+				WHERE funders.short_code = NEW.funder_collaborative_short_code
+					AND funders.is_collaborative = false
+		) INTO forbidden;
+
+    IF forbidden THEN
+        RAISE EXCEPTION 'Non-collaborative funder %', NEW.funder_collaborative_short_code
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION prevent_inserting_collaborative_invited_funder()
+RETURNS trigger AS $$
+DECLARE
+    forbidden BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+			SELECT 1
+				FROM funders
+				WHERE funders.short_code = NEW.invited_funder_short_code
+					AND funders.is_collaborative = true
+		) INTO forbidden;
+
+    IF forbidden THEN
+        RAISE EXCEPTION 'Invitation funder cannot be a collaborative funder %', NEW.invited_funder_short_code
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE
+FUNCTION prevent_updating_invitation_status_if_accepted_or_rejected()
+RETURNS trigger AS $$
+BEGIN
+    IF OLD.invitation_status IN ('accepted', 'rejected')
+        THEN
+        RAISE EXCEPTION 'Cannot modify invitation_status after it has been responded to'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER check_funder_is_non_collaborative
+BEFORE INSERT ON funder_collaborative_invitations
+FOR EACH ROW
+EXECUTE FUNCTION prevent_inserting_non_collaborative_funder_collaborative();
+
+CREATE TRIGGER check_invitation_funder_is_collaborative
+BEFORE INSERT ON funder_collaborative_invitations
+FOR EACH ROW
+EXECUTE FUNCTION prevent_inserting_collaborative_invited_funder();
+
+CREATE TRIGGER prevent_invitation_status_update_if_accepted_or_rejected
+BEFORE UPDATE OF invitation_status ON funder_collaborative_invitations
+FOR EACH ROW
+EXECUTE FUNCTION prevent_updating_invitation_status_if_accepted_or_rejected();
+
+SELECT audit_table('funder_collaborative_invitations');

--- a/src/database/operations/funderCollaborativeInvitations/createFunderCollaborativeInvitation.ts
+++ b/src/database/operations/funderCollaborativeInvitations/createFunderCollaborativeInvitation.ts
@@ -1,0 +1,21 @@
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type {
+	FunderCollaborativeInvitation,
+	InternallyWritableFunderCollaborativeInvitation,
+} from '../../../types';
+
+const createFunderCollaborativeInvitation = generateCreateOrUpdateItemOperation<
+	FunderCollaborativeInvitation,
+	InternallyWritableFunderCollaborativeInvitation,
+	[]
+>(
+	'funderCollaborativeInvitations.insertOne',
+	[
+		'funderCollaborativeShortCode',
+		'invitedFunderShortCode',
+		'invitationStatus',
+	],
+	[],
+);
+
+export { createFunderCollaborativeInvitation };

--- a/src/database/operations/funderCollaborativeInvitations/index.ts
+++ b/src/database/operations/funderCollaborativeInvitations/index.ts
@@ -1,0 +1,5 @@
+export * from './createFunderCollaborativeInvitation';
+export * from './loadFunderCollaborativeInvitation';
+export * from './loadFunderCollaborativeInvitationBundle';
+export * from './removeFunderCollaborativeInvitation';
+export * from './updateFunderCollaborativeInvitation';

--- a/src/database/operations/funderCollaborativeInvitations/loadFunderCollaborativeInvitation.ts
+++ b/src/database/operations/funderCollaborativeInvitations/loadFunderCollaborativeInvitation.ts
@@ -1,0 +1,13 @@
+import { generateLoadItemOperation } from '../generators';
+import type { ShortCode, FunderCollaborativeInvitation } from '../../../types';
+
+const loadFunderCollaborativeInvitation = generateLoadItemOperation<
+	FunderCollaborativeInvitation,
+	[funderCollaborativeShortCode: ShortCode, invitedFunderShortCode: ShortCode]
+>(
+	'funderCollaborativeInvitations.selectByShortCode',
+	'FunderCollaborativeInvitation',
+	['funderCollaborativeShortCode', 'invitedFunderShortCode'],
+);
+
+export { loadFunderCollaborativeInvitation };

--- a/src/database/operations/funderCollaborativeInvitations/loadFunderCollaborativeInvitationBundle.ts
+++ b/src/database/operations/funderCollaborativeInvitations/loadFunderCollaborativeInvitationBundle.ts
@@ -1,0 +1,21 @@
+import { generateLoadBundleOperation } from '../generators';
+import type {
+	FunderCollaborativeInvitation,
+	FunderCollaborativeInvitationStatus,
+	ShortCode,
+} from '../../../types';
+
+const loadFunderCollaborativeInvitiationBundle = generateLoadBundleOperation<
+	FunderCollaborativeInvitation,
+	[
+		funderCollaborativeShortCode: ShortCode | undefined,
+		invitedFunderShortCode: ShortCode | undefined,
+		status: FunderCollaborativeInvitationStatus | undefined,
+	]
+>(
+	'funderCollaborativeInvitations.selectWithPagination',
+	'funder_collaborative_invitations',
+	['funderCollaborativeShortCode', 'invitedFunderShortCode', 'status'],
+);
+
+export { loadFunderCollaborativeInvitiationBundle };

--- a/src/database/operations/funderCollaborativeInvitations/removeFunderCollaborativeInvitation.ts
+++ b/src/database/operations/funderCollaborativeInvitations/removeFunderCollaborativeInvitation.ts
@@ -1,0 +1,12 @@
+import { generateRemoveItemOperation } from '../generators';
+import type { FunderCollaborativeInvitation, ShortCode } from '../../../types';
+
+const removeFunderCollaborativeInvitation = generateRemoveItemOperation<
+	FunderCollaborativeInvitation,
+	[funderCollaborativeShortCode: ShortCode, invitedFunderShortCode: ShortCode]
+>('funderCollaborativeInvitations.deleteOne', 'FunderCollaborativeInvitation', [
+	'funderCollaborativeShortCode',
+	'invitedFunderShortCode',
+]);
+
+export { removeFunderCollaborativeInvitation };

--- a/src/database/operations/funderCollaborativeInvitations/updateFunderCollaborativeInvitation.ts
+++ b/src/database/operations/funderCollaborativeInvitations/updateFunderCollaborativeInvitation.ts
@@ -1,0 +1,18 @@
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type {
+	FunderCollaborativeInvitation,
+	ShortCode,
+	WritableFunderCollaborativeInvitation,
+} from '../../../types';
+
+const updateFunderCollaborativeInvitation = generateCreateOrUpdateItemOperation<
+	FunderCollaborativeInvitation,
+	Partial<WritableFunderCollaborativeInvitation>,
+	[funderCollaborativeShortCode: ShortCode, invitedFunderShortCode: ShortCode]
+>(
+	'funderCollaborativeInvitations.updateByShortCode',
+	['invitationStatus'],
+	['funderCollaborativeShortCode', 'invitedFunderShortCode'],
+);
+
+export { updateFunderCollaborativeInvitation };

--- a/src/database/operations/funderCollaborativeMembers/createOrUpdateFunderCollaborativeMember.ts
+++ b/src/database/operations/funderCollaborativeMembers/createOrUpdateFunderCollaborativeMember.ts
@@ -1,0 +1,18 @@
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type {
+	FunderCollaborativeMember,
+	InternallyWritableFunderCollaborativeMember,
+} from '../../../types/FunderCollaborativeMember';
+
+const createOrUpdateFunderCollaborativeMember =
+	generateCreateOrUpdateItemOperation<
+		FunderCollaborativeMember,
+		InternallyWritableFunderCollaborativeMember,
+		[]
+	>(
+		'funderCollaborativeMembers.insertOrUpdateOne',
+		['funderCollaborativeShortCode', 'memberFunderShortCode'],
+		[],
+	);
+
+export { createOrUpdateFunderCollaborativeMember };

--- a/src/database/operations/funderCollaborativeMembers/index.ts
+++ b/src/database/operations/funderCollaborativeMembers/index.ts
@@ -1,0 +1,4 @@
+export * from './createOrUpdateFunderCollaborativeMember';
+export * from './loadFunderCollaborativeMember';
+export * from './loadFunderCollaborativeMemberBundle';
+export * from './removeFunderCollaborativeMember';

--- a/src/database/operations/funderCollaborativeMembers/loadFunderCollaborativeMember.ts
+++ b/src/database/operations/funderCollaborativeMembers/loadFunderCollaborativeMember.ts
@@ -1,0 +1,13 @@
+import { generateLoadItemOperation } from '../generators';
+import type { FunderCollaborativeMember } from '../../../types/FunderCollaborativeMember';
+import type { ShortCode } from '../../../types/ShortCode';
+
+const loadFunderCollaborativeMember = generateLoadItemOperation<
+	FunderCollaborativeMember,
+	[funderCollaborativeShortCode: ShortCode, memberFunderShortCode: ShortCode]
+>('funderCollaborativeMembers.selectByShortCode', 'FunderCollaborativeMember', [
+	'funderCollaborativeShortCode',
+	'memberFunderShortCode',
+]);
+
+export { loadFunderCollaborativeMember };

--- a/src/database/operations/funderCollaborativeMembers/loadFunderCollaborativeMemberBundle.ts
+++ b/src/database/operations/funderCollaborativeMembers/loadFunderCollaborativeMemberBundle.ts
@@ -1,0 +1,16 @@
+import { generateLoadBundleOperation } from '../generators';
+import type { FunderCollaborativeMember, ShortCode } from '../../../types';
+
+const loadFunderCollaborativeMemberBundle = generateLoadBundleOperation<
+	FunderCollaborativeMember,
+	[
+		funderCollaborativeShortCode: ShortCode | undefined,
+		memberFunderShortCode: ShortCode | undefined,
+	]
+>(
+	'funderCollaborativeMembers.selectWithPagination',
+	'funder_collaborative_members',
+	['funderCollaborativeShortCode', 'memberFunderShortCode'],
+);
+
+export { loadFunderCollaborativeMemberBundle };

--- a/src/database/operations/funderCollaborativeMembers/removeFunderCollaborativeMember.ts
+++ b/src/database/operations/funderCollaborativeMembers/removeFunderCollaborativeMember.ts
@@ -1,0 +1,12 @@
+import { generateRemoveItemOperation } from '../generators';
+import type { FunderCollaborativeMember, ShortCode } from '../../../types';
+
+const removeFunderCollaborativeMember = generateRemoveItemOperation<
+	FunderCollaborativeMember,
+	[funderCollaborativeShortCode: ShortCode, memberFunderShortCode: ShortCode]
+>('funderCollaborativeMembers.deleteOne', 'FunderCollaborativeMember', [
+	'funderCollaborativeShortCode',
+	'memberFunderShortCode',
+]);
+
+export { removeFunderCollaborativeMember };

--- a/src/database/operations/funders/createOrUpdateFunder.ts
+++ b/src/database/operations/funders/createOrUpdateFunder.ts
@@ -7,7 +7,7 @@ const createOrUpdateFunder = generateCreateOrUpdateItemOperation<
 	[]
 >(
 	'funders.insertOrUpdateOne',
-	['shortCode', 'name', 'keycloakOrganizationId'],
+	['shortCode', 'name', 'keycloakOrganizationId', 'isCollaborative'],
 	[],
 );
 

--- a/src/database/operations/index.ts
+++ b/src/database/operations/index.ts
@@ -9,6 +9,7 @@ export * from './changemakers';
 export * from './dataProviders';
 export * from './ephemeralUserGroupAssociations';
 export * from './fiscalSponsorships';
+export * from './funderCollaborativeMembers';
 export * from './funders';
 export * from './generic';
 export * from './opportunities';

--- a/src/database/operations/index.ts
+++ b/src/database/operations/index.ts
@@ -9,6 +9,7 @@ export * from './changemakers';
 export * from './dataProviders';
 export * from './ephemeralUserGroupAssociations';
 export * from './fiscalSponsorships';
+export * from './funderCollaborativeInvitations';
 export * from './funderCollaborativeMembers';
 export * from './funders';
 export * from './generic';

--- a/src/database/operations/users/__tests__/loadUserByKeycloakUserId.int.test.ts
+++ b/src/database/operations/users/__tests__/loadUserByKeycloakUserId.int.test.ts
@@ -48,6 +48,7 @@ describe('loadUserByKeycloakUserId', () => {
 			keycloakOrganizationId: funderKeycloakOrganizationId,
 			name: 'Foo Funder',
 			shortCode: 'fooFunder',
+			isCollaborative: false,
 		});
 		const dataProviderKeycloakOrganizationId =
 			'9426f49a-4c11-4d26-9e58-2b62bf2ee512';
@@ -280,6 +281,7 @@ describe('loadUserByKeycloakUserId', () => {
 			keycloakOrganizationId: funderKeycloakOrganizationId,
 			name: 'Foo Funder',
 			shortCode: 'fooFunder',
+			isCollaborative: false,
 		});
 		await createEphemeralUserGroupAssociation(db, null, {
 			userKeycloakUserId: user.keycloakUserId,

--- a/src/database/queries/funderCollaborativeInvitations/deleteOne.sql
+++ b/src/database/queries/funderCollaborativeInvitations/deleteOne.sql
@@ -1,0 +1,9 @@
+UPDATE funder_collaborative_invitations
+SET not_after = now()
+WHERE
+	funder_collaborative_short_code = :funderCollaborativeShortCode
+	AND invited_funder_short_code = :invitedFunderShortCode
+	AND NOT is_expired(not_after)
+RETURNING
+	funder_collaborative_invitation_to_json(funder_collaborative_invitations)
+		AS object;

--- a/src/database/queries/funderCollaborativeInvitations/insertOne.sql
+++ b/src/database/queries/funderCollaborativeInvitations/insertOne.sql
@@ -1,0 +1,20 @@
+INSERT INTO funder_collaborative_invitations (
+	funder_collaborative_short_code,
+	invited_funder_short_code,
+	invitation_status,
+	created_by
+) VALUES (
+	:funderCollaborativeShortCode,
+	:invitedFunderShortCode,
+	:invitationStatus,
+	:authContextKeycloakUserId
+)
+ON CONFLICT (
+	funder_collaborative_short_code,
+	invited_funder_short_code
+) DO UPDATE
+	SET
+		not_after = null
+RETURNING
+	funder_collaborative_invitation_to_json(funder_collaborative_invitations)
+		AS object;

--- a/src/database/queries/funderCollaborativeInvitations/selectByShortCode.sql
+++ b/src/database/queries/funderCollaborativeInvitations/selectByShortCode.sql
@@ -1,0 +1,7 @@
+SELECT
+	funder_collaborative_invitation_to_json(funder_collaborative_invitations.*)
+		AS object
+FROM funder_collaborative_invitations
+WHERE
+	funder_collaborative_short_code = :funderCollaborativeShortCode
+	AND invited_funder_short_code = :invitedFunderShortCode;

--- a/src/database/queries/funderCollaborativeInvitations/selectWithPagination.sql
+++ b/src/database/queries/funderCollaborativeInvitations/selectWithPagination.sql
@@ -1,0 +1,26 @@
+SELECT
+	funder_collaborative_invitation_to_json(funder_collaborative_invitations.*)
+		AS object
+FROM funder_collaborative_invitations
+WHERE
+	CASE
+		WHEN :funderCollaborativeShortCode::short_code_t IS NULL THEN
+			TRUE
+		ELSE
+			funder_collaborative_short_code = :funderCollaborativeShortCode::short_code_t
+	END
+	AND CASE
+		WHEN :invitedFunderShortCode::short_code_t IS NULL THEN
+			TRUE
+		ELSE
+			invited_funder_short_code = :invitedFunderShortCode::short_code_t
+	END
+	AND CASE
+		WHEN :status::invitation_status_t IS NULL THEN
+			TRUE
+		ELSE
+			invitation_status = :status::invitation_status_t
+	END
+	AND NOT is_expired(not_after)
+ORDER BY created_at DESC
+LIMIT :limit OFFSET :offset;

--- a/src/database/queries/funderCollaborativeInvitations/updateByShortCode.sql
+++ b/src/database/queries/funderCollaborativeInvitations/updateByShortCode.sql
@@ -1,0 +1,10 @@
+UPDATE funder_collaborative_invitations
+SET
+	invitation_status
+	= coalesce(:invitationStatus::invitation_status_t, invitation_status)
+WHERE
+	funder_collaborative_short_code = :funderCollaborativeShortCode::short_code_t
+	AND invited_funder_short_code = :invitedFunderShortCode::short_code_t
+RETURNING
+	funder_collaborative_invitation_to_json(funder_collaborative_invitations.*)
+		AS object;

--- a/src/database/queries/funderCollaborativeMembers/deleteOne.sql
+++ b/src/database/queries/funderCollaborativeMembers/deleteOne.sql
@@ -1,0 +1,9 @@
+UPDATE funder_collaborative_members
+SET not_after = now()
+WHERE
+	funder_collaborative_short_code = :funderCollaborativeShortCode
+	AND member_funder_short_code = :memberFunderShortCode
+	AND NOT is_expired(not_after)
+RETURNING
+	funder_collaborative_member_to_json(funder_collaborative_members)
+		AS object;

--- a/src/database/queries/funderCollaborativeMembers/insertOrUpdateOne.sql
+++ b/src/database/queries/funderCollaborativeMembers/insertOrUpdateOne.sql
@@ -1,0 +1,16 @@
+INSERT INTO funder_collaborative_members (
+	funder_collaborative_short_code,
+	member_funder_short_code,
+	created_by
+) VALUES (
+	:funderCollaborativeShortCode,
+	:memberFunderShortCode,
+	:authContextKeycloakUserId
+)
+ON CONFLICT (
+	funder_collaborative_short_code,
+	member_funder_short_code
+) DO UPDATE
+	SET not_after = null
+RETURNING
+	funder_collaborative_member_to_json(funder_collaborative_members) AS object;

--- a/src/database/queries/funderCollaborativeMembers/selectByShortCode.sql
+++ b/src/database/queries/funderCollaborativeMembers/selectByShortCode.sql
@@ -1,0 +1,8 @@
+SELECT
+	funder_collaborative_member_to_json(funder_collaborative_members.*)
+		AS object
+FROM funder_collaborative_members
+WHERE
+	funder_collaborative_short_code = :funderCollaborativeShortCode
+	AND member_funder_short_code = :memberFunderShortCode
+	AND NOT is_expired(not_after);

--- a/src/database/queries/funderCollaborativeMembers/selectWithPagination.sql
+++ b/src/database/queries/funderCollaborativeMembers/selectWithPagination.sql
@@ -1,0 +1,24 @@
+SELECT
+	funder_collaborative_member_to_json(funder_collaborative_members.*)
+		AS object
+FROM funder_collaborative_members
+WHERE
+	CASE
+		WHEN
+			:funderCollaborativeShortCode::short_code_t IS NULL
+		THEN
+			TRUE
+		ELSE
+			funder_collaborative_short_code = :funderCollaborativeShortCode
+	END
+	AND CASE
+		WHEN
+			:memberFunderShortCode::short_code_t IS NULL
+		THEN
+			TRUE
+		ELSE
+			member_funder_short_code = :memberFunderShortCode
+	END
+	AND NOT is_expired(not_after)
+ORDER BY created_at DESC
+LIMIT :limit OFFSET :offset;

--- a/src/database/queries/funders/insertOrUpdateOne.sql
+++ b/src/database/queries/funders/insertOrUpdateOne.sql
@@ -1,15 +1,18 @@
 INSERT INTO funders (
 	short_code,
 	name,
-	keycloak_organization_id
+	keycloak_organization_id,
+	is_collaborative
 ) VALUES (
 	:shortCode,
 	:name,
-	:keycloakOrganizationId
+	:keycloakOrganizationId,
+	:isCollaborative
 )
 ON CONFLICT (short_code)
 DO UPDATE
 	SET
 		name = excluded.name,
-		keycloak_organization_id = excluded.keycloak_organization_id
+		keycloak_organization_id = excluded.keycloak_organization_id,
+		is_collaborative = excluded.is_collaborative
 RETURNING funder_to_json(funders) AS object;

--- a/src/handlers/funderCollaborativeInvitationsHandlers.ts
+++ b/src/handlers/funderCollaborativeInvitationsHandlers.ts
@@ -1,0 +1,201 @@
+import { HTTP_STATUS } from '../constants';
+import {
+	db,
+	getLimitValues,
+	loadFunderCollaborativeInvitiationBundle,
+	createFunderCollaborativeInvitation,
+	createOrUpdateFunderCollaborativeMember,
+	updateFunderCollaborativeInvitation,
+} from '../database';
+import {
+	FunderCollaborativeInvitationStatus,
+	isAuthContext,
+	isFunderCollaborativeInvitationPatch,
+	isFunderCollaborativeInvitationPost,
+} from '../types';
+import { FailedMiddlewareError, InputValidationError } from '../errors';
+import { extractPaginationParameters } from '../queryParameters';
+import { isShortCode } from '../types/ShortCode';
+import type { Request, Response } from 'express';
+
+const postFunderCollaborativeInvitation = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const {
+		params: { funderShortCode, invitedFunderShortCode },
+	} = req;
+	if (!isShortCode(funderShortCode)) {
+		throw new InputValidationError(
+			'Invalid funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+	if (!isShortCode(invitedFunderShortCode)) {
+		throw new InputValidationError(
+			'Invalid invited funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+	const body = req.body as unknown;
+	if (!isFunderCollaborativeInvitationPost(body)) {
+		throw new InputValidationError(
+			'Invalid request body.',
+			isFunderCollaborativeInvitationPost.errors ?? [],
+		);
+	}
+
+	const funderCollaborativeInvitation =
+		await createFunderCollaborativeInvitation(db, req, {
+			funderCollaborativeShortCode: funderShortCode,
+			invitedFunderShortCode,
+			invitationStatus: FunderCollaborativeInvitationStatus.PENDING,
+		});
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
+		.contentType('application/json')
+		.send(funderCollaborativeInvitation);
+};
+
+const getSentFunderCollaborativeInvitations = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const {
+		params: { funderShortCode },
+	} = req;
+	if (!isShortCode(funderShortCode)) {
+		throw new InputValidationError(
+			'Invalid inviter short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+	const paginationParameters = extractPaginationParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	const funderCollaborativeInvitations =
+		await loadFunderCollaborativeInvitiationBundle(
+			db,
+			req,
+			funderShortCode,
+			undefined,
+			undefined,
+			limit,
+			offset,
+		);
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(funderCollaborativeInvitations);
+};
+
+const getRecievedFunderCollaborativeInvitations = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const {
+		params: { funderShortCode },
+	} = req;
+	if (!isShortCode(funderShortCode)) {
+		throw new InputValidationError(
+			'Invalid funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+
+	const paginationParameters = extractPaginationParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	const funderCollaborativeInvitations =
+		await loadFunderCollaborativeInvitiationBundle(
+			db,
+			req,
+			undefined,
+			funderShortCode,
+			undefined,
+			limit,
+			offset,
+		);
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(funderCollaborativeInvitations);
+};
+
+const patchFunderCollaborativeInvitation = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const {
+		params: { funderShortCode, invitedFunderShortCode },
+	} = req;
+
+	if (!isShortCode(funderShortCode)) {
+		throw new InputValidationError(
+			'Invalid funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+
+	if (!isShortCode(invitedFunderShortCode)) {
+		throw new InputValidationError(
+			'Invalid invited funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+
+	const body = req.body as unknown;
+
+	if (!isFunderCollaborativeInvitationPatch(body)) {
+		throw new InputValidationError(
+			'Invalid request body.',
+			isFunderCollaborativeInvitationPatch.errors ?? [],
+		);
+	}
+
+	const { invitationStatus } = body;
+	const finalFunderCollaborativeInvitation = await db.transaction(
+		async (transactionDb) => {
+			const funderCollaborativeInvitation =
+				await updateFunderCollaborativeInvitation(
+					transactionDb,
+					req,
+					{
+						invitationStatus,
+					},
+					invitedFunderShortCode,
+					funderShortCode,
+				);
+			if (invitationStatus === FunderCollaborativeInvitationStatus.ACCEPTED) {
+				await createOrUpdateFunderCollaborativeMember(transactionDb, req, {
+					funderCollaborativeShortCode: invitedFunderShortCode,
+					memberFunderShortCode: funderShortCode,
+				});
+			}
+			return {
+				...funderCollaborativeInvitation,
+			};
+		},
+	);
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(finalFunderCollaborativeInvitation);
+};
+
+export const funderCollaborativeInvitationsHandlers = {
+	postFunderCollaborativeInvitation,
+	getSentFunderCollaborativeInvitations,
+	getRecievedFunderCollaborativeInvitations,
+	patchFunderCollaborativeInvitation,
+};

--- a/src/handlers/funderCollaborativeMembersHandlers.ts
+++ b/src/handlers/funderCollaborativeMembersHandlers.ts
@@ -1,0 +1,154 @@
+import { HTTP_STATUS } from '../constants';
+import {
+	db,
+	getLimitValues,
+	loadFunderCollaborativeMember,
+	loadFunderCollaborativeMemberBundle,
+	createOrUpdateFunderCollaborativeMember,
+	removeFunderCollaborativeMember,
+} from '../database';
+import { isAuthContext } from '../types';
+import { FailedMiddlewareError, InputValidationError } from '../errors';
+import { extractPaginationParameters } from '../queryParameters';
+import { isShortCode } from '../types/ShortCode';
+import type { Request, Response } from 'express';
+
+const getFunderCollaborativeMember = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const {
+		params: { funderShortCode, memberFunderShortCode },
+	} = req;
+	if (!isShortCode(funderShortCode)) {
+		throw new InputValidationError(
+			'Invalid funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+	if (!isShortCode(memberFunderShortCode)) {
+		throw new InputValidationError(
+			'Invalid member short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+	const funder = await loadFunderCollaborativeMember(
+		db,
+		req,
+		funderShortCode,
+		memberFunderShortCode,
+	);
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(funder);
+};
+
+const getFunderCollaborativeMembers = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const {
+		params: { funderShortCode },
+	} = req;
+	if (!isShortCode(funderShortCode)) {
+		throw new InputValidationError(
+			'Invalid funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+	const paginationParameters = extractPaginationParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	const funderBundle = await loadFunderCollaborativeMemberBundle(
+		db,
+		req,
+		funderShortCode,
+		undefined,
+		limit,
+		offset,
+	);
+
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(funderBundle);
+};
+
+const postFunderCollaborativeMember = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const {
+		params: { funderShortCode, memberFunderShortCode },
+	} = req;
+
+	if (!isShortCode(funderShortCode)) {
+		throw new InputValidationError(
+			'Invalid funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+	if (!isShortCode(memberFunderShortCode)) {
+		throw new InputValidationError(
+			'Invalid member funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+
+	const funder = await createOrUpdateFunderCollaborativeMember(db, req, {
+		funderCollaborativeShortCode: funderShortCode,
+		memberFunderShortCode,
+	});
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
+		.contentType('application/json')
+		.send(funder);
+};
+
+const deleteFunderCollaborativeMember = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	const {
+		params: { funderShortCode, memberFunderShortCode },
+	} = req;
+	if (!isShortCode(funderShortCode)) {
+		throw new InputValidationError(
+			'Invalid funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+	if (!isShortCode(memberFunderShortCode)) {
+		throw new InputValidationError(
+			'Invalid member funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+
+	const item = await removeFunderCollaborativeMember(
+		db,
+		null,
+		funderShortCode,
+		memberFunderShortCode,
+	);
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(item);
+};
+
+export const funderCollaborativeMembersHandlers = {
+	getFunderCollaborativeMember,
+	getFunderCollaborativeMembers,
+	postFunderCollaborativeMember,
+	deleteFunderCollaborativeMember,
+};

--- a/src/handlers/fundersHandlers.ts
+++ b/src/handlers/fundersHandlers.ts
@@ -65,11 +65,12 @@ const putFunder = async (req: Request, res: Response): Promise<void> => {
 		);
 	}
 
-	const { name, keycloakOrganizationId } = body;
+	const { name, keycloakOrganizationId, isCollaborative } = body;
 	const funder = await createOrUpdateFunder(db, null, {
 		shortCode,
 		name,
 		keycloakOrganizationId,
+		isCollaborative,
 	});
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -65,6 +65,9 @@
 			"Funder": {
 				"$ref": "./components/schemas/Funder.json"
 			},
+			"FunderCollaborativeMember": {
+				"$ref": "./components/schemas/FunderCollaborativeMember.json"
+			},
 			"ShallowChangemaker": {
 				"$ref": "./components/schemas/ShallowChangemaker.json"
 			},
@@ -238,6 +241,12 @@
 		},
 		"/funders/{funderShortCode}": {
 			"$ref": "./paths/funder.json"
+		},
+		"/funders/{funderCollaborativeShortCode}/members": {
+			"$ref": "./paths/funderCollaborativeMembers.json"
+		},
+		"/funders/{funderCollaborativeShortCode}/members/{memberFunderShortCode}": {
+			"$ref": "./paths/funderCollaborativeMember.json"
 		},
 		"/baseFields/{baseFieldShortCode}/localizations": {
 			"$ref": "./paths/baseFieldLocalizations.json"

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -248,6 +248,18 @@
 		"/funders/{funderCollaborativeShortCode}/members/{memberFunderShortCode}": {
 			"$ref": "./paths/funderCollaborativeMember.json"
 		},
+		"/funders/{funderCollaborativeShortCode}/invitations/sent": {
+			"$ref": "./paths/funderCollaborativeInvitationsSent.json"
+		},
+		"/funders/{funderCollaborativeShortCode}/invitations/sent/{invitedFunderShortCode}": {
+			"$ref": "./paths/funderCollaborativeInvitationSent.json"
+		},
+		"/funders/{invitedFunderShortCode}/invitations/received": {
+			"$ref": "./paths/funderCollaborativeInvitationsReceived.json"
+		},
+		"/funders/{invitedFunderShortCode}/invitations/received/{funderCollaborativeShortCode}": {
+			"$ref": "./paths/funderCollaborativeInvitationReceived.json"
+		},
 		"/baseFields/{baseFieldShortCode}/localizations": {
 			"$ref": "./paths/baseFieldLocalizations.json"
 		},

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.21.0",
+		"version": "0.22.0",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"

--- a/src/openapi/components/responses/DatabaseError.json
+++ b/src/openapi/components/responses/DatabaseError.json
@@ -1,0 +1,3 @@
+{
+	"description": "A datanase error occurred."
+}

--- a/src/openapi/components/responses/InputValidation.json
+++ b/src/openapi/components/responses/InputValidation.json
@@ -1,0 +1,3 @@
+{
+	"description": "The request body is invalid."
+}

--- a/src/openapi/components/responses/Unauthorized.json
+++ b/src/openapi/components/responses/Unauthorized.json
@@ -1,0 +1,3 @@
+{
+	"description": "Authentication was not provided or was invalid."
+}

--- a/src/openapi/components/responses/UnprocessableEntity.json
+++ b/src/openapi/components/responses/UnprocessableEntity.json
@@ -1,0 +1,3 @@
+{
+	"description": "The referenced entity does not exist in the database."
+}

--- a/src/openapi/components/schemas/Funder.json
+++ b/src/openapi/components/schemas/Funder.json
@@ -16,7 +16,11 @@
 			"type": "string",
 			"format": "date-time",
 			"readOnly": true
+		},
+		"isCollaborative": {
+			"type": "boolean",
+			"default": false
 		}
 	},
-	"required": ["id", "name", "createdAt"]
+	"required": ["id", "name", "createdAt", "isCollaborative"]
 }

--- a/src/openapi/components/schemas/FunderCollaborativeInvitation.json
+++ b/src/openapi/components/schemas/FunderCollaborativeInvitation.json
@@ -1,0 +1,34 @@
+{
+	"type": "object",
+	"properties": {
+		"funderCollaborativeShortCode": {
+			"$ref": "./shortCode.json",
+			"readOnly": true
+		},
+		"invitedFunderShortCode": {
+			"$ref": "./shortCode.json",
+			"readOnly": true
+		},
+		"createdAt": {
+			"type": "string",
+			"format": "date-time",
+			"readOnly": true
+		},
+		"invitationStatus": {
+			"type": "string",
+			"enum": ["pending", "accepted", "rejected"]
+		},
+		"createdBy": {
+			"description": "The keycloak user id of the PDC user that created this funder collaborative member",
+			"type": "string",
+			"format": "uuid",
+			"readOnly": true
+		}
+	},
+	"required": [
+		"funderCollaborativeShortCode",
+		"invitedFunderShortCode",
+		"createdAt",
+		"createdBy"
+	]
+}

--- a/src/openapi/components/schemas/FunderCollaborativeInvitationBundle.json
+++ b/src/openapi/components/schemas/FunderCollaborativeInvitationBundle.json
@@ -1,0 +1,19 @@
+{
+	"allOf": [
+		{
+			"$ref": "./Bundle.json"
+		},
+		{
+			"type": "object",
+			"properties": {
+				"entries": {
+					"type": "array",
+					"items": {
+						"$ref": "./FunderCollaborativeInvitation.json"
+					}
+				}
+			},
+			"required": ["entries"]
+		}
+	]
+}

--- a/src/openapi/components/schemas/FunderCollaborativeMember.json
+++ b/src/openapi/components/schemas/FunderCollaborativeMember.json
@@ -1,0 +1,30 @@
+{
+	"type": "object",
+	"properties": {
+		"funderCollaborativeShortCode": {
+			"$ref": "./shortCode.json",
+			"readOnly": true
+		},
+		"memberFunderShortCode": {
+			"$ref": "./shortCode.json",
+			"readOnly": true
+		},
+		"createdAt": {
+			"type": "string",
+			"format": "date-time",
+			"readOnly": true
+		},
+		"createdBy": {
+			"description": "The keycloak user id of the PDC user that created this funder collaborative member",
+			"type": "string",
+			"format": "uuid",
+			"readOnly": true
+		}
+	},
+	"required": [
+		"funderCollaborativeShortCode",
+		"memberFunderShortCode",
+		"createdAt",
+		"createdBy"
+	]
+}

--- a/src/openapi/components/schemas/FunderCollaborativeMemberBundle.json
+++ b/src/openapi/components/schemas/FunderCollaborativeMemberBundle.json
@@ -1,0 +1,19 @@
+{
+	"allOf": [
+		{
+			"$ref": "./Bundle.json"
+		},
+		{
+			"type": "object",
+			"properties": {
+				"entries": {
+					"type": "array",
+					"items": {
+						"$ref": "./FunderCollaborativeMember.json"
+					}
+				}
+			},
+			"required": ["entries"]
+		}
+	]
+}

--- a/src/openapi/paths/funderCollaborativeInvitationReceived.json
+++ b/src/openapi/paths/funderCollaborativeInvitationReceived.json
@@ -1,0 +1,60 @@
+{
+	"patch": {
+		"operationId": "updateFunderCollaborativeInvitation",
+		"summary": "Updates a funder collaborative invitation.",
+		"tags": ["Funder Collaborative Invitations"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "funderCollaborativeShortCode",
+				"description": "The short code of the collaborative funder that sent the invitation.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			{
+				"name": "invitedFunderShortCode",
+				"description": "The short code of the funder that recieved the invitation.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			}
+		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/FunderCollaborativeInvitation.json"
+					}
+				}
+			}
+		},
+		"responses": {
+			"201": {
+				"description": "The new funder collaborative member that was created.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/FunderCollaborativeMember.json"
+						}
+					}
+				}
+			},
+			"400": {
+				"$ref": "../components/responses/InputValidation.json"
+			},
+			"401": {
+				"$ref": "../components/responses/Unauthorized.json"
+			}
+		}
+	}
+}

--- a/src/openapi/paths/funderCollaborativeInvitationSent.json
+++ b/src/openapi/paths/funderCollaborativeInvitationSent.json
@@ -1,0 +1,60 @@
+{
+	"post": {
+		"operationId": "createFunderCollaborativeInvitation",
+		"summary": "Creates a new funder collaborative invitation.",
+		"tags": ["Funder Collaborative Invitations"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "funderCollaborativeShortCode",
+				"description": "The short code of the source collaborative funder.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			{
+				"name": "invitedFunderShortCode",
+				"description": "The short code of the invited funder.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			}
+		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/EmptyObject.json"
+					}
+				}
+			}
+		},
+		"responses": {
+			"201": {
+				"description": "The funder collaborative invitation.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/FunderCollaborativeInvitation.json"
+						}
+					}
+				}
+			},
+			"400": {
+				"$ref": "../components/responses/InputValidation.json"
+			},
+			"401": {
+				"$ref": "../components/responses/Unauthorized.json"
+			}
+		}
+	}
+}

--- a/src/openapi/paths/funderCollaborativeInvitationsReceived.json
+++ b/src/openapi/paths/funderCollaborativeInvitationsReceived.json
@@ -1,0 +1,43 @@
+{
+	"get": {
+		"operationId": "getReceivedFunderCollaborativeInvitations",
+		"summary": "Gets a list of funder collaborative invitations received by the funder.",
+		"tags": ["Funder Collaborative Invitations"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "invitedFunderShortCode",
+				"description": "The short code of the funder that is receiving the invitation.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			{ "$ref": "../components/parameters/pageParam.json" },
+			{ "$ref": "../components/parameters/countParam.json" }
+		],
+		"responses": {
+			"200": {
+				"description": "A list of funder collaborative invitations .",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/FunderCollaborativeInvitationBundle.json"
+						}
+					}
+				}
+			},
+			"401": {
+				"$ref": "../components/responses/Unauthorized.json"
+			},
+			"404": {
+				"$ref": "../components/responses/NotFound.json"
+			}
+		}
+	}
+}

--- a/src/openapi/paths/funderCollaborativeInvitationsSent.json
+++ b/src/openapi/paths/funderCollaborativeInvitationsSent.json
@@ -1,0 +1,50 @@
+{
+	"get": {
+		"operationId": "getSentFunderCollaborativeInvitations",
+		"summary": "Gets a list of funder collaborative invitations sent by the funder.",
+		"tags": ["Funder Collaborative Invitations"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "funderCollaborativeShortCode",
+				"description": "The short code of the source funder.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			{ "$ref": "../components/parameters/pageParam.json" },
+			{ "$ref": "../components/parameters/countParam.json" }
+		],
+		"responses": {
+			"200": {
+				"description": "A list of funder collaborative invitations .",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/FunderCollaborativeMemberBundle.json"
+						}
+					}
+				}
+			},
+			"401": {
+				"description": "Authentication was not provided or was invalid.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/PdcError.json"
+						}
+					}
+				}
+			},
+			"404": {
+				"$ref": "../components/responses/NotFound.json"
+			}
+		}
+	}
+}

--- a/src/openapi/paths/funderCollaborativeMember.json
+++ b/src/openapi/paths/funderCollaborativeMember.json
@@ -1,0 +1,153 @@
+{
+	"get": {
+		"operationId": "getFunderCollaborativeMemberByShortCode",
+		"summary": "Gets a specific funder collaborative member.",
+		"tags": ["Funder Collaborative Members"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "funderCollaborativeShortCode",
+				"description": "The short code of a funder collaborative.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			{
+				"name": "memberFunderShortCode",
+				"description": "The short code of funder to be made a member of the collaborative.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			}
+		],
+		"responses": {
+			"200": {
+				"description": "The funder collaborative member.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/FunderCollaborativeMember.json"
+						}
+					}
+				}
+			},
+			"404": {
+				"$ref": "../components/responses/NotFound.json"
+			}
+		}
+	},
+	"post": {
+		"operationId": "createOrUpdateFunderCollaborativeMember",
+		"summary": "Creates or updates a new funder collaborative member.",
+		"tags": ["Funder Collaborative Members"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "funderCollaborativeShortCode",
+				"description": "The short code of a collaborative funder.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			{
+				"name": "memberFunderShortCode",
+				"description": "The short code of a member funder.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			}
+		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/FunderCollaborativeMember.json"
+					}
+				}
+			}
+		},
+		"responses": {
+			"201": {
+				"description": "The new funder collaborative member that was created.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/FunderCollaborativeMember.json"
+						}
+					}
+				}
+			},
+			"400": {
+				"$ref": "../components/responses/DatabaseError.json"
+			},
+			"401": {
+				"$ref": "../components/responses/Unauthorized.json"
+			},
+			"422": {
+				"$ref": "../components/responses/UnprocessableEntity.json"
+			}
+		}
+	},
+	"delete": {
+		"operationId": "deleteFunderCollaborativeMemberByShortCode",
+		"summary": "Deletes a specific funder collaborative member.",
+		"tags": ["Funder Collaborative Members"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "funderCollaborativeShortCode",
+				"description": "The short code of a funder collaborative member.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			{
+				"name": "memberFunderShortCode",
+				"description": "The short code of a member.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			}
+		],
+		"responses": {
+			"200": {
+				"description": "The deleted funder collaborative member.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/FunderCollaborativeMember.json"
+						}
+					}
+				}
+			},
+			"422": {
+				"$ref": "../components/responses/UnprocessableEntity.json"
+			}
+		}
+	}
+}

--- a/src/openapi/paths/funderCollaborativeMembers.json
+++ b/src/openapi/paths/funderCollaborativeMembers.json
@@ -1,0 +1,40 @@
+{
+	"get": {
+		"operationId": "getFunderCollaborativeMembers",
+		"summary": "Gets a list of funder collaborative members.",
+		"tags": ["Funder Collaborative Members"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "funderCollaborativeShortCode",
+				"description": "The short code of a collaborative funder.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"type": "string"
+				}
+			},
+			{ "$ref": "../components/parameters/pageParam.json" },
+			{ "$ref": "../components/parameters/countParam.json" }
+		],
+		"responses": {
+			"200": {
+				"description": "A list of funder collaborative members.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/FunderCollaborativeMemberBundle.json"
+						}
+					}
+				}
+			},
+			"404": {
+				"$ref": "../components/responses/NotFound.json"
+			}
+		}
+	}
+}

--- a/src/routers/fundersRouter.ts
+++ b/src/routers/fundersRouter.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import { fundersHandlers } from '../handlers/fundersHandlers';
-import { requireAdministratorRole, requireAuthentication } from '../middleware';
+import { funderCollaborativeMembersHandlers } from '../handlers/funderCollaborativeMembersHandlers';
+import { requireAdministratorRole, requireAuthentication, requireFunderPermission } from '../middleware';
+import { Permission } from '../types';
 
 const fundersRouter = express.Router();
 
@@ -16,6 +18,30 @@ fundersRouter.put(
 	'/:funderShortCode',
 	requireAdministratorRole,
 	fundersHandlers.putFunder,
+);
+
+fundersRouter.get(
+	'/:funderShortCode/members',
+	requireFunderPermission(Permission.MANAGE),
+	funderCollaborativeMembersHandlers.getFunderCollaborativeMembers,
+);
+
+fundersRouter.get(
+	'/:funderShortCode/members/:memberFunderShortCode',
+	requireFunderPermission(Permission.MANAGE),
+	funderCollaborativeMembersHandlers.getFunderCollaborativeMember,
+);
+
+fundersRouter.post(
+	'/:funderShortCode/members/:memberFunderShortCode',
+	requireAdministratorRole,
+	funderCollaborativeMembersHandlers.postFunderCollaborativeMember,
+);
+
+fundersRouter.delete(
+	'/:funderShortCode/members/:memberFunderShortCode',
+	requireAdministratorRole,
+	funderCollaborativeMembersHandlers.deleteFunderCollaborativeMember,
 );
 
 export { fundersRouter };

--- a/src/routers/fundersRouter.ts
+++ b/src/routers/fundersRouter.ts
@@ -1,7 +1,12 @@
 import express from 'express';
 import { fundersHandlers } from '../handlers/fundersHandlers';
 import { funderCollaborativeMembersHandlers } from '../handlers/funderCollaborativeMembersHandlers';
-import { requireAdministratorRole, requireAuthentication, requireFunderPermission } from '../middleware';
+import { funderCollaborativeInvitationsHandlers } from '../handlers/funderCollaborativeInvitationsHandlers';
+import {
+	requireAdministratorRole,
+	requireAuthentication,
+	requireFunderPermission,
+} from '../middleware';
 import { Permission } from '../types';
 
 const fundersRouter = express.Router();
@@ -44,4 +49,27 @@ fundersRouter.delete(
 	funderCollaborativeMembersHandlers.deleteFunderCollaborativeMember,
 );
 
+fundersRouter.post(
+	'/:funderShortCode/invitations/sent/:invitedFunderShortCode',
+	requireFunderPermission(Permission.MANAGE),
+	funderCollaborativeInvitationsHandlers.postFunderCollaborativeInvitation,
+);
+
+fundersRouter.get(
+	'/:funderShortCode/invitations/sent',
+	requireFunderPermission(Permission.MANAGE),
+	funderCollaborativeInvitationsHandlers.getSentFunderCollaborativeInvitations,
+);
+
+fundersRouter.get(
+	'/:funderShortCode/invitations/received',
+	requireFunderPermission(Permission.MANAGE),
+	funderCollaborativeInvitationsHandlers.getRecievedFunderCollaborativeInvitations,
+);
+
+fundersRouter.patch(
+	'/:funderShortCode/invitations/received/:invitedFunderShortCode',
+	requireFunderPermission(Permission.MANAGE),
+	funderCollaborativeInvitationsHandlers.patchFunderCollaborativeInvitation,
+);
 export { fundersRouter };

--- a/src/types/Funder.ts
+++ b/src/types/Funder.ts
@@ -12,6 +12,7 @@ interface Funder {
 	// https://github.com/ajv-validator/ajv/issues/2283 and/or
 	// https://github.com/ajv-validator/ajv/issues/2163.
 	keycloakOrganizationId: KeycloakId | null | undefined;
+	isCollaborative: boolean;
 	readonly createdAt: string;
 }
 
@@ -29,8 +30,11 @@ const writableFunderSchema: JSONSchemaType<WritableFunder> = {
 			...keycloakIdSchema,
 			nullable: true,
 		},
+		isCollaborative: {
+			type: 'boolean',
+		},
 	},
-	required: ['name'],
+	required: ['name', 'isCollaborative'],
 };
 
 const isWritableFunder = ajv.compile(writableFunderSchema);

--- a/src/types/FunderCollaborativeInvitation.ts
+++ b/src/types/FunderCollaborativeInvitation.ts
@@ -1,0 +1,75 @@
+import { ajv } from '../ajv';
+import type { ShortCode } from './ShortCode';
+import type { KeycloakId } from './KeycloakId';
+import type { Writable } from './Writable';
+import type { JSONSchemaType } from 'ajv';
+
+enum FunderCollaborativeInvitationStatus {
+	PENDING = 'pending',
+	ACCEPTED = 'accepted',
+	REJECTED = 'rejected',
+}
+
+interface FunderCollaborativeInvitation {
+	readonly funderCollaborativeShortCode: ShortCode;
+	readonly invitedFunderShortCode: ShortCode;
+	invitationStatus: FunderCollaborativeInvitationStatus;
+	readonly createdBy: KeycloakId;
+	readonly createdAt: string;
+}
+
+type WritableFunderCollaborativeInvitation =
+	Writable<FunderCollaborativeInvitation>;
+
+type InternallyWritableFunderCollaborativeInvitation =
+	WritableFunderCollaborativeInvitation &
+		Pick<
+			FunderCollaborativeInvitation,
+			'funderCollaborativeShortCode' | 'invitedFunderShortCode'
+		>;
+
+type FunderCollaborativeInvitationPost = Omit<
+	WritableFunderCollaborativeInvitation,
+	'invitationStatus'
+>;
+
+type FunderCollaborativeInvitationPatch = WritableFunderCollaborativeInvitation;
+
+const FunderCollaborativeInvitationPostSchema: JSONSchemaType<FunderCollaborativeInvitationPost> =
+	{
+		type: 'object',
+		properties: {},
+	};
+
+const isFunderCollaborativeInvitationPost = ajv.compile(
+	FunderCollaborativeInvitationPostSchema,
+);
+
+const FunderCollaborativeInvitationPatchSchema: JSONSchemaType<FunderCollaborativeInvitationPatch> =
+	{
+		type: 'object',
+		properties: {
+			invitationStatus: {
+				type: 'string',
+				enum: Object.values(FunderCollaborativeInvitationStatus),
+			},
+		},
+		required: ['invitationStatus'],
+	};
+
+const isFunderCollaborativeInvitationPatch = ajv.compile(
+	FunderCollaborativeInvitationPatchSchema,
+);
+
+export {
+	type FunderCollaborativeInvitation,
+	type InternallyWritableFunderCollaborativeInvitation,
+	type FunderCollaborativeInvitationPost,
+	type FunderCollaborativeInvitationPatch,
+	type WritableFunderCollaborativeInvitation,
+	FunderCollaborativeInvitationStatus,
+	FunderCollaborativeInvitationPostSchema,
+	FunderCollaborativeInvitationPatchSchema,
+	isFunderCollaborativeInvitationPost,
+	isFunderCollaborativeInvitationPatch,
+};

--- a/src/types/FunderCollaborativeMember.ts
+++ b/src/types/FunderCollaborativeMember.ts
@@ -1,0 +1,24 @@
+import type { KeycloakId } from './KeycloakId';
+import type { ShortCode } from './ShortCode';
+import type { Writable } from './Writable';
+
+interface FunderCollaborativeMember {
+	readonly funderCollaborativeShortCode: ShortCode;
+	readonly memberFunderShortCode: ShortCode;
+	readonly createdBy: KeycloakId;
+	readonly createdAt: string;
+}
+
+type WritableFunderCollaborativeMember = Writable<FunderCollaborativeMember>;
+
+type InternallyWritableFunderCollaborativeMember =
+	WritableFunderCollaborativeMember &
+		Pick<
+			FunderCollaborativeMember,
+			'funderCollaborativeShortCode' | 'memberFunderShortCode'
+		>;
+
+export {
+	type FunderCollaborativeMember,
+	type InternallyWritableFunderCollaborativeMember,
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export * from './EphemeralUserGroupAssociation';
 export * from './express/AuthenticatedRequest';
 export * from './FiscalSponsorship';
 export * from './Funder';
+export * from './FunderCollaborativeInvitation';
 export * from './FunderCollaborativeMember';
 export * from './Id';
 export * from './JsonObject';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export * from './EphemeralUserGroupAssociation';
 export * from './express/AuthenticatedRequest';
 export * from './FiscalSponsorship';
 export * from './Funder';
+export * from './FunderCollaborativeMember';
 export * from './Id';
 export * from './JsonObject';
 export * from './JsonResultSet';


### PR DESCRIPTION
This PR adds the concept of funder collaboratives to the pdc, as outlined in Issue #1639. The PR is split up into two major commits 

1. fdf7520c4fea759d692924bf3d859e0f20d405fc -> This commit adds in the `funderCollaborativeMembers` entity, which serves as the concrete relationship between a funder and a collaborative, extending the funders permissions onto the collaborative (but not vice versa) . Currently the only way to initialize a new funderCollaborative is for an admin to create one, as a 1-to-1 relationship between a collaborative funder and a non-collaborative funder. It also adds an `isCollaborative`attribute to the funders table, which we decided was the best way to be able to ensure that a collaborative funder can not be a collaborator on another collaborative funder, and that a non-collaborative funder cannot be collaborated on

2. f0b185cacecf18f54daefd36b5616fbae311078e -> This commit adds the `funderCollaborativeInvitations` entity, which supports the intended method of adding collaborators to a collaborative. A funder must have manage permissions on the collaborative in question in order to send an invitation to another funder. A funder that recieves an invitation has the option to either accept or reject an invitation. If they choose to accept, a funderCollaborativeMember entity is created between the invitee and the collaborative funder in question

Closes #1639 