### PR TITLE
Use trusted publisher flow for npm publish

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -7,11 +7,13 @@ on:
     branches:
       - 'main'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   typescript:
     runs-on: ubuntu-latest
-    env:
-      npm_token_exists: ${{ secrets.NPM_TOKEN != '' }}
     steps:
       - name: Check out our code
         uses: actions/checkout@v6
@@ -51,10 +53,9 @@ jobs:
         working-directory: sdk/build/typescript
         run: npm run build
       - name: Publish to NPM if there is a new version
-        if: ${{ env.npm_token_exists == 'true' }}
         uses: JS-DevTools/npm-publish@v4
         with:
           package: sdk/build/typescript
-          token: ${{ secrets.NPM_TOKEN }}
           access: public
           dry-run: ${{ github.event_name == 'pull_request' }}
+          provenance: true


### PR DESCRIPTION
This PR changes our npm publication workflow to use the new, more secure ["Trusted Publishers" approach](https://docs.npmjs.com/trusted-publishers)

I don't know for sure how to test this (in fact, I don't think I can test it locally at all, even if I was able to simulate github actions!)  That said, I do think that it will do a dry run in PR.

Resolves #2170 