### PR TITLE
Remove `unprocessed` s3 key validation checks

### DIFF
--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -278,7 +278,7 @@ describe('/tasks/bulkUploads', () => {
 				await createBulkUploadTask(db, testUserAuthContext, {
 					sourceId: systemSource.id,
 					fileName: `bar-${i + 1}.csv`,
-					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+					sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 					status: TaskStatus.COMPLETED,
 					funderShortCode: systemFunder.shortCode,
 				});
@@ -304,8 +304,7 @@ describe('/tasks/bulkUploads', () => {
 								funder: systemFunder,
 								fileName: 'bar-15.csv',
 								fileSize: null,
-								sourceKey:
-									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: TaskStatus.COMPLETED,
 								createdAt: expectTimestamp(),
 								createdBy: testUser.keycloakUserId,
@@ -318,8 +317,7 @@ describe('/tasks/bulkUploads', () => {
 								funder: systemFunder,
 								fileName: 'bar-14.csv',
 								fileSize: null,
-								sourceKey:
-									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: TaskStatus.COMPLETED,
 								createdAt: expectTimestamp(),
 								createdBy: testUser.keycloakUserId,
@@ -332,8 +330,7 @@ describe('/tasks/bulkUploads', () => {
 								funder: systemFunder,
 								fileName: 'bar-13.csv',
 								fileSize: null,
-								sourceKey:
-									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: TaskStatus.COMPLETED,
 								createdAt: expectTimestamp(),
 								createdBy: testUser.keycloakUserId,
@@ -346,8 +343,7 @@ describe('/tasks/bulkUploads', () => {
 								funder: systemFunder,
 								fileName: 'bar-12.csv',
 								fileSize: null,
-								sourceKey:
-									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: TaskStatus.COMPLETED,
 								createdAt: expectTimestamp(),
 								createdBy: testUser.keycloakUserId,
@@ -360,8 +356,7 @@ describe('/tasks/bulkUploads', () => {
 								funder: systemFunder,
 								fileName: 'bar-11.csv',
 								fileSize: null,
-								sourceKey:
-									'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+								sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 								status: TaskStatus.COMPLETED,
 								createdAt: expectTimestamp(),
 								createdBy: testUser.keycloakUserId,
@@ -405,7 +400,7 @@ describe('/tasks/bulkUploads', () => {
 					sourceId: systemSource.id,
 					funderShortCode: systemFunder.shortCode,
 					fileName: 'foo.csv',
-					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+					sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				})
 				.expect(201);
 			const after = await loadTableMetrics('bulk_upload_tasks');
@@ -419,7 +414,7 @@ describe('/tasks/bulkUploads', () => {
 				fileSize: null,
 				funderShortCode: systemFunder.shortCode,
 				funder: systemFunder,
-				sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+				sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				status: 'pending',
 				createdAt: expectTimestamp(),
 				createdBy: testUser.keycloakUserId,
@@ -453,7 +448,7 @@ describe('/tasks/bulkUploads', () => {
 					sourceId: systemSource.id,
 					funderShortCode: systemFunder.shortCode,
 					fileName: 'foo.csv',
-					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+					sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				})
 				.expect(422);
 			const after = await loadTableMetrics('bulk_upload_tasks');
@@ -512,7 +507,7 @@ describe('/tasks/bulkUploads', () => {
 				.send({
 					sourceId: systemSource.id,
 					fileName: 'foo.png',
-					sourceKey: 'unprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+					sourceKey: '96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
 				})
 				.expect(400);
 			expect(result.body).toMatchObject({
@@ -539,7 +534,7 @@ describe('/tasks/bulkUploads', () => {
 				.send({
 					sourceId: systemSource.id,
 					fileName: 'foo.csv',
-					sourceKey: 'notUnprocessed/96ddab90-1931-478d-8c02-a1dc80ae01e5-bar',
+					sourceKey: '96dde01e5-bar',
 				})
 				.expect(400);
 			expect(result.body).toMatchObject({

--- a/src/handlers/bulkUploadTasksHandlers.ts
+++ b/src/handlers/bulkUploadTasksHandlers.ts
@@ -23,7 +23,6 @@ import {
 	extractPaginationParameters,
 } from '../queryParameters';
 import { addProcessBulkUploadJob } from '../jobQueue';
-import { S3_UNPROCESSED_KEY_PREFIX } from '../s3';
 import { authContextHasFunderPermission } from '../authorization';
 import type { Request, Response } from 'express';
 
@@ -47,13 +46,6 @@ const postBulkUploadTask = async (
 	if (!authContextHasFunderPermission(req, funderShortCode, Permission.EDIT)) {
 		throw new UnprocessableEntityError(
 			'You do not have write permissions on a funder with the specified short code.',
-		);
-	}
-
-	if (!sourceKey.startsWith(`${S3_UNPROCESSED_KEY_PREFIX}/`)) {
-		throw new InputValidationError(
-			`sourceKey must be unprocessed, and begin with '${S3_UNPROCESSED_KEY_PREFIX}/'.`,
-			[],
 		);
 	}
 

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -46,5 +46,4 @@ export const generatePresignedPost = async (
 		],
 	});
 
-export const S3_UNPROCESSED_KEY_PREFIX = 'unprocessed';
 export const S3_BULK_UPLOADS_KEY_PREFIX = 'bulk-uploads';

--- a/src/tasks/processBulkUploadTask.ts
+++ b/src/tasks/processBulkUploadTask.ts
@@ -4,11 +4,7 @@ import { finished } from 'node:stream/promises';
 import { parse } from 'csv-parse';
 import { requireEnv } from 'require-env-variable';
 import tmp from 'tmp-promise';
-import {
-	s3Client,
-	S3_BULK_UPLOADS_KEY_PREFIX,
-	S3_UNPROCESSED_KEY_PREFIX,
-} from '../s3';
+import { s3Client, S3_BULK_UPLOADS_KEY_PREFIX } from '../s3';
 import { db } from '../database/db';
 import {
 	createApplicationForm,
@@ -238,10 +234,6 @@ const loadTaskRunnerAuthContext = async (): Promise<AuthContext> => ({
 	},
 });
 
-/* eslint-disable-next-line complexity --
- * This function is, without a doubt, too complex. It's so complex that fixing it requires its own issue:
- * https://github.com/PhilanthropyDataCommons/service/issues/1787
- */
 export const processBulkUploadTask = async (
 	payload: unknown,
 	helpers: JobHelpers,
@@ -265,21 +257,6 @@ export const processBulkUploadTask = async (
 		helpers.logger.warn(
 			'Bulk upload cannot be processed because it is not in a PENDING state',
 			{ bulkUploadTask },
-		);
-		return;
-	}
-	if (!bulkUploadTask.sourceKey.startsWith(S3_UNPROCESSED_KEY_PREFIX)) {
-		helpers.logger.info(
-			`Bulk upload task cannot be processed because the associated sourceKey does not begin with ${S3_UNPROCESSED_KEY_PREFIX}`,
-			{ bulkUploadTask },
-		);
-		await updateBulkUploadTask(
-			db,
-			null,
-			{
-				status: TaskStatus.FAILED,
-			},
-			bulkUploadTask.id,
 		);
 		return;
 	}


### PR DESCRIPTION
This commit removes all references to, and enforcement of, an `unprocessed/` prefix on our s3 keys. Since we no longer force that that be the prefix for our keys, we want to make sure we don't expect it or make any confusing references to it.

Closes #1886 