### PR TITLE
Bump API version from 0.25.0 to 0.25.1

### DIFF
--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.25.0",
+		"version": "0.25.1",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"


### PR DESCRIPTION
This PR fixes a mistake where the version was not bumped when it should have been