### PR TITLE
Rename `organization:*` to `organizations`

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -72,7 +72,7 @@ PDC interprets this as "Grant the user `9f16a4e6-acfe-4048-82dd-d8a2d14effd0`
 
 Groups of PDC users are managed within Keycloak via the [Keycloak organizations]
 capability. Like Keycloak users, Keycloak organizations are identified by UUID.
-Assuming the (OAuth) Client used to log in requests the `organization:*` scope,
+Assuming the (OAuth) Client used to log in requests the `organizations` scope,
 group membership is shown within a user's JWT in the `organizations` section.
 For the PDC UI and OpenAPI documentation that scope is configured by default.
 
@@ -87,7 +87,7 @@ For example, here is the relevant portion of a decoded JWT:
 ```
 
 Users can see their Keycloak organizations by decoding their JWTs (again,
-assuming the client they used to log in requests the `organization:*` scope), or
+assuming the client they used to log in requests the `organizations` scope), or
 by logging into the account management interface e.g. URL `realms/pdc/account`.
 
 Administrators of the PDC Keycloak realm can see organizations, respective


### PR DESCRIPTION
This change reflects a recent change in PDC Keycloak configuration.

When trying organizations for the first time, there was a workaround to get `organizations` to show in the JWT by using a new Client scope. Afterwards, the colon character (`:`) gained new and special meaning in releases of Keycloak. To maintain `organizations` in the JWT, the name of the Client scope is now `organizations`.

Issue https://github.com/PhilanthropyDataCommons/auth/issues/57
Issue https://github.com/keycloak/keycloak/issues/40670