### PR TITLE
Update the Keycloak checklist

### DIFF
--- a/docs/KEYCLOAK_CHECKLIST.md
+++ b/docs/KEYCLOAK_CHECKLIST.md
@@ -13,6 +13,7 @@ as expected. It is intended to remind, not to detail setup of each item.
 - [ ] SMS Authentication step in Browser authn flow has an alias
 - [ ] SMS Authentication step also has SenderId "Philanthropy Data Commons"
 - [ ] Custom Login theme enabled (realm Themes)
+- [ ] Custom Email theme enabled (realm Themes)
 - [ ] Use `pdc-` prefix on custom clients to distinguish from built-in clients
 - [ ] `pdc-openapi-docs` client (service API docs use this)
 - [ ] `pdc-admin` group

--- a/docs/KEYCLOAK_CHECKLIST.md
+++ b/docs/KEYCLOAK_CHECKLIST.md
@@ -11,6 +11,7 @@ as expected. It is intended to remind, not to detail setup of each item.
 - [ ] Authn Required Actions includes "Update mobile number" enabled
 - [ ] Browser authn flow includes "TOTP or SMS" after passphrase
 - [ ] SMS Authentication step in Browser authn flow has an alias
+- [ ] SMS Authentication step also has SenderId "Philanthropy Data Commons"
 - [ ] Custom Login theme enabled (realm Themes)
 - [ ] Use `pdc-` prefix on custom clients to distinguish from built-in clients
 - [ ] `pdc-openapi-docs` client (service API docs use this)


### PR DESCRIPTION
Send SMS from a more appropriate SenderId
When sending a 2FA SMS OTP, use "Philanthropy Data Commons" instead of
the default "Keycloak" SenderId.

Enable the Email theme in Keycloak
This helps make the email messages more friendly.