### PR TITLE
Add `funder` filter to `GET /proposals`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.20.1 2025-07-10
+
+### Added
+
+- `GET /proposals` now accepts a `funder` querystring filter which returns a subset of proposals based on the funder of the proposal's opportunity.
+
 ## 0.20.0 2025-06-17
 
 ### Changed

--- a/src/database/operations/proposals/loadProposalBundle.ts
+++ b/src/database/operations/proposals/loadProposalBundle.ts
@@ -1,16 +1,18 @@
 import { generateLoadBundleOperation } from '../generators';
-import type { Proposal, KeycloakId } from '../../../types';
+import type { Proposal, KeycloakId, ShortCode } from '../../../types';
 
 const loadProposalBundle = generateLoadBundleOperation<
 	Proposal,
 	[
 		createdBy: KeycloakId | undefined,
 		changemakerId: number | undefined,
+		funderShortCode: ShortCode | undefined,
 		search: string | undefined,
 	]
 >('proposals.selectWithPagination', 'proposals', [
 	'createdBy',
 	'changemakerId',
+	'funderShortCode',
 	'search',
 ]);
 

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -19,6 +19,7 @@ import {
 	extractChangemakerParameters,
 	extractPaginationParameters,
 	extractSearchParameters,
+	extractFunderParameters,
 } from '../queryParameters';
 import { authContextHasFunderPermission } from '../authorization';
 import type { Request, Response } from 'express';
@@ -31,6 +32,7 @@ const getProposals = async (req: Request, res: Response): Promise<void> => {
 	const { offset, limit } = getLimitValues(paginationParameters);
 	const { search } = extractSearchParameters(req);
 	const { changemakerId } = extractChangemakerParameters(req);
+	const { funderShortCode } = extractFunderParameters(req);
 	const { createdBy } = extractCreatedByParameters(req);
 
 	const proposalBundle = await loadProposalBundle(
@@ -38,6 +40,7 @@ const getProposals = async (req: Request, res: Response): Promise<void> => {
 		req,
 		createdBy,
 		changemakerId,
+		funderShortCode,
 		search,
 		limit,
 		offset,

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.19.0",
+		"version": "0.20.1",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"

--- a/src/openapi/components/parameters/funderParam.json
+++ b/src/openapi/components/parameters/funderParam.json
@@ -1,0 +1,9 @@
+{
+	"schema": {
+		"type": "string"
+	},
+	"in": "query",
+	"name": "funder",
+	"required": false,
+	"description": "A reference (shortCode) to an existing funder entity."
+}

--- a/src/openapi/paths/proposals.json
+++ b/src/openapi/paths/proposals.json
@@ -13,6 +13,7 @@
 			{ "$ref": "../components/parameters/countParam.json" },
 			{ "$ref": "../components/parameters/searchParam.json" },
 			{ "$ref": "../components/parameters/changemakerParam.json" },
+			{ "$ref": "../components/parameters/funderParam.json" },
 			{ "$ref": "../components/parameters/createdByParam.json" }
 		],
 		"responses": {

--- a/src/queryParameters/extractFunderParameters.ts
+++ b/src/queryParameters/extractFunderParameters.ts
@@ -1,0 +1,42 @@
+import { ajv } from '../ajv';
+import { InputValidationError } from '../errors';
+import { shortCodeSchema } from '../types';
+import type { JSONSchemaType } from 'ajv';
+import type { Request } from 'express';
+import type { ShortCode } from '../types';
+
+interface FunderParameters {
+	funderShortCode: ShortCode | undefined;
+}
+
+interface FunderParametersQuery {
+	funder: ShortCode | undefined;
+}
+
+const funderParametersQuerySchema: JSONSchemaType<FunderParametersQuery> = {
+	type: 'object',
+	properties: {
+		funder: {
+			...shortCodeSchema,
+			nullable: true,
+		},
+	},
+	required: [],
+};
+
+const isFunderParametersQuery = ajv.compile(funderParametersQuerySchema);
+
+const extractFunderParameters = (request: Request): FunderParameters => {
+	const { query } = request;
+	if (!isFunderParametersQuery(query)) {
+		throw new InputValidationError(
+			'Invalid funder parameters.',
+			isFunderParametersQuery.errors ?? [],
+		);
+	}
+	return {
+		funderShortCode: query.funder,
+	};
+};
+
+export { extractFunderParameters };

--- a/src/queryParameters/index.ts
+++ b/src/queryParameters/index.ts
@@ -1,5 +1,6 @@
 export * from './extractChangemakerParameters';
 export * from './extractCreatedByParameters';
+export * from './extractFunderParameters';
 export * from './extractKeycloakUserIdParameters';
 export * from './extractPaginationParameters';
 export * from './extractProposalParameters';

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -489,6 +489,7 @@ describe('processBulkUploadTask', () => {
 			undefined,
 			undefined,
 			undefined,
+			undefined,
 			NO_LIMIT,
 			NO_OFFSET,
 		);


### PR DESCRIPTION
This PR adds a `funder` filter to the `GET /proposals` endpoint.

Resolves #1747