### PR TITLE
Use the official node docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM bitnami/node:22-debian-12
+FROM docker.io/node:22-bookworm-slim
 
-RUN adduser --home /opt/philanthropy-data-commons --uid 902 \
+RUN apt-get update && apt-get install -y curl
+RUN adduser --home /opt/philanthropy-data-commons --uid 1002 \
     --disabled-login web
 
 USER web

--- a/compose-ci.yml
+++ b/compose-ci.yml
@@ -104,8 +104,8 @@ services:
         condition: service_completed_successfully
   pdc-api:
     image: ghcr.io/philanthropydatacommons/service:latest
-    # The image contains user 902
-    user: 902:902
+    # The image contains user 1002
+    user: 1002:1002
     ports:
       - '3030:3030'
     environment:


### PR DESCRIPTION
Bitnami is not going to support all the images they used to anymore. See https://github.com/bitnami/charts/issues/35164

The plain (Debian) bookworm image was 1.5GiB (very big) and the slim version of the same image didn't come with `curl` which we use in the `compose-ci.yml` file to run some scripts. So install `curl` in the slim image. Also, due to warnings about UIDs under 1000, update the user ID to 1002 instead of 902.

Issue #1947 Update docker image