### PR TITLE
Cache user name on authenticated requests

### DIFF
--- a/src/__tests__/baseFieldsCopyTasks.int.test.ts
+++ b/src/__tests__/baseFieldsCopyTasks.int.test.ts
@@ -46,6 +46,7 @@ describe('/tasks/baseFieldsCopy', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
+				keycloakUserName: 'Henry',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
 

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -108,6 +108,7 @@ describe('/tasks/bulkUploads', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
+				keycloakUserName: 'Joe',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
 			const firstProposal = await createTestFile(db, testUserAuthContext);
@@ -152,6 +153,7 @@ describe('/tasks/bulkUploads', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
+				keycloakUserName: 'Karen',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
 			const firstProposalsFile = await createTestFile(db, testUserAuthContext);
@@ -198,6 +200,7 @@ describe('/tasks/bulkUploads', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
+				keycloakUserName: 'Larry',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
 			const firstProposalsFile = await createTestFile(db, testUserAuthContext);

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -470,6 +470,7 @@ describe('/proposals', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
+				keycloakUserName: 'Dave',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
 			const systemFunder = await loadSystemFunder(db, null);
@@ -521,6 +522,7 @@ describe('/proposals', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
+				keycloakUserName: 'Erin',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
 			const systemFunder = await loadSystemFunder(db, null);
@@ -565,6 +567,7 @@ describe('/proposals', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
+				keycloakUserName: 'Fulton',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
 			const systemFunder = await loadSystemFunder(db, null);
@@ -836,6 +839,7 @@ describe('/proposals', () => {
 			const testUser = await loadTestUser();
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
+				keycloakUserName: 'Georgina',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
 			const systemFunder = await loadSystemFunder(db, null);

--- a/src/__tests__/users.int.test.ts
+++ b/src/__tests__/users.int.test.ts
@@ -32,6 +32,7 @@ import {
 const createAdditionalTestUser = async () =>
 	await createOrUpdateUser(db, null, {
 		keycloakUserId: stringToKeycloakId('123e4567-e89b-12d3-a456-426614174000'),
+		keycloakUserName: 'Call me Ishmael',
 	});
 
 describe('/users', () => {
@@ -53,7 +54,7 @@ describe('/users', () => {
 				total: userCount,
 				entries: [
 					{
-						keycloakUserId: testUser.keycloakUserId,
+						...testUser,
 						permissions: {
 							changemaker: {},
 							dataProvider: {},
@@ -124,7 +125,7 @@ describe('/users', () => {
 				total: userCount,
 				entries: [
 					{
-						keycloakUserId: testUser.keycloakUserId,
+						...testUser,
 						permissions: {
 							changemaker: {
 								[changemaker.id]: [Permission.VIEW],
@@ -176,7 +177,7 @@ describe('/users', () => {
 				total: userCount,
 				entries: [
 					{
-						keycloakUserId: testUser.keycloakUserId,
+						...testUser,
 						permissions: {
 							changemaker: {},
 							dataProvider: {},
@@ -234,6 +235,7 @@ describe('/users', () => {
 				await p;
 				await createOrUpdateUser(db, null, {
 					keycloakUserId: uuid,
+					keycloakUserName: 'Alice',
 				});
 			}, Promise.resolve());
 			const { count: userCount } = await loadTableMetrics('users');
@@ -251,6 +253,7 @@ describe('/users', () => {
 				entries: [
 					{
 						keycloakUserId: uuids[14],
+						keycloakUserName: 'Alice',
 						permissions: {
 							changemaker: {},
 							dataProvider: {},
@@ -261,6 +264,7 @@ describe('/users', () => {
 					},
 					{
 						keycloakUserId: uuids[13],
+						keycloakUserName: 'Alice',
 						permissions: {
 							changemaker: {},
 							dataProvider: {},
@@ -271,6 +275,7 @@ describe('/users', () => {
 					},
 					{
 						keycloakUserId: uuids[12],
+						keycloakUserName: 'Alice',
 						permissions: {
 							changemaker: {},
 							dataProvider: {},
@@ -281,6 +286,7 @@ describe('/users', () => {
 					},
 					{
 						keycloakUserId: uuids[11],
+						keycloakUserName: 'Alice',
 						permissions: {
 							changemaker: {},
 							dataProvider: {},
@@ -291,6 +297,7 @@ describe('/users', () => {
 					},
 					{
 						keycloakUserId: uuids[10],
+						keycloakUserName: 'Alice',
 						permissions: {
 							changemaker: {},
 							dataProvider: {},

--- a/src/database/initialization/user_to_json.sql
+++ b/src/database/initialization/user_to_json.sql
@@ -153,6 +153,7 @@ BEGIN
 
   RETURN jsonb_build_object(
     'keycloakUserId', "user".keycloak_user_id,
+    'keycloakUserName', "user".keycloak_user_name,
     'permissions', permissions_json,
     'createdAt', "user".created_at
   );

--- a/src/database/migrations/0072-alter-users.sql
+++ b/src/database/migrations/0072-alter-users.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users ADD COLUMN keycloak_user_name varchar NOT NULL
+DEFAULT 'User who has not recently logged in';
+ALTER TABLE users ALTER COLUMN keycloak_user_name DROP DEFAULT;

--- a/src/database/operations/users/__tests__/loadUserByKeycloakUserId.int.test.ts
+++ b/src/database/operations/users/__tests__/loadUserByKeycloakUserId.int.test.ts
@@ -35,6 +35,7 @@ describe('loadUserByKeycloakUserId', () => {
 		const ephemeralExpiration = new Date(Date.now() + 3600000).toISOString();
 		const user = await createOrUpdateUser(db, null, {
 			keycloakUserId: '42db47e1-0612-4a41-9092-7928491b1fad',
+			keycloakUserName: 'Bob',
 		});
 		const changemakerKeycloakOrganizationId =
 			'b10aaea1-4558-422b-85bf-073bfc9cd05f';
@@ -216,8 +217,8 @@ describe('loadUserByKeycloakUserId', () => {
 		);
 
 		expect(populatedUser).toEqual({
+			...user,
 			createdAt: expectTimestamp(),
-			keycloakUserId: user.keycloakUserId,
 			permissions: {
 				changemaker: {
 					1: expectArrayContaining([
@@ -257,6 +258,7 @@ describe('loadUserByKeycloakUserId', () => {
 		const systemUserAuthContext = getAuthContext(systemUser);
 		const user = await createOrUpdateUser(db, null, {
 			keycloakUserId: '42db47e1-0612-4a41-9092-7928491b1fad',
+			keycloakUserName: 'Carol',
 		});
 
 		// Associate the user with a changemaker group
@@ -343,8 +345,8 @@ describe('loadUserByKeycloakUserId', () => {
 		);
 
 		expect(populatedUser).toEqual({
+			...user,
 			createdAt: expectTimestamp(),
-			keycloakUserId: user.keycloakUserId,
 			permissions: {
 				changemaker: {},
 				dataProvider: {},

--- a/src/database/operations/users/createOrUpdateUser.ts
+++ b/src/database/operations/users/createOrUpdateUser.ts
@@ -5,6 +5,6 @@ const createOrUpdateUser = generateCreateOrUpdateItemOperation<
 	User,
 	WritableUser,
 	[]
->('users.insertOrUpdateOne', ['keycloakUserId'], []);
+>('users.insertOrUpdateOne', ['keycloakUserId', 'keycloakUserName'], []);
 
 export { createOrUpdateUser };

--- a/src/database/queries/users/insertOrUpdateOne.sql
+++ b/src/database/queries/users/insertOrUpdateOne.sql
@@ -1,11 +1,14 @@
 INSERT INTO users (
-	keycloak_user_id
+	keycloak_user_id,
+	keycloak_user_name
 )
 VALUES (
-	:keycloakUserId
+	:keycloakUserId,
+	:keycloakUserName
 )
 ON CONFLICT (keycloak_user_id)
 DO UPDATE
 	SET
-		keycloak_user_id = excluded.keycloak_user_id
+		keycloak_user_id = excluded.keycloak_user_id,
+		keycloak_user_name = excluded.keycloak_user_name
 RETURNING user_to_json(users) AS object;

--- a/src/middleware/__tests__/addUserContext.int.test.ts
+++ b/src/middleware/__tests__/addUserContext.int.test.ts
@@ -42,6 +42,7 @@ describe('addUserContext', () => {
 		const res = getMockResponse();
 		req.auth = {
 			sub: '123e4567-e89b-12d3-a456-426614174000',
+			name: 'Olivia',
 		};
 
 		loadTableMetrics('users')
@@ -68,6 +69,7 @@ describe('addUserContext', () => {
 
 	it('creates ephemeral user group associations when organizations are provided', (done) => {
 		const mockSub = '123e4567-e89b-12d3-a456-426614174000';
+		const mockName = 'Provolone';
 		const mockAuthExp = Math.round(new Date().getTime() / 1000) + 3600;
 		const expectedNotAfter = new Date(mockAuthExp * 1000).toISOString();
 		const myOrganizationId = '47d406ad-5e50-42d4-88f1-f87947a3e314';
@@ -76,6 +78,7 @@ describe('addUserContext', () => {
 		const res = getMockResponse();
 		req.auth = {
 			sub: mockSub,
+			name: mockName,
 			exp: mockAuthExp,
 			organizations: {
 				myOrganization: { id: myOrganizationId },
@@ -139,6 +142,7 @@ describe('addUserContext', () => {
 		const res = getMockResponse();
 		req.auth = {
 			sub: 'this is not a UUID',
+			name: 'Qualita',
 		};
 
 		loadTableMetrics('users')
@@ -168,7 +172,9 @@ describe('addUserContext', () => {
 	it('does not create or assign a user when no keycloakUserId is provided', (done) => {
 		const req = getMockRequest() as AuthenticatedRequest;
 		const res = getMockResponse();
-		req.auth = {};
+		req.auth = {
+			name: 'Robert',
+		};
 
 		loadTableMetrics('users')
 			.then(({ count: baselineUserCount }) => {

--- a/src/middleware/__tests__/addUserContext.unit.test.ts
+++ b/src/middleware/__tests__/addUserContext.unit.test.ts
@@ -1,0 +1,27 @@
+import { InputValidationError } from '../../errors';
+import { getMockRequest, getMockResponse } from '../../test/mockExpress';
+import { addUserContext } from '../addUserContext';
+import type { AuthenticatedRequest } from '../../types';
+
+jest.mock('../../config', () => ({
+	getSystemUser: () => ({
+		sub: '00000000-0000-0000-0000-000000000000',
+		name: 'Unknown',
+	}),
+}));
+describe('addUserContext (unit)', () => {
+	it('calls next with an InputValidationError when no `name` is in the JWT', () => {
+		const req = getMockRequest() as AuthenticatedRequest;
+		const res = getMockResponse();
+		const mockAuthExp = Math.round(new Date().getTime() / 1000) + 3600;
+		req.auth = {
+			sub: '45131d6f-3ec3-4953-bd71-9e61b31e842a',
+			exp: mockAuthExp,
+		};
+		let argToNext: unknown = null;
+		addUserContext(req, res, (err: unknown) => {
+			argToNext = err;
+		});
+		expect(argToNext).toBeInstanceOf(InputValidationError);
+	});
+});

--- a/src/middleware/__tests__/requireAdministratorRole.int.test.ts
+++ b/src/middleware/__tests__/requireAdministratorRole.int.test.ts
@@ -1,11 +1,15 @@
 import { requireAdministratorRole } from '../requireAdministratorRole';
 import { UnauthorizedError } from '../../errors';
-import { getTestUserKeycloakUserId } from '../../test/utils';
+import {
+	getTestUserKeycloakUserId,
+	getTestUserKeycloakUserName,
+} from '../../test/utils';
 import { getMockRequest, getMockResponse } from '../../test/mockExpress';
 import type { AuthenticatedRequest, User } from '../../types';
 
 const getMockedUser = (): User => ({
 	keycloakUserId: getTestUserKeycloakUserId(),
+	keycloakUserName: getTestUserKeycloakUserName(),
 	createdAt: '',
 	permissions: {
 		changemaker: {},

--- a/src/middleware/__tests__/requireAuthentication.int.test.ts
+++ b/src/middleware/__tests__/requireAuthentication.int.test.ts
@@ -71,6 +71,7 @@ describe('requireAuthentication', () => {
 		const res = getMockResponse();
 		req.auth = {
 			sub: 'test@example.com',
+			name: 'Norbert',
 		};
 		const nextMock = jest.fn();
 		requireAuthentication(req, res, nextMock);
@@ -87,11 +88,12 @@ describe('requireAuthentication', () => {
 		/* eslint-enable @typescript-eslint/no-unsafe-member-access */
 	});
 
-	it('calls next when when an auth value is provided', async () => {
+	it('calls next when an auth value is provided', async () => {
 		const req = getMockRequest() as AuthenticatedRequest;
 		const res = getMockResponse();
 		req.auth = {
-			sub: 'test@example.com',
+			sub: 'test2@example.com',
+			name: 'Peter',
 		};
 		req.role = {
 			isAdministrator: false,

--- a/src/middleware/__tests__/requireAuthentication.unit.test.ts
+++ b/src/middleware/__tests__/requireAuthentication.unit.test.ts
@@ -1,0 +1,23 @@
+import { getMockRequest, getMockResponse } from '../../test/mockExpress';
+import { requireAuthentication } from '../requireAuthentication';
+import { UnauthorizedError } from '../../errors';
+import type { Request as JwtRequest } from 'express-jwt';
+
+describe('requireAuthentication (unit)', () => {
+	it('calls next with an UnauthorizedError when no `name` is in the JWT', () => {
+		// Because `requireAuthentication` is used to verify that `auth` exists, it
+		// would not make sense to make `req` an `AuthenticatedRequest` here.
+		const req = getMockRequest() as JwtRequest;
+		const res = getMockResponse();
+		const mockAuthExp = Math.round(new Date().getTime() / 1000) + 3600;
+		req.auth = {
+			sub: '3cbe4293-3dcc-463f-8749-488e189aae5a',
+			exp: mockAuthExp,
+		};
+		let argToNext: unknown = null;
+		requireAuthentication(req, res, (err: unknown) => {
+			argToNext = err;
+		});
+		expect(argToNext).toBeInstanceOf(UnauthorizedError);
+	});
+});

--- a/src/middleware/requireAuthentication.ts
+++ b/src/middleware/requireAuthentication.ts
@@ -1,5 +1,9 @@
 import { UnauthorizedError } from '../errors';
-import { hasMeaningfulAuthSub, isAuthContext } from '../types';
+import {
+	hasMeaningfulAuthName,
+	hasMeaningfulAuthSub,
+	isAuthContext,
+} from '../types';
 import type { Request, Response, NextFunction } from 'express';
 
 const requireAuthentication = (
@@ -15,6 +19,14 @@ const requireAuthentication = (
 		next(
 			new UnauthorizedError(
 				'The authentication token must have a non-empty value for `auth.sub`.',
+			),
+		);
+		return;
+	}
+	if (!hasMeaningfulAuthName(req)) {
+		next(
+			new UnauthorizedError(
+				'The authentication token must have a non-empty value for `auth.name`.',
 			),
 		);
 		return;

--- a/src/openapi/components/schemas/User.json
+++ b/src/openapi/components/schemas/User.json
@@ -5,6 +5,11 @@
 			"type": "string",
 			"example": "550e8400-e29b-41d4-a716-446655440000"
 		},
+		"keycloakUserName": {
+			"type": "string",
+			"description": "The full name of the user (described in OIDC 1.0 'name' standard claim) as of most recent logged-in service activity.",
+			"example": "John Doe"
+		},
 		"permissions": {
 			"type": "object",
 			"readOnly": true,

--- a/src/test/mockJwt.ts
+++ b/src/test/mockJwt.ts
@@ -2,7 +2,10 @@ import createJWKSMock from 'mock-jwks';
 import { issuer } from '../auth/jwtOptions';
 import { nonNullKeycloakIdToString } from '../types';
 import { MS_PER_SECOND } from '../constants';
-import { getTestUserKeycloakUserId } from './utils';
+import {
+	getTestUserKeycloakUserId,
+	getTestUserKeycloakUserName,
+} from './utils';
 import type { JWKSMock } from 'mock-jwks';
 import type { JwtPayload } from 'jsonwebtoken';
 
@@ -39,6 +42,7 @@ const getMockJwt = (
 		realm_access: {
 			roles: settings.roles ?? ['default-roles-pdc'],
 		},
+		name: getTestUserKeycloakUserName(),
 	});
 	return { Authorization: `Bearer ${token}` };
 };

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -28,9 +28,12 @@ export const generateNextWithAssertions = (
 export const getTestUserKeycloakUserId = (): KeycloakId =>
 	stringToKeycloakId('11111111-1111-1111-1111-111111111111'); // This value is not a reference, it's just a static GUID
 
+export const getTestUserKeycloakUserName = (): string => 'Moe';
+
 export const createTestUser = async (): Promise<User> =>
 	await createOrUpdateUser(db, null, {
 		keycloakUserId: getTestUserKeycloakUserId(),
+		keycloakUserName: getTestUserKeycloakUserName(),
 	});
 
 export const loadTestUser = async (): Promise<User> =>

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -9,6 +9,7 @@ import type { OpportunityPermission } from './OpportunityPermission';
 
 interface User {
 	keycloakUserId: KeycloakId;
+	keycloakUserName: string;
 	readonly permissions: {
 		changemaker: Record<string, Permission[]>;
 		dataProvider: Record<string, Permission[]>;
@@ -22,6 +23,9 @@ const userSchema: JSONSchemaType<User> = {
 	type: 'object',
 	properties: {
 		keycloakUserId: keycloakIdSchema,
+		keycloakUserName: {
+			type: 'string',
+		},
 		permissions: {
 			type: 'object',
 			properties: {
@@ -64,7 +68,7 @@ const userSchema: JSONSchemaType<User> = {
 			type: 'string',
 		},
 	},
-	required: ['keycloakUserId', 'permissions', 'createdAt'],
+	required: ['keycloakUserId', 'keycloakUserName', 'permissions', 'createdAt'],
 };
 
 type WritableUser = Writable<User>;

--- a/src/types/express/AuthenticatedRequest.ts
+++ b/src/types/express/AuthenticatedRequest.ts
@@ -14,6 +14,12 @@ interface ObjectWithAuthWithSub {
 	};
 }
 
+interface ObjectWithAuthWithName {
+	auth: {
+		name: string;
+	};
+}
+
 interface ObjectWithAuthWithExp {
 	auth: {
 		exp: number;
@@ -45,6 +51,22 @@ const objectWithAuthWithSubSchema: JSONSchemaType<ObjectWithAuthWithSub> = {
 				},
 			},
 			required: ['sub'],
+		},
+	},
+	required: ['auth'],
+};
+
+const objectWithAuthWithNameSchema: JSONSchemaType<ObjectWithAuthWithName> = {
+	type: 'object',
+	properties: {
+		auth: {
+			type: 'object',
+			properties: {
+				name: {
+					type: 'string',
+				},
+			},
+			required: ['name'],
 		},
 	},
 	required: ['auth'],
@@ -117,6 +139,8 @@ const objectWithAuthWithOrganizationsSchema: JSONSchemaType<ObjectWithAuthWithOr
 
 const hasAuthWithSub = ajv.compile(objectWithAuthWithSubSchema);
 
+const hasAuthWithName = ajv.compile(objectWithAuthWithNameSchema);
+
 const isObjectWithAuthWithExp = ajv.compile(objectWithAuthWithExpSchema);
 
 const hasAuthWithRealmAccessRoles = ajv.compile(
@@ -129,6 +153,9 @@ const isObjectWithAuthWithOrganizations = ajv.compile(
 
 const getAuthSubFromRequest = (req: Request): string | undefined =>
 	hasAuthWithSub(req) ? req.auth.sub : undefined;
+
+const getAuthNameFromRequest = (req: Request): string | undefined =>
+	hasAuthWithName(req) ? req.auth.name : undefined;
 
 const getRealmAccessRolesFromRequest = (req: Request): string[] =>
 	hasAuthWithRealmAccessRoles(req) ? req.auth.realm_access.roles : [];
@@ -148,11 +175,18 @@ const hasMeaningfulAuthSub = (req: Request): boolean => {
 	return authSub !== undefined && authSub !== '';
 };
 
+const hasMeaningfulAuthName = (req: Request): boolean => {
+	const authName = getAuthNameFromRequest(req);
+	return authName !== undefined && authName !== '';
+};
+
 export {
 	type AuthenticatedRequest,
+	getAuthNameFromRequest,
 	getAuthSubFromRequest,
 	getRealmAccessRolesFromRequest,
 	getKeycloakOrganizationIdsFromRequest,
 	getJwtExpFromRequest,
 	hasMeaningfulAuthSub,
+	hasMeaningfulAuthName,
 };


### PR DESCRIPTION
This change allows the `/users` endpoint to return the name from a user's most recent JWT. Whenever a user authenticates, the table is updated with the `name` value from the JWT. The existing audit tables track updates to names.

Issue #1904 Cache user metadata