### PR TITLE
Add pagination parameters

### DIFF
--- a/src/openapi/paths/applicationForms.json
+++ b/src/openapi/paths/applicationForms.json
@@ -1,6 +1,10 @@
 {
 	"get": {
 		"operationId": "getApplicationForms",
+		"parameters": [
+			{ "$ref": "../components/parameters/pageParam.json" },
+			{ "$ref": "../components/parameters/countParam.json" }
+		],
 		"summary": "Gets a list of application forms.",
 		"tags": ["Application Forms"],
 		"security": [


### PR DESCRIPTION
Added page and count parameters to applicationForms OpenAPI spec.

Issue #1864 Add pagination parameters to OpenAPI where missing

Thanks to codename `goose` 1.5.0, `ollama` 0.11.5, and the LLMs `devstral:24b-small-2505-q4_K_M` and `hf.co/unsloth/Qwen3-8B-GGUF:UD-Q4_K_XL` for the previous commit from my prompting (and at times for `devstral`, my urging). I recommend `qwen3` over `devstral` in this setup because `qwen3` is better at tool calling.

I did not ask `devstral`  or `qwen3` to look for other instances where the change is needed, rather this was an experiment to see if a locally-running LLM could actually make a change, do the commit, and so forth. It can.

I made a separate `llm` user, cloned the repository to that user's home directory, created a branch on behalf of the user, then used codename `goose` to call `devstral` and (later) `qwen3` via `ollama`. Both `goose` and `ollama` run under the `llm` user. Back in my own clone of the repo, I added a remote to the LLMs' clone of the repo. I fetched the branch, added this commit, and pushed to GH. For now, I don't feel comfortable asking codename `goose` and the LLMs to run network-ish commands such as `git push`, `git pull`, so I'll do those. I did end up giving `goose` and the LLMs `nvm` access so that they could run `npm lint` and so forth.
