### PR TITLE
Fix `createBulkUploadLog` export

### DIFF
--- a/src/database/operations/index.ts
+++ b/src/database/operations/index.ts
@@ -3,6 +3,7 @@ export * from './applicationForms';
 export * from './baseFieldLocalization';
 export * from './baseFields';
 export * from './baseFieldsCopyTasks';
+export * from './bulkUploadLogs';
 export * from './bulkUploadTasks';
 export * from './changemakerProposals';
 export * from './changemakers';

--- a/src/tasks/processBulkUploadTask.ts
+++ b/src/tasks/processBulkUploadTask.ts
@@ -8,6 +8,7 @@ import { db } from '../database/db';
 import {
 	createApplicationForm,
 	createApplicationFormField,
+	createBulkUploadLog,
 	createOpportunity,
 	createChangemaker,
 	createChangemakerProposal,
@@ -25,7 +26,6 @@ import { TaskStatus, isProcessBulkUploadJobPayload } from '../types';
 import { fieldValueIsValid } from '../fieldValidation';
 import { allNoLeaks } from '../promises';
 import { SINGLE_STEP } from '../constants';
-import { createBulkUploadLog } from '../database/operations/bulkUploadLogs/createBulkUploadLog';
 import { getBulkUploadLogDetailsFromError } from './getBulkUploadLogDetailsFromError';
 import type TinyPg from 'tinypg';
 import type { JobHelpers, Logger } from 'graphile-worker';


### PR DESCRIPTION
This PR export `bulkUploadLogs` operations to mirror the other operation exports (and allow for less verbose import)