### PR TITLE
Fix opportunity permission api documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The required fields associated with `UserGroupChangemakerPermission`, `UserGroupDataProviderPermission`, and `UserGroupFunderPermission` are now correctly documented.
+- The various opportunity permission endpoints are now correctly documented.
 
 ## 0.21.0 2025-07-16
 

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -269,6 +269,9 @@
 		"/users/{userKeycloakUserId}/dataProviders/{dataProviderShortCode}/permissions/{permission}": {
 			"$ref": "./paths/userDataProviderPermission.json"
 		},
+		"/users/{userKeycloakUserId}/opportunities/{opportunityId}/permissions/{opportunityPermission}": {
+			"$ref": "./paths/userOpportunityPermission.json"
+		},
 		"/userGroups/{keycloakOrganizationId}/changemakers/{changemakerId}/permissions/{permission}": {
 			"$ref": "./paths/userGroupChangemakerPermission.json"
 		},
@@ -277,6 +280,9 @@
 		},
 		"/userGroups/{keycloakOrganizationId}/dataProviders/{dataProviderShortCode}/permissions/{permission}": {
 			"$ref": "./paths/userGroupDataProviderPermission.json"
+		},
+		"/userGroups/{keycloakOrganizationId}/opportunities/{opportunityId}/permissions/{opportunityPermission}": {
+			"$ref": "./paths/userGroupOpportunityPermission.json"
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes our documentation so that opportunity permission endpoints show up in our API documentation

Resolves #1773 