### PR TITLE
Fix `file` type for base_fields in our schema

### DIFF
--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -186,6 +186,37 @@ describe('/baseFields', () => {
 			expect(after.count).toEqual(1);
 		});
 
+		it('supports creation of file-type base fields', async () => {
+			const before = await loadTableMetrics('base_fields');
+			const result = await request(app)
+				.put('/baseFields/shorts')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					label: '🏷️',
+					description: '😍',
+					dataType: BaseFieldDataType.FILE,
+					category: BaseFieldCategory.PROJECT,
+					valueRelevanceHours: null,
+					sensitivityClassification: BaseFieldSensitivityClassification.PUBLIC,
+				})
+				.expect(200);
+			const after = await loadTableMetrics('base_fields');
+			expect(before.count).toEqual(0);
+			expect(result.body).toMatchObject({
+				label: '🏷️',
+				description: '😍',
+				shortCode: 'shorts',
+				dataType: BaseFieldDataType.FILE,
+				category: BaseFieldCategory.PROJECT,
+				valueRelevanceHours: null,
+				sensitivityClassification: BaseFieldSensitivityClassification.PUBLIC,
+				localizations: {},
+				createdAt: expectTimestamp(),
+			});
+			expect(after.count).toEqual(1);
+		});
+
 		it('returns 400 bad request when no label is sent', async () => {
 			const result = await request(app)
 				.put('/baseFields/shorts')

--- a/src/database/migrations/0073-alter-base_fields-add-file.sql
+++ b/src/database/migrations/0073-alter-base_fields-add-file.sql
@@ -1,0 +1,15 @@
+CREATE TYPE updated_field_type AS ENUM (
+	'string',
+	'number',
+	'phone_number',
+	'email',
+	'url',
+	'boolean',
+	'currency',
+	'file'
+);
+ALTER TABLE base_fields
+ALTER COLUMN data_type TYPE updated_field_type USING
+data_type::text::updated_field_type;
+DROP TYPE field_type CASCADE;
+ALTER TYPE updated_field_type RENAME TO field_type;


### PR DESCRIPTION
This PR fixes a mistake that made it so that base fields could not ACTUALLY have a `file` type.

Resolves #1996