### PR TITLE
Convert patch queries to use nullable pattern

### DIFF
--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -1149,6 +1149,68 @@ describe('/changemakers', () => {
 				.send({})
 				.expect(400);
 		});
+
+		it('Returns 400 validation error when taxId is set to null', async () => {
+			const changemaker = await createChangemaker(db, null, {
+				taxId: '1234567890',
+				name: 'Test Changemaker',
+				keycloakOrganizationId: null,
+			});
+			const result = await request(app)
+				.patch(`/changemakers/${changemaker.id}`)
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					taxId: null,
+				})
+				.expect(400);
+			expect(result.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expectArray(),
+			});
+		});
+
+		it('Returns 400 validation error when name is set to null', async () => {
+			const changemaker = await createChangemaker(db, null, {
+				taxId: '0987654321',
+				name: 'Another Test Changemaker',
+				keycloakOrganizationId: null,
+			});
+			const result = await request(app)
+				.patch(`/changemakers/${changemaker.id}`)
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					name: null,
+				})
+				.expect(400);
+			expect(result.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expectArray(),
+			});
+		});
+
+		it('Successfully sets keycloakOrganizationId to null', async () => {
+			const changemaker = await createChangemaker(db, null, {
+				taxId: '5555555555',
+				name: 'Changemaker with org id',
+				keycloakOrganizationId: stringToKeycloakId(
+					'12345678-1234-1234-1234-123456789abc',
+				),
+			});
+			const result = await request(app)
+				.patch(`/changemakers/${changemaker.id}`)
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					keycloakOrganizationId: null,
+				})
+				.expect(200);
+			expect(result.body).toStrictEqual({
+				...changemaker,
+				keycloakOrganizationId: null,
+			});
+		});
 	});
 
 	describe('PUT /:changemakerId/fiscalSponsors/:fiscalSponsorChangemakerId', () => {

--- a/src/database/queries/baseFieldsCopyTasks/updateById.sql
+++ b/src/database/queries/baseFieldsCopyTasks/updateById.sql
@@ -1,5 +1,5 @@
 UPDATE base_fields_copy_tasks
 SET
-	status = coalesce(:status, status)
+	status = update_if(:statusWasProvided, :status, status)
 WHERE id = :baseFieldsCopyTaskId
 RETURNING base_fields_copy_task_to_json(base_fields_copy_tasks) AS object;

--- a/src/database/queries/bulkUploadTasks/updateById.sql
+++ b/src/database/queries/bulkUploadTasks/updateById.sql
@@ -1,6 +1,6 @@
 UPDATE bulk_upload_tasks
 SET
-	status = coalesce(:status, status)
+	status = update_if(:statusWasProvided, :status, status)
 WHERE id = :bulkUploadTaskId
 RETURNING bulk_upload_task_to_json(
 	bulk_upload_tasks,

--- a/src/database/queries/changemakers/updateById.sql
+++ b/src/database/queries/changemakers/updateById.sql
@@ -1,9 +1,11 @@
 UPDATE changemakers
 SET
-	tax_id = coalesce(:taxId, tax_id),
-	name = coalesce(:name, name),
-	keycloak_organization_id = coalesce(
-		:keycloakOrganizationId, keycloak_organization_id
+	tax_id = update_if(:taxIdWasProvided, :taxId, tax_id),
+	name = update_if(:nameWasProvided, :name, name),
+	keycloak_organization_id = update_if(
+		:keycloakOrganizationIdWasProvided,
+		:keycloakOrganizationId,
+		keycloak_organization_id
 	)
 WHERE id = :changemakerId
 RETURNING changemaker_to_json(changemakers) AS object;

--- a/src/database/queries/funderCollaborativeInvitations/updateByShortCode.sql
+++ b/src/database/queries/funderCollaborativeInvitations/updateByShortCode.sql
@@ -1,7 +1,10 @@
 UPDATE funder_collaborative_invitations
 SET
-	invitation_status
-	= coalesce(:invitationStatus::invitation_status_t, invitation_status)
+	invitation_status = update_if(
+		:invitationStatusWasProvided,
+		:invitationStatus::invitation_status_t,
+		invitation_status
+	)
 WHERE
 	funder_collaborative_short_code = :funderCollaborativeShortCode::short_code_t
 	AND invited_funder_short_code = :invitedFunderShortCode::short_code_t

--- a/src/types/Changemaker.ts
+++ b/src/types/Changemaker.ts
@@ -50,11 +50,19 @@ const partialWritableChangemakerSchema: JSONSchemaType<PartialWritableChangemake
 		properties: {
 			taxId: {
 				type: 'string',
-				nullable: true,
+				/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion --
+				 * This is a gross workaround for the fact that AJV does not support nullable types in TypeScript.
+				 * See: https://github.com/ajv-validator/ajv/issues/2163
+				 */
+				nullable: false as true,
 			},
 			name: {
 				type: 'string',
-				nullable: true,
+				/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion --
+				 * This is a gross workaround for the fact that AJV does not support nullable types in TypeScript.
+				 * See: https://github.com/ajv-validator/ajv/issues/2163
+				 */
+				nullable: false as true,
 			},
 			keycloakOrganizationId: {
 				...keycloakIdSchema,


### PR DESCRIPTION
This PR updates our `update` queries to use `update_if` instead of `coalesce`.  This change allows explicit `null` values to be set in an update (before null was treated as though it meant `undefined` since pg converts both `null` and `undefined` to SQL null)

Resolves #1472

I have rebased this against #2164 and so it shouldn't be merged until after that PR is merged.