### PR TITLE
Normalize S3 Buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `BaseField` can now be of type `file`.
+- `S3Bucket` now exists.
 
 ### Fixed
 
 - `BaseField` is now properly documented as being allowed to be type `currency`.
+
+### Changed
+
+- `File` now has an `s3BucketName` attribute as well as an `s3Bucket` attribute, and no longer has a has a `bucketName` or `bucketRegion` attribute.
 
 ## 0.23.0 2025-08-29
 

--- a/src/__tests__/files.int.test.ts
+++ b/src/__tests__/files.int.test.ts
@@ -39,14 +39,13 @@ describe('/files', () => {
 				mimeType: 'application/pdf',
 				size: 1024,
 				storageKey: expectString(),
-				bucketName: expectString(),
-				bucketRegion: expectString(),
+				s3BucketName: process.env.S3_BUCKET,
 				createdBy: expectString(),
 				createdAt: expectTimestamp(),
 			});
 		});
 
-		it('populates bucketName and bucketRegion from environment variables', async () => {
+		it('references an s3_bucket record', async () => {
 			const result = await request(app)
 				.post('/files')
 				.type('application/json')
@@ -59,12 +58,11 @@ describe('/files', () => {
 				.expect(201);
 
 			expect(result.body).toMatchObject({
-				bucketName: process.env.S3_BUCKET,
-				bucketRegion: process.env.S3_REGION,
+				s3BucketName: process.env.S3_BUCKET,
 			});
 		});
 
-		it('ignores user-provided bucketName and bucketRegion values', async () => {
+		it('ignores user-provided s3BucketName values', async () => {
 			const result = await request(app)
 				.post('/files')
 				.type('application/json')
@@ -73,22 +71,15 @@ describe('/files', () => {
 					name: 'malicious-test.pdf',
 					mimeType: 'application/pdf',
 					size: 256,
-					bucketName: 'user-provided-bucket',
-					bucketRegion: 'user-provided-region',
+					s3BucketName: 'some-user-provided-bucket-value',
 				})
 				.expect(201);
 
-			// Should use environment variables, not user-provided values
 			expect(result.body).toMatchObject({
-				bucketName: process.env.S3_BUCKET,
-				bucketRegion: process.env.S3_REGION,
-			});
-			// Ensure each field individually rejects user input
-			expect(result.body).not.toMatchObject({
-				bucketName: 'user-provided-bucket',
+				s3BucketName: process.env.S3_BUCKET,
 			});
 			expect(result.body).not.toMatchObject({
-				bucketRegion: 'user-provided-region',
+				s3BucketName: 'some-user-provided-bucket-value',
 			});
 		});
 

--- a/src/database/initialization/file_to_json.sql
+++ b/src/database/initialization/file_to_json.sql
@@ -4,7 +4,14 @@ CREATE FUNCTION file_to_json(file files)
 RETURNS jsonb AS $$
 DECLARE
   file_json JSONB := NULL::JSONB;
+  s3_bucket_json JSONB := NULL::JSONB;
 BEGIN
+  -- Get the s3_bucket data
+  SELECT s3_bucket_to_json(s3_buckets.*)
+  INTO s3_bucket_json
+  FROM s3_buckets
+  WHERE s3_buckets.name = file.s3_bucket_name;
+
   SELECT jsonb_object_agg(name, value)
   INTO file_json
   FROM (VALUES
@@ -13,8 +20,8 @@ BEGIN
     ('storageKey', to_jsonb(file.storage_key)),
     ('mimeType', to_jsonb(file.mime_type)),
     ('size', to_jsonb(file.size)),
-    ('bucketName', to_jsonb(file.bucket_name)),
-    ('bucketRegion', to_jsonb(file.bucket_region)),
+    ('s3BucketName', to_jsonb(file.s3_bucket_name)),
+    ('s3Bucket', s3_bucket_json),
     ('createdBy', to_jsonb(file.created_by)),
     ('createdAt', to_jsonb(file.created_at))
   ) AS props(name, value)

--- a/src/database/initialization/s3_bucket_to_json.sql
+++ b/src/database/initialization/s3_bucket_to_json.sql
@@ -1,0 +1,15 @@
+SELECT drop_function('s3_bucket_to_json');
+
+CREATE FUNCTION s3_bucket_to_json(s3_bucket s3_buckets)
+RETURNS jsonb AS $$
+BEGIN
+  RETURN jsonb_object_agg(name, value)
+  FROM (VALUES
+    ('name', to_jsonb(s3_bucket.name)),
+    ('region', to_jsonb(s3_bucket.region)),
+    ('endpoint', to_jsonb(s3_bucket.endpoint)),
+    ('createdAt', to_jsonb(s3_bucket.created_at))
+  ) AS props(name, value)
+  WHERE value IS NOT NULL;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -4,8 +4,10 @@ import { requireEnv } from 'require-env-variable';
 import { runJobQueueMigrations } from '../jobQueue';
 import { getLogger } from '../logger';
 import { db } from './db';
+import type { PoolClient } from 'pg';
 
 const logger = getLogger(__filename);
+const { S3_ENDPOINT } = requireEnv('S3_ENDPOINT');
 
 try {
 	requireEnv('PGUSER', 'PGPASSWORD', 'PGDATABASE', 'PGHOST', 'PGPORT');
@@ -16,9 +18,21 @@ try {
 	);
 }
 
+const setPsqlSettingsForMigrations = async (
+	client: PoolClient,
+): Promise<void> => {
+	await client.query('SELECT set_config($1, $2, false)', [
+		'app.s3_endpoint',
+		S3_ENDPOINT,
+	]);
+	logger.info(`Set migration settings: S3_ENDPOINT=${S3_ENDPOINT}`);
+};
+
 export const migrate = async (schema = 'public'): Promise<void> => {
 	const client = await db.getClient();
 	try {
+		await setPsqlSettingsForMigrations(client);
+
 		await pgMigrate({ client }, path.resolve(__dirname, 'migrations'), {
 			logger: (msg) => {
 				logger.info(msg);

--- a/src/database/migrations/0070-normalize-s3-buckets.sql
+++ b/src/database/migrations/0070-normalize-s3-buckets.sql
@@ -1,0 +1,39 @@
+-- Create s3_buckets table
+CREATE TABLE s3_buckets (
+	name text PRIMARY KEY,
+	region text NOT NULL,
+	endpoint text NOT NULL,
+	created_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+SELECT audit_table('s3_buckets');
+
+-- Insert unique bucket combinations from existing files
+-- Using the currently configured S3 endpoint as the endpoint
+INSERT INTO s3_buckets (name, region, endpoint)
+SELECT DISTINCT
+	bucket_name,
+	bucket_region,
+	current_setting('app.s3_endpoint') AS endpoint
+FROM files
+ON CONFLICT (name) DO NOTHING;
+
+-- Add s3_bucket_name column to files table
+ALTER TABLE files
+ADD COLUMN s3_bucket_name text REFERENCES s3_buckets (name);
+
+-- Update files to reference the appropriate s3_bucket
+UPDATE files
+SET s3_bucket_name = s3_buckets.name
+FROM s3_buckets
+WHERE files.bucket_name = s3_buckets.name;
+
+-- Make s3_bucket_name NOT NULL after populating it
+ALTER TABLE files
+ALTER COLUMN s3_bucket_name SET NOT NULL;
+
+-- Remove the old bucket columns from files table
+-- These are now normalized in the s3_buckets table
+ALTER TABLE files
+DROP COLUMN bucket_name,
+DROP COLUMN bucket_region;

--- a/src/database/operations/files/createFile.ts
+++ b/src/database/operations/files/createFile.ts
@@ -5,10 +5,6 @@ const createFile = generateCreateOrUpdateItemOperation<
 	File,
 	InternallyWritableFile,
 	[]
->(
-	'files.insertOne',
-	['name', 'mimeType', 'size', 'bucketName', 'bucketRegion'],
-	[],
-);
+>('files.insertOne', ['name', 'mimeType', 'size', 's3BucketName'], []);
 
 export { createFile };

--- a/src/database/operations/index.ts
+++ b/src/database/operations/index.ts
@@ -19,6 +19,7 @@ export * from './organizations';
 export * from './proposalFieldValues';
 export * from './proposals';
 export * from './proposalVersions';
+export * from './s3Buckets';
 export * from './sources';
 export * from './userChangemakerPermissions';
 export * from './userDataProviderPermissions';

--- a/src/database/operations/s3Buckets/index.ts
+++ b/src/database/operations/s3Buckets/index.ts
@@ -1,0 +1,1 @@
+export * from './loadOrCreateS3Bucket';

--- a/src/database/operations/s3Buckets/loadOrCreateS3Bucket.ts
+++ b/src/database/operations/s3Buckets/loadOrCreateS3Bucket.ts
@@ -1,0 +1,9 @@
+import { generateCreateOrUpdateItemOperation } from '../generators';
+import type { S3Bucket, InternallyWritableS3Bucket } from '../../../types';
+
+const loadOrCreateS3Bucket = generateCreateOrUpdateItemOperation<
+	S3Bucket,
+	InternallyWritableS3Bucket,
+	[]
+>('s3Buckets.selectOrCreateOne', ['name', 'region', 'endpoint'], []);
+export { loadOrCreateS3Bucket };

--- a/src/database/queries/files/insertOne.sql
+++ b/src/database/queries/files/insertOne.sql
@@ -2,16 +2,14 @@ INSERT INTO files (
 	name,
 	mime_type,
 	size,
-	bucket_name,
-	bucket_region,
+	s3_bucket_name,
 	created_by
 )
 VALUES (
 	:name,
 	:mimeType,
 	:size,
-	:bucketName,
-	:bucketRegion,
+	:s3BucketName,
 	:authContextKeycloakUserId
 )
 RETURNING file_to_json(files) AS object;

--- a/src/database/queries/s3Buckets/selectOrCreateOne.sql
+++ b/src/database/queries/s3Buckets/selectOrCreateOne.sql
@@ -1,0 +1,5 @@
+INSERT INTO s3_buckets (name, region, endpoint)
+VALUES (:name, :region, :endpoint)
+ON CONFLICT (name)
+DO UPDATE SET name = s3_buckets.name
+RETURNING s3_bucket_to_json(s3_buckets.*) AS object;

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -146,6 +146,9 @@
 			"File": {
 				"$ref": "./components/schemas/File.json"
 			},
+			"S3Bucket": {
+				"$ref": "./components/schemas/S3Bucket.json"
+			},
 			"ProposalBundle": {
 				"$ref": "./components/schemas/ProposalBundle.json"
 			},

--- a/src/openapi/components/schemas/File.json
+++ b/src/openapi/components/schemas/File.json
@@ -23,15 +23,14 @@
 			"minimum": 0,
 			"example": 1024
 		},
-		"bucketName": {
+		"s3BucketName": {
 			"type": "string",
 			"readOnly": true,
 			"example": "my-s3-bucket"
 		},
-		"bucketRegion": {
-			"type": "string",
-			"readOnly": true,
-			"example": "us-east-1"
+		"s3Bucket": {
+			"$ref": "./S3Bucket.json",
+			"readOnly": true
 		},
 		"createdBy": {
 			"type": "string",
@@ -52,8 +51,8 @@
 		"storageKey",
 		"mimeType",
 		"size",
-		"bucketName",
-		"bucketRegion",
+		"s3BucketName",
+		"s3Bucket",
 		"createdBy",
 		"createdAt"
 	]

--- a/src/openapi/components/schemas/S3Bucket.json
+++ b/src/openapi/components/schemas/S3Bucket.json
@@ -1,0 +1,27 @@
+{
+	"type": "object",
+	"properties": {
+		"name": {
+			"type": "string",
+			"readOnly": true,
+			"example": "my-s3-bucket"
+		},
+		"region": {
+			"type": "string",
+			"readOnly": true,
+			"example": "us-east-1"
+		},
+		"endpoint": {
+			"type": "string",
+			"readOnly": true,
+			"example": "https://s3.us-east-1.amazonaws.com"
+		},
+		"createdAt": {
+			"type": "string",
+			"format": "date-time",
+			"readOnly": true,
+			"example": "2023-10-01T12:00:00.000Z"
+		}
+	},
+	"required": ["name", "region", "endpoint", "createdAt"]
+}

--- a/src/types/File.ts
+++ b/src/types/File.ts
@@ -4,15 +4,17 @@ import type { KeycloakId } from './KeycloakId';
 import type { JSONSchemaType } from 'ajv';
 import type { PresignedPost } from '@aws-sdk/s3-presigned-post';
 import type { Writable } from './Writable';
+import type { Id } from './Id';
+import type { S3Bucket } from './S3Bucket';
 
 interface File {
-	readonly id: number;
+	readonly id: Id;
 	name: string;
 	readonly storageKey: Uuid;
 	mimeType: string;
 	size: number;
-	readonly bucketName: string;
-	readonly bucketRegion: string;
+	readonly s3BucketName: string;
+	readonly s3Bucket: S3Bucket;
 	readonly presignedPost?: PresignedPost;
 	readonly createdBy: KeycloakId;
 	readonly createdAt: string;
@@ -20,8 +22,7 @@ interface File {
 
 type WritableFile = Writable<File>;
 
-type InternallyWritableFile = WritableFile &
-	Pick<File, 'bucketName' | 'bucketRegion'>;
+type InternallyWritableFile = WritableFile & Pick<File, 's3BucketName'>;
 
 const writableFileSchema: JSONSchemaType<WritableFile> = {
 	type: 'object',

--- a/src/types/S3Bucket.ts
+++ b/src/types/S3Bucket.ts
@@ -1,0 +1,12 @@
+import type { Writable } from './Writable';
+
+interface S3Bucket {
+	readonly name: string;
+	readonly region: string;
+	readonly endpoint: string;
+	readonly createdAt: string;
+}
+type InternallyWritableS3Bucket = Writable<S3Bucket> &
+	Pick<S3Bucket, 'name' | 'region' | 'endpoint'>;
+
+export { type S3Bucket, type InternallyWritableS3Bucket };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,7 @@ export * from './ProcessBulkUploadJobPayload';
 export * from './Proposal';
 export * from './ProposalFieldValue';
 export * from './ProposalVersion';
+export * from './S3Bucket';
 export * from './ShortCode';
 export * from './Source';
 export * from './TableMetrics';


### PR DESCRIPTION
This PR normalizes our file-storage-metadata to account for what we learned about S3 endpoint being tightly coupled to a given bucket for DigitalOcean.  We need to know the endpoint associated with a bucket in order to access it properly.

Related to #1901