### PR TITLE
Catch more errors in Bulk Upload

### DIFF
--- a/src/tasks/processBulkUploadTask.ts
+++ b/src/tasks/processBulkUploadTask.ts
@@ -523,13 +523,14 @@ export const processBulkUploadTask = async (
 	}
 
 	let bulkUploadHasFailed = false;
-	const shortCodes = await loadShortCodesFromBulkUploadTaskCsv(
-		temporaryProposalsDataFile.path,
-	);
-	const changemakerNameIndex = getChangemakerNameIndex(shortCodes);
-	const changemakerTaxIdIndex = getChangemakerTaxIdIndex(shortCodes);
 
 	try {
+		const shortCodes = await loadShortCodesFromBulkUploadTaskCsv(
+			temporaryProposalsDataFile.path,
+		);
+		const changemakerNameIndex = getChangemakerNameIndex(shortCodes);
+		const changemakerTaxIdIndex = getChangemakerTaxIdIndex(shortCodes);
+
 		await assertBulkUploadTaskCsvIsValid(temporaryProposalsDataFile.path);
 
 		await db.transaction(async (transactionDb) => {


### PR DESCRIPTION
Without this change, an error could "escape" to the graphile task runner rather than being propagated out to the error logs and user. With this change, errors thrown during a call to `loadShortCodesFromBulkUploadTaskCsv` will propagate more happily. That means fewer jobs will end up stuck in PDC DB state `in_progress`.

Issue #1973 Bulk uploads stuck with `in_progress` status