### PR TITLE
Expand `pdc-admin` group Keycloak roles

### DIFF
--- a/docs/KEYCLOAK_CHECKLIST.md
+++ b/docs/KEYCLOAK_CHECKLIST.md
@@ -18,9 +18,19 @@ as expected. It is intended to remind, not to detail setup of each item.
 - [ ] `pdc-openapi-docs` client (service API docs use this)
 - [ ] `pdc-admin` group
 - [ ] `pdc-admin` role assigned to `pdc-admin` group
-- [ ] `realm-management` `manage-users` role assigned to `pdc-admin` group
-- [ ] `realm-management` `view-users` role assigned to `pdc-admin` group
-- [ ] `realm-management` `query-users` role assigned to `pdc-admin` group
+- [ ] The following (Client) roles assigned to the `pdc-admin` group:
+  - [ ] `realm-management` `manage-users`
+  - [ ] `realm-management` `view-users`
+  - [ ] `realm-management` `query-users`
+  - [ ] `realm-management` `query-groups`
+  - [ ] `realm-management` `view-clients`
+  - [ ] `realm-management` `create-client`
+  - [ ] `realm-management` `manage-clients`
+  - [ ] `realm-management` `query-clients`
+  - [ ] `realm-management` `view-identity-providers`
+  - [ ] `realm-management` `manage-identity-providers`
+  - [ ] `realm-management` `view-realm`
+  - [ ] `realm-management` `view-events`
 - [ ] At least one user assigned to `pdc-admin` group
 - [ ] Organizations enabled
 - [ ] Admin Permissions enabled in realm (aka Fine-grained Admin Permissions)


### PR DESCRIPTION
In order to have a consistent PDC visual theme, administrators need to have greater access within the PDC realm. These updated roles are closer to what is needed to allow full organization onboarding from the PDC Keycloak realm (rather than the Keycloak Keycloak realm).

Issue https://github.com/PhilanthropyDataCommons/auth/issues/75