### PR TITLE
Lock uuid major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'uuid'
+        update-types: ['version-update:semver-major']
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
This PR will prevent major version dependabot bumps for this library; starting in v12 uuid has dropped commonJS support, and we are not yet ready to prioritize an ESM migration.

This will close out #1911 