### PR TITLE
Start versioning beyond version zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.0.0 2025-09-11
+
+No API changes but this change signals that 0.23.0 has become version 1.0.0.
+
 ## 0.23.0 2025-08-29
 
 ### Changed

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.23.0",
+		"version": "1.0.0",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"


### PR DESCRIPTION
Until recently, the PDC back-end software has largely been in an experimental or prototype state. At least two parties (besides the team developing the PDC back-end) call it. We also anticipate real data to be sent to the PDC soon. Even if the software remains experimental for a while, the API has matured over the past three-plus years since its first commit. It is time to call it version one.