### PR TITLE
Reduce unnecessary polling in graphile workers

### DIFF
--- a/src/constants/time.ts
+++ b/src/constants/time.ts
@@ -1,4 +1,5 @@
 export const MS_PER_SECOND = 1000;
 export const SECONDS_PER_HOUR = 3600;
+export const TEN_MINUTES_IN_MS = 600_000;
 export const ISO_TIMESTAMP_PATTERN =
 	/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?(Z|(\+|-)\d{2}:\d{2})$/;


### PR DESCRIPTION
A test of once per five minutes did not prevent a bulk upload from
being processed nearly immediately.

Issue #1266 Graphile-worker runs UPDATE statements very frequently