### PR TITLE
Adjust dependabot cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: 'mock-jwks'
@@ -26,15 +30,27 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 2
 
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'pip'
     directory: 'sqlfluff/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This PR slows dependabot down a bit, attempting to strike a balance between using the latest of a given dependency and the overhead of review.

Resolves #2140 