### PR TITLE
Add `file` type to `BaseFields`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `BaseField` can now be of type `file`.
+
 ## 0.23.0 2025-08-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `BaseField` can now be of type `file`.
 
+### Fixed
+
+- `BaseField` is now properly documented as being allowed to be type `currency`.
+
 ## 0.23.0 2025-08-29
 
 ### Changed

--- a/src/__tests__/fieldValidation.unit.test.ts
+++ b/src/__tests__/fieldValidation.unit.test.ts
@@ -126,4 +126,18 @@ describe('field value validation against BaseFieldDataType', () => {
 			false,
 		);
 	});
+	test('validate a valid file.id as FILE', () => {
+		expect(fieldValueIsValid('123', BaseFieldDataType.FILE)).toBe(true);
+		expect(fieldValueIsValid('1', BaseFieldDataType.FILE)).toBe(true);
+		expect(fieldValueIsValid('9999', BaseFieldDataType.FILE)).toBe(true);
+	});
+	test('validate an invalid file.id as FILE', () => {
+		expect(fieldValueIsValid('0', BaseFieldDataType.FILE)).toBe(false);
+		expect(fieldValueIsValid('-1', BaseFieldDataType.FILE)).toBe(false);
+		expect(fieldValueIsValid('abc', BaseFieldDataType.FILE)).toBe(false);
+		expect(fieldValueIsValid('123.45', BaseFieldDataType.FILE)).toBe(false);
+		expect(fieldValueIsValid('123abc', BaseFieldDataType.FILE)).toBe(false);
+		expect(fieldValueIsValid(' 123 ', BaseFieldDataType.FILE)).toBe(false);
+		expect(fieldValueIsValid('', BaseFieldDataType.FILE)).toBe(false);
+	});
 });

--- a/src/fieldValidation.ts
+++ b/src/fieldValidation.ts
@@ -1,5 +1,5 @@
 import validator from 'validator';
-import { BaseFieldDataType } from './types';
+import { BaseFieldDataType, isId } from './types';
 import { ajv } from './ajv';
 
 const isEmailString = ajv.compile({
@@ -55,6 +55,13 @@ const isCurrencyWithCodeString = (value: string): boolean => {
 	);
 };
 
+const isIdString = (value: string): boolean => {
+	if (value.trim() !== value) {
+		return false;
+	}
+	return isId(value);
+};
+
 export const fieldValueIsValid = (
 	fieldValue: string,
 	dataType: BaseFieldDataType,
@@ -72,6 +79,8 @@ export const fieldValueIsValid = (
 			return isBooleanString(fieldValue);
 		case BaseFieldDataType.CURRENCY:
 			return isCurrencyWithCodeString(fieldValue);
+		case BaseFieldDataType.FILE:
+			return isIdString(fieldValue);
 		default:
 			return isString(fieldValue);
 	}

--- a/src/openapi/components/schemas/BaseField.json
+++ b/src/openapi/components/schemas/BaseField.json
@@ -23,7 +23,15 @@
 		},
 		"dataType": {
 			"type": "string",
-			"enum": ["string", "number", "email", "phone_number", "url", "boolean"],
+			"enum": [
+				"string",
+				"number",
+				"email",
+				"phone_number",
+				"url",
+				"boolean",
+				"file"
+			],
 			"example": "string"
 		},
 		"category": {

--- a/src/openapi/components/schemas/BaseField.json
+++ b/src/openapi/components/schemas/BaseField.json
@@ -30,6 +30,7 @@
 				"phone_number",
 				"url",
 				"boolean",
+				"currency",
 				"file"
 			],
 			"example": "string"

--- a/src/types/BaseField.ts
+++ b/src/types/BaseField.ts
@@ -13,6 +13,7 @@ export enum BaseFieldDataType {
 	URL = 'url',
 	BOOLEAN = 'boolean',
 	CURRENCY = 'currency',
+	FILE = 'file',
 }
 
 enum BaseFieldCategory {


### PR DESCRIPTION
This PR adds support for a `file` type for our base fields.

This implementation declares a file value valid if it is a valid id string (e.g. a whole number greater than 0).

I had originally planned `isValid` to only be true if it *also* referenced a file that the proposal author had created themselves, but that type of check means we're caching permission state in the `isValid` attribute.  In reality, permission checks should be performed at the time of access and according to whatever the current business logic has been defined to entail.

This PR does not yet populate proposal field values with file metadata or accessible file URLs; this will be a larger lift!

Related to #1689 