### PR TITLE
Log a warning on missing `PG...` env vars

### DIFF
--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -1,10 +1,20 @@
 import path from 'node:path';
 import { migrate as pgMigrate } from 'postgres-schema-migrations';
+import { requireEnv } from 'require-env-variable';
 import { runJobQueueMigrations } from '../jobQueue';
 import { getLogger } from '../logger';
 import { db } from './db';
 
 const logger = getLogger(__filename);
+
+try {
+	requireEnv('PGUSER', 'PGPASSWORD', 'PGDATABASE', 'PGHOST', 'PGPORT');
+} catch (err) {
+	logger.warn(
+		err,
+		'The pg module usually expects some environment variables starting with "PG".',
+	);
+}
 
 export const migrate = async (schema = 'public'): Promise<void> => {
 	const client = await db.getClient();


### PR DESCRIPTION
Without this change, simply missing some PG environment variables can be difficult to track down. With this change, a warning is logged when one of the usual `PG...` environment variables is missing. These are not directly used by the service but are a convention for underlying libraries, that is why it is a warning and may not be an error.

Issue #1829 When migrations fail, it is hard to tell why

Example output, the first part is the new (see also the case also in #1829 where no clue is at the end):
```shell
./docker-entrypoint.sh | npx pino-pretty
[2025-08-07T16:48:01.137Z] WARN (6730): The pg module usually expects some environment variables starting with "PG".
    source: "PhilanthropyDataCommons/service/dist/database/migrate.js"
    err: {
      "type": "Error",
      "message": "Environment variables missing: [ \"PGUSER\", \"PGHOST\" ]",
      "stack":
          Error: Environment variables missing: [ "PGUSER", "PGHOST" ]
              at Object.<anonymous> (PhilanthropyDataCommons/service/dist/database/migrate.js:15:43)
              at Module._compile (node:internal/modules/cjs/loader:1730:14)
              at Object..js (node:internal/modules/cjs/loader:1895:10)
              at Module.load (node:internal/modules/cjs/loader:1465:32)
              at Function._load (node:internal/modules/cjs/loader:1282:12)
              at TracingChannel.traceSync (node:diagnostics_channel:322:14)
              at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
              at Module.require (node:internal/modules/cjs/loader:1487:12)
              at require (node:internal/modules/helpers:135:16)
              at Object.<anonymous> (PhilanthropyDataCommons/service/dist/database/index.js:18:14)
    }
[2025-08-07T16:48:01.139Z] INFO (6730): Starting migrations...
    source: "PhilanthropyDataCommons/service/dist/scripts/migrate.js"
[2025-08-07T16:48:01.530Z] ERROR (6730): Migrations failed!
    source: "PhilanthropyDataCommons/service/dist/scripts/migrate.js"
[2025-08-07T16:48:01.530Z] ERROR (6730): password authentication failed for user "user"
    source: "PhilanthropyDataCommons/service/dist/scripts/migrate.js"
```