### PR TITLE
Improve test noise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,10 @@ HOST=localhost
 PORT=3001
 
 # Logging to stderr, filtered by log level
-# "fatal" | "error" | "warn" | "info" | "debug" | "trace"
+# "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace"
 # https://github.com/pinojs/pino/blob/main/docs/api.md#level-1
 LOG_LEVEL=info
+TEST_LOG_LEVEL=silent
 
 # Set this when running in production, and unset it otherwise
 # https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -3,10 +3,13 @@ if (process.env.TEST_LOG_LEVEL !== undefined) {
 }
 
 module.exports = {
-	globals: {
-		'ts-jest': {
-			tsconfig: 'tsconfig.dev.json',
-		},
+	transform: {
+		'^.+\\.tsx?$': [
+			'ts-jest',
+			{
+				tsconfig: 'tsconfig.dev.json',
+			},
+		],
 	},
 	collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.*'],
 	preset: 'ts-jest',

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,3 +1,7 @@
+if (process.env.TEST_LOG_LEVEL !== undefined) {
+	process.env.LOG_LEVEL = process.env.TEST_LOG_LEVEL;
+}
+
 module.exports = {
 	globals: {
 		'ts-jest': {

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -3,7 +3,8 @@
 	"compilerOptions": {
 		"noEmit": true,
 		"resolveJsonModule": true,
-		"noUncheckedIndexedAccess": true
+		"noUncheckedIndexedAccess": true,
+		"isolatedModules": true
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
This PR fixes three little things that were making tests a bit noisy:

1. It allows a dev to set a test log level (this is separate from jest's `--silence`)
2. It fixes tsconfig
3. It fixes jest config

There is still one warning that comes from running tests but this is related to a deprecated use of `node:punycode` and resolving that issue requires removing `node-fetch` <-- we should do this, but it will be a separate issue + PR.

Resolves #568
Resolves #1716 