### PR TITLE
Use an empty request body in OpenAPI doc

### DIFF
--- a/src/openapi/paths/userChangemakerPermission.json
+++ b/src/openapi/paths/userChangemakerPermission.json
@@ -39,6 +39,16 @@
 				}
 			}
 		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/EmptyObject.json"
+					}
+				}
+			}
+		},
 		"responses": {
 			"201": {
 				"description": "The resulting permission.",

--- a/src/openapi/paths/userDataProviderPermission.json
+++ b/src/openapi/paths/userDataProviderPermission.json
@@ -39,6 +39,16 @@
 				}
 			}
 		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/EmptyObject.json"
+					}
+				}
+			}
+		},
 		"responses": {
 			"201": {
 				"description": "The resulting permission.",

--- a/src/openapi/paths/userFunderPermission.json
+++ b/src/openapi/paths/userFunderPermission.json
@@ -39,6 +39,16 @@
 				}
 			}
 		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/EmptyObject.json"
+					}
+				}
+			}
+		},
 		"responses": {
 			"201": {
 				"description": "The resulting permission.",

--- a/src/openapi/paths/userGroupChangemakerPermission.json
+++ b/src/openapi/paths/userGroupChangemakerPermission.json
@@ -39,6 +39,16 @@
 				}
 			}
 		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/EmptyObject.json"
+					}
+				}
+			}
+		},
 		"responses": {
 			"201": {
 				"description": "The resulting permission.",

--- a/src/openapi/paths/userGroupDataProviderPermission.json
+++ b/src/openapi/paths/userGroupDataProviderPermission.json
@@ -39,6 +39,16 @@
 				}
 			}
 		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/EmptyObject.json"
+					}
+				}
+			}
+		},
 		"responses": {
 			"201": {
 				"description": "The resulting permission.",

--- a/src/openapi/paths/userGroupFunderPermission.json
+++ b/src/openapi/paths/userGroupFunderPermission.json
@@ -39,6 +39,16 @@
 				}
 			}
 		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/EmptyObject.json"
+					}
+				}
+			}
+		},
 		"responses": {
 			"201": {
 				"description": "The resulting permission.",


### PR DESCRIPTION
 Use an empty request body in OpenAPI doc

This lets permissions endpoints work from OpenAPI. The endpoints expect an `application/json` request header, and the body that makes sense in that case is an empty JSON object.

Issue #1601 Permissions endpoints require object body