### PR TITLE
Enable auto-merge for Dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Auto-merge
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR brings the workflow we just added to `front-end` over here.

It works there; the only downside is we can't defensively make sure approvals are actually required on the main branch.   Maybe that will be possible in future, but for now we just have to be sure not to lower our strictness on code review.

Resolves #2090