### PR TITLE
Remove the "git+" prefix from repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/PhilanthropyDataCommons/service.git"
+		"url": "https://github.com/PhilanthropyDataCommons/service.git"
 	},
 	"keywords": [
 		"Philanthropy",


### PR DESCRIPTION
Issue #2170 Fix our NPM publishing action