### PR TITLE
Cascade updates to `base_field.short_code`

### DIFF
--- a/src/database/migrations/0098-alter-references-to-base_fields-short_code.sql
+++ b/src/database/migrations/0098-alter-references-to-base_fields-short_code.sql
@@ -1,0 +1,18 @@
+-- This lays the groundwork to allow simple renaming of base_field short_code.
+-- It is anticipated that a separate table would be created to support
+-- redirects at the API level because a simple rename without a redirect
+-- breaks previously working URLs.
+ALTER TABLE application_form_fields DROP CONSTRAINT base_field_short_code_fkey;
+ALTER TABLE application_form_fields
+ADD CONSTRAINT base_field_short_code_fkey FOREIGN KEY (base_field_short_code)
+REFERENCES base_fields (short_code) ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE base_field_localizations
+DROP CONSTRAINT base_field_short_code_fkey;
+ALTER TABLE base_field_localizations
+ADD CONSTRAINT base_field_short_code_fkey FOREIGN KEY (base_field_short_code)
+REFERENCES base_fields (short_code) ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE changemaker_field_values
+DROP CONSTRAINT fk_base_field;
+ALTER TABLE changemaker_field_values
+ADD CONSTRAINT fk_base_field FOREIGN KEY (base_field_short_code)
+REFERENCES base_fields (short_code) ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
On tables that reference base field short codes, update the column automatically when the referenced short code changes. This maintains referential integrity in the database when short codes change.

This migration does not make such changes available at the API level nor does it make such changes safe at the social level.

Issue #1827