### PR TITLE
Include a name in `compose-ci.yml` service account

### DIFF
--- a/compose-ci.yml
+++ b/compose-ci.yml
@@ -282,6 +282,8 @@ services:
             ./kcadm.sh get \
             realms/pdc/clients/$(cat dev_client_id)/service-account-user \
             --fields id --format csv --noquotes > dev_service_account_id
+            ./kcadm.sh update -r pdc users/$(cat dev_service_account_id) \
+            -s attributes='{"firstName": "Development Admin", "lastName": "Service Account"}'
             ./kcadm.sh update -r pdc \
             users/$(cat dev_service_account_id)/groups/$(cat admin_group_id) \
             -s realm=pdc -s userId=$(cat dev_service_account_id) \


### PR DESCRIPTION
In a previous commit (namely https://github.com/PhilanthropyDataCommons/service/commit/9ab1468ea618a50d2ad84968688d9ac28536da4f) we started to cache the `name` from the JWT in the PDC service. When service accounts do not have names, they get an error. Therefore, add names to service accounts. Human users are already required by Keycloak to set a name.

Fixes #1938