### PR TITLE
Add a Keycloak checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ Alternatively, one may set `LOG_LEVEL` in the `.env` file.
 
 ### Authentication and Authorization
 
-A valid Bearer JSON Web Token (Bearer JWT) is required in requests to the PDC service. The PDC officially recommends using [KeyCloak](https://www.keycloak.org/) as the authentication provider, but supports any valid Bearer JWT provider. Please refer to [the relevant documentation for setup and configuration](https://www.keycloak.org/guides#getting-started)
+A valid Bearer JSON Web Token (Bearer JWT) is required in requests to the PDC service. The PDC officially uses [Keycloak](https://www.keycloak.org/) as the authentication provider and/or IdP broker. Please refer to [the relevant official Keycloak documentation](https://www.keycloak.org/guides#getting-started), the rest of this section, and the [PDC Keycloak checklist](docs/KEYCLOAK_CHECKLIST.md) to configure Keycloak for use by the PDC service. The [permissions document](docs/PERMISSIONS.md) explains distinctions and interactions between Keycloak and PDC with regard to authorization on PDC data.
 
-See `.env.example` for documentation on the necessary environment variables for Keycloak (or chosen authentication provider)
+See `.env.example` for documentation on the necessary environment variables for Keycloak.
 
 #### An example with a Keycloak authentication and Swagger-UI
 

--- a/docs/KEYCLOAK_CHECKLIST.md
+++ b/docs/KEYCLOAK_CHECKLIST.md
@@ -1,0 +1,30 @@
+# Keycloak Checklist
+
+This is intended to be a comprehensive checklist of Keycloak configurations that
+should be present to fully interoperate with the PDC service and external IdPs
+as expected. It is intended to remind, not to detail setup of each item.
+
+- [ ] Required action `.jar` file in `providers` directory (from `auth` project)
+- [ ] SMS 2FA `.jar` file in `providers` directory (from `auth` project)
+- [ ] Theme `.jar` file in `providers` directory (from `auth` project)
+- [ ] A realm matching the PDC service env vars (rest is part of this realm)
+- [ ] Authn Required Actions includes "Update mobile number" enabled
+- [ ] Browser authn flow includes "TOTP or SMS" after passphrase
+- [ ] SMS Authentication step in Browser authn flow has an alias
+- [ ] Custom Login theme enabled (realm Themes)
+- [ ] Use `pdc-` prefix on custom clients to distinguish from built-in clients
+- [ ] `pdc-openapi-docs` client (service API docs use this)
+- [ ] `pdc-admin` group
+- [ ] `pdc-admin` role assigned to `pdc-admin` group
+- [ ] `realm-management` `manage-users` role assigned to `pdc-admin` group
+- [ ] `realm-management` `view-users` role assigned to `pdc-admin` group
+- [ ] `realm-management` `query-users` role assigned to `pdc-admin` group
+- [ ] At least one user assigned to `pdc-admin` group
+- [ ] Organizations enabled
+- [ ] Admin Permissions enabled in realm (aka Fine-grained Admin Permissions)
+- [ ] Email as username enabled (realm Login, assists IdP domain-name matching)
+- [ ] Login with email enabled (realm Login, assists IdP domain-name matching)
+- [ ] Browser authn flow includes organization elements
+- [ ] Broker first login authn flow includes organization elements
+- [ ] `organizations` Client scope with `organizations` mapper (for JWT)
+- [ ] All custom clients have `organizations` client scope assigned as default


### PR DESCRIPTION
The PDC service assumes certain Keycloak configuration. A checklist helps maintain that Keycloak configuration both for production and local development instances. Sometimes there are details that must be (surprisingly) configured, such as "add this custom Client scope to all clients," so this checklist is intended to remind the PDC team of them.