### PR TITLE
Use gold schema for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,12 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
+      - name: Install PostgreSQL client tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-common
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          sudo apt-get install -y postgresql-client
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ dist
 
 # Python
 venv/
+
+# Test schema dumps
+.test_dumps/

--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -1,6 +1,8 @@
 var config = require('./jest.config.base.js');
+var integrationConfig = require('./jest.config.int.js');
+var unitConfig = require('./jest.config.unit.js');
 
-commonProjectConfig = {
+var commonProjectConfig = {
 	transform: {
 		'^.+\\.tsx?$': [
 			'ts-jest',
@@ -19,13 +21,16 @@ module.exports = {
 		{
 			...commonProjectConfig,
 			displayName: 'integration',
-			testMatch: ['**/*.int.test.ts'],
-			setupFilesAfterEnv: ['<rootDir>/src/test/integrationSuiteSetup.ts'],
+			testMatch: integrationConfig.testMatch,
+			globalSetup: integrationConfig.globalSetup,
+			globalTeardown: integrationConfig.globalTeardown,
+			setupFilesAfterEnv: integrationConfig.setupFilesAfterEnv,
+			maxWorkers: integrationConfig.maxWorkers,
 		},
 		{
 			...commonProjectConfig,
 			displayName: 'unit',
-			testMatch: ['**/*.unit.test.ts'],
+			testMatch: unitConfig.testMatch,
 		},
 	],
 };

--- a/jest.config.int.js
+++ b/jest.config.int.js
@@ -1,4 +1,8 @@
 var config = require('./jest.config.base.js');
 config.testMatch = ['**/?(*.)+(int).(spec|test).[jt]s?(x)'];
+config.globalSetup = '<rootDir>/src/test/integrationGlobalSetup.ts';
+config.globalTeardown = '<rootDir>/src/test/globalTeardown.ts';
 config.setupFilesAfterEnv = ['<rootDir>/src/test/integrationSuiteSetup.ts'];
+// Cap workers to prevent PostgreSQL "out of shared memory" errors from too many concurrent schemas
+config.maxWorkers = 8;
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
 		"start": "ts-node src/index.ts | pino-pretty",
 		"test": "npm run test:unit && npm run test:integration",
 		"test:unit": "jest --config=jest.config.unit.js",
-		"test:integration": "jest --config=jest.config.int.js --runInBand",
-		"test:ci": "jest --config=jest.config.ci.js --runInBand"
+		"test:integration": "jest --config=jest.config.int.js",
+		"test:ci": "jest --config=jest.config.ci.js"
 	},
 	"repository": {
 		"type": "git",

--- a/src/constants/exitCodes.ts
+++ b/src/constants/exitCodes.ts
@@ -1,1 +1,3 @@
 export const EXIT_CODE_FAILURE = 1;
+export const EXIT_CODE_SIGINT = 130;
+export const EXIT_CODE_SIGTERM = 143;

--- a/src/test/globalTeardown.ts
+++ b/src/test/globalTeardown.ts
@@ -1,0 +1,35 @@
+/* eslint-disable import/no-default-export --
+ * Jest expects a single default function to be exported from this file.
+ */
+import fs from 'node:fs/promises';
+import {
+	dropGoldSchema,
+	dropWorkerSchemas,
+	TEST_TEMP_DIR,
+} from './goldSchemaSetup';
+
+// Must match the value in jest.config.int.js and integrationGlobalSetup.ts
+const MAX_INTEGRATION_WORKERS = 8;
+
+/**
+ * Removes the .test directory and all its contents.
+ */
+const cleanupTestTempDir = async (): Promise<void> => {
+	try {
+		await fs.rm(TEST_TEMP_DIR, { recursive: true, force: true });
+	} catch {
+		// Directory may not exist, ignore
+	}
+};
+
+/**
+ * Global teardown for integration tests.
+ * Runs once after all integration tests complete.
+ *
+ * Drops the gold schema, worker schemas, and cleans up the .test directory.
+ */
+export default async (): Promise<void> => {
+	await dropGoldSchema();
+	await dropWorkerSchemas(MAX_INTEGRATION_WORKERS);
+	await cleanupTestTempDir();
+};

--- a/src/test/goldSchemaSetup.ts
+++ b/src/test/goldSchemaSetup.ts
@@ -1,0 +1,279 @@
+/**
+ * Gold Schema Setup for Integration Tests
+ *
+ * This module handles the lifecycle of the "gold" schema used to speed up
+ * integration tests. Instead of running ~79 migrations before each test,
+ * we run migrations once into a gold schema and clone it for each test.
+ */
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { TinyPg } from 'tinypg';
+import { migrate as pgMigrate } from 'postgres-schema-migrations';
+import { requireEnv } from 'require-env-variable';
+import type { PoolClient } from 'pg';
+
+// Use a unique name unlikely to appear in SQL code to avoid replacement collisions
+export const GOLD_SCHEMA_NAME = '__pdc_test_gold_schema__';
+
+const migrationsDirectory = path.resolve(__dirname, '../database/migrations');
+const initializationDirectory = path.resolve(
+	__dirname,
+	'../database/initialization',
+);
+
+// Directory for temporary test schema dumps
+// Stored in project root, should be gitignored
+export const TEST_TEMP_DIR = path.resolve(__dirname, '../../.test_dumps');
+
+// File path to cache the schema dump (shared across processes)
+export const SCHEMA_DUMP_CACHE_FILE = path.join(
+	TEST_TEMP_DIR,
+	'gold_schema_dump.sql',
+);
+
+const execAsync = promisify(exec);
+
+/**
+ * Creates a dedicated TinyPg instance for gold schema setup.
+ * This is separate from the main db instance to avoid PGOPTIONS interference.
+ */
+const createDb = (): TinyPg =>
+	new TinyPg({
+		root_dir: [path.resolve(__dirname, '../database/queries')],
+	});
+
+/**
+ * Sets PostgreSQL configuration variables needed during migrations.
+ * Must use the same client that will run migrations so settings are available.
+ */
+const setPsqlSettingsForMigrations = async (
+	client: PoolClient,
+): Promise<void> => {
+	const { S3_ENDPOINT, S3_BUCKET, S3_REGION } = requireEnv(
+		'S3_ENDPOINT',
+		'S3_BUCKET',
+		'S3_REGION',
+	);
+
+	await client.query('SELECT set_config($1, $2, false)', [
+		'app.s3_endpoint',
+		S3_ENDPOINT,
+	]);
+	await client.query('SELECT set_config($1, $2, false)', [
+		'app.s3_bucket',
+		S3_BUCKET,
+	]);
+	await client.query('SELECT set_config($1, $2, false)', [
+		'app.s3_region',
+		S3_REGION,
+	]);
+};
+
+/**
+ * Runs initialization SQL files from src/database/initialization/ against the gold schema.
+ * Uses a single client to ensure search_path is consistent across all queries.
+ */
+const runInitialization = async (
+	db: TinyPg,
+	schemaName: string,
+): Promise<void> => {
+	const initializationFiles = (
+		await fs.readdir(initializationDirectory)
+	).filter((file) => file.endsWith('.sql'));
+
+	// Pre-read all SQL files
+	const sqlContents = await Promise.all(
+		initializationFiles.map(async (file) => {
+			const filePath = path.join(initializationDirectory, file);
+			return (await fs.readFile(filePath)).toString();
+		}),
+	);
+
+	// Use a single client for all initialization to maintain search_path
+	// Execute sequentially to ensure proper ordering
+	const client = await db.getClient();
+	try {
+		await client.query(`SET search_path TO ${schemaName}`);
+
+		for (const sql of sqlContents) {
+			// eslint-disable-next-line no-await-in-loop -- Sequential execution required for DB consistency
+			await client.query(sql);
+		}
+	} finally {
+		client.release();
+	}
+};
+
+/**
+ * Dumps the gold schema directly to the cache file using pg_dump.
+ * Pipes directly to file to avoid memory buffering of large dumps.
+ */
+const dumpGoldSchemaToFile = async (): Promise<void> => {
+	// pg_dump reads connection info from PG* environment variables automatically
+	// Options to minimize dump size:
+	// --no-owner, --no-privileges: skip ownership/permissions
+	// --no-comments: skip comments
+	// --inserts: use INSERT instead of COPY (needed for schema name replacement)
+	// Pipe directly to file to avoid memory buffering
+	await execAsync(
+		`pg_dump --schema=${GOLD_SCHEMA_NAME} --no-owner --no-privileges --no-comments --inserts > "${SCHEMA_DUMP_CACHE_FILE}"`,
+	);
+};
+
+/**
+ * Cleans up orphaned functions left behind by interrupted test runs.
+ * These orphans occur when test processes are killed mid-execution,
+ * leaving functions that reference non-existent schemas.
+ * This prevents pg_dump from failing with "schema with OID X does not exist".
+ */
+const cleanupOrphanedFunctions = async (db: TinyPg): Promise<void> => {
+	// Find and remove functions whose namespace no longer exists
+	// This is a defensive cleanup for any orphans from previous interrupted runs
+	await db.query(`
+		DO $$
+		DECLARE
+			r RECORD;
+		BEGIN
+			FOR r IN
+				SELECT p.oid
+				FROM pg_proc p
+				LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
+				WHERE n.oid IS NULL
+			LOOP
+				DELETE FROM pg_depend WHERE objid = r.oid;
+				DELETE FROM pg_proc WHERE oid = r.oid;
+			END LOOP;
+		END $$
+	`);
+};
+
+/**
+ * Creates the gold schema with all migrations and initialization applied.
+ * This should be called once before all integration tests run.
+ */
+export const createGoldSchema = async (): Promise<void> => {
+	const db = createDb();
+
+	try {
+		// Clean up any orphaned functions from previous interrupted test runs
+		// This prevents pg_dump from failing due to stale references
+		await cleanupOrphanedFunctions(db);
+
+		// Drop existing gold schema if present (cleanup from crashed previous run)
+		await db.query(`DROP SCHEMA IF EXISTS ${GOLD_SCHEMA_NAME} CASCADE`);
+
+		// Create gold schema
+		await db.query(`CREATE SCHEMA ${GOLD_SCHEMA_NAME}`);
+
+		// Run migrations against the gold schema
+		// Use a single client for S3 settings and migrations so settings are available
+		const client = await db.getClient();
+		try {
+			await setPsqlSettingsForMigrations(client);
+			// Set search_path so migrations create tables in the gold schema
+			await client.query(`SET search_path TO ${GOLD_SCHEMA_NAME}`);
+			await pgMigrate({ client }, migrationsDirectory, {
+				logger: () => {
+					// Silent during test setup
+				},
+				schema: GOLD_SCHEMA_NAME,
+			});
+		} finally {
+			client.release();
+		}
+
+		// Run initialization SQL files (functions, views, etc.)
+		await runInitialization(db, GOLD_SCHEMA_NAME);
+
+		// Ensure the test temp directory exists
+		await fs.mkdir(TEST_TEMP_DIR, { recursive: true });
+
+		// Cache the schema dump to a file for cloning (shared across processes)
+		await dumpGoldSchemaToFile();
+	} finally {
+		await db.close();
+	}
+};
+
+/**
+ * Generates the path for a worker-specific dump file.
+ */
+export const getWorkerDumpFilePath = (workerId: number): string =>
+	path.join(TEST_TEMP_DIR, `test_${workerId}_dump.sql`);
+
+const FIRST_WORKER_ID = 1;
+
+/**
+ * Creates worker-specific dump files by replacing the gold schema name.
+ * Should be called during global setup after createGoldSchema.
+ *
+ * @param maxWorkers - The maximum number of Jest workers (from config)
+ */
+export const createWorkerDumpFiles = async (
+	maxWorkers: number,
+): Promise<void> => {
+	// Create dump files for each worker (worker IDs are 1-indexed in Jest)
+	const workerIds = Array.from(
+		{ length: maxWorkers },
+		(_, i) => i + FIRST_WORKER_ID,
+	);
+
+	await Promise.all(
+		workerIds.map(async (workerId) => {
+			const workerDumpFile = getWorkerDumpFilePath(workerId);
+			const targetSchema = `test_${workerId}`;
+			// Use sed for fast string replacement
+			await execAsync(
+				`sed 's/${GOLD_SCHEMA_NAME}/${targetSchema}/g' "${SCHEMA_DUMP_CACHE_FILE}" > "${workerDumpFile}"`,
+			);
+		}),
+	);
+};
+
+/**
+ * Drops the gold schema.
+ * This should be called after all integration tests complete.
+ */
+export const dropGoldSchema = async (): Promise<void> => {
+	const db = createDb();
+
+	try {
+		await db.query(`DROP SCHEMA IF EXISTS ${GOLD_SCHEMA_NAME} CASCADE`);
+		// Clean up the cached schema dump file
+		try {
+			await fs.unlink(SCHEMA_DUMP_CACHE_FILE);
+		} catch (_error) {
+			// File may not exist, ignore
+		}
+	} finally {
+		await db.close();
+	}
+};
+
+/**
+ * Drops all worker test schemas (test_1, test_2, etc.).
+ * This is used during cleanup to ensure no worker schemas are left behind.
+ *
+ * @param maxWorkers - The maximum number of workers to clean up
+ */
+export const dropWorkerSchemas = async (maxWorkers: number): Promise<void> => {
+	const db = createDb();
+
+	try {
+		const workerIds = Array.from(
+			{ length: maxWorkers },
+			(_, i) => i + FIRST_WORKER_ID,
+		);
+
+		await Promise.all(
+			workerIds.map(async (workerId) => {
+				const schemaName = `test_${workerId}`;
+				await db.query(`DROP SCHEMA IF EXISTS ${schemaName} CASCADE`);
+			}),
+		);
+	} finally {
+		await db.close();
+	}
+};

--- a/src/test/integrationGlobalSetup.ts
+++ b/src/test/integrationGlobalSetup.ts
@@ -1,0 +1,143 @@
+/* eslint-disable import/no-default-export --
+ * Jest expects a single default function to be exported from this file.
+ */
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import {
+	EXIT_CODE_FAILURE,
+	EXIT_CODE_SIGINT,
+	EXIT_CODE_SIGTERM,
+} from '../constants';
+import {
+	createGoldSchema,
+	createWorkerDumpFiles,
+	dropGoldSchema,
+	dropWorkerSchemas,
+	TEST_TEMP_DIR,
+} from './goldSchemaSetup';
+import type { Config } from 'jest';
+
+const DEFAULT_MAX_WORKERS = 4;
+const MIN_WORKERS = 1;
+const PERCENTAGE_DIVISOR = 100;
+// Cap workers to prevent PostgreSQL "out of shared memory" errors from too many concurrent schemas
+const MAX_INTEGRATION_WORKERS = 8;
+
+// Track the number of workers for cleanup during signal handling
+let registeredMaxWorkers = DEFAULT_MAX_WORKERS;
+
+/**
+ * Performs emergency cleanup when tests are interrupted.
+ * Drops all test schemas and cleans up temporary files.
+ */
+const performEmergencyCleanup = async (): Promise<void> => {
+	// Use process.stderr.write to avoid any logging framework issues during shutdown
+	process.stderr.write('\nInterrupted - cleaning up test schemas...\n');
+
+	try {
+		await dropGoldSchema();
+		await dropWorkerSchemas(registeredMaxWorkers);
+		await fs.rm(TEST_TEMP_DIR, { recursive: true, force: true });
+		process.stderr.write('Cleanup complete.\n');
+	} catch (error) {
+		process.stderr.write(`Cleanup error: ${String(error)}\n`);
+	}
+};
+
+/**
+ * Signal handler for SIGINT (Ctrl+C) and SIGTERM.
+ * Performs cleanup before exiting.
+ */
+const handleSignal = (signal: string): void => {
+	process.stderr.write(`\nReceived ${signal}.\n`);
+
+	// Remove handlers to prevent re-entry
+	process.removeListener('SIGINT', handleSignal);
+	process.removeListener('SIGTERM', handleSignal);
+
+	performEmergencyCleanup()
+		.finally(() => {
+			const exitCode =
+				signal === 'SIGINT' ? EXIT_CODE_SIGINT : EXIT_CODE_SIGTERM;
+			process.exit(exitCode);
+		})
+		.catch(() => {
+			// Fallback exit if something goes wrong
+			process.exit(EXIT_CODE_FAILURE);
+		});
+};
+
+/**
+ * Registers signal handlers for graceful shutdown.
+ */
+const registerSignalHandlers = (): void => {
+	process.on('SIGINT', () => {
+		handleSignal('SIGINT');
+	});
+	process.on('SIGTERM', () => {
+		handleSignal('SIGTERM');
+	});
+};
+
+/**
+ * Determines the number of workers Jest will use.
+ * Jest's maxWorkers can be a number or a percentage string like "50%".
+ */
+const getMaxWorkers = (globalConfig: Config): number => {
+	const { maxWorkers } = globalConfig;
+
+	if (typeof maxWorkers === 'number') {
+		return maxWorkers;
+	}
+
+	if (typeof maxWorkers === 'string' && maxWorkers.endsWith('%')) {
+		const percentage = parseInt(maxWorkers, 10);
+		const { length: cpuCount } = os.cpus();
+		return Math.max(
+			MIN_WORKERS,
+			Math.floor((cpuCount * percentage) / PERCENTAGE_DIVISOR),
+		);
+	}
+
+	// Default fallback
+	return DEFAULT_MAX_WORKERS;
+};
+
+/**
+ * Global setup for integration tests.
+ * Runs once before all integration tests start.
+ *
+ * 1. Registers signal handlers for graceful shutdown on interrupt
+ * 2. Sets LOG_LEVEL to silent if running in silent mode
+ * 3. Creates the gold schema with migrations and initialization
+ * 4. Creates worker-specific dump files for all workers
+ */
+export default async (
+	globalConfig: Config,
+	projectConfig: Config,
+): Promise<void> => {
+	// Register signal handlers early so cleanup runs even if setup is interrupted
+	registerSignalHandlers();
+
+	// Set log level (replicated from base globalSetup.ts)
+	if (
+		(process.env.LOG_LEVEL === undefined || process.env.LOG_LEVEL === '') &&
+		(globalConfig.silent === true || projectConfig.silent === true)
+	) {
+		process.env.LOG_LEVEL = 'silent';
+	}
+
+	// Create the gold schema with all migrations applied
+	await createGoldSchema();
+
+	// Create worker-specific dump files for all workers (capped to prevent DB overload)
+	const maxWorkers = Math.min(
+		getMaxWorkers(globalConfig),
+		MAX_INTEGRATION_WORKERS,
+	);
+
+	// Store maxWorkers for signal handler cleanup
+	registeredMaxWorkers = maxWorkers;
+
+	await createWorkerDumpFiles(maxWorkers);
+};


### PR DESCRIPTION
This PR is not ready for review but I wanted to show it off for now.

It moves our tests to use a gold schema instead of running migrations for every test.  This is faster out of the box, but also it allows us to run our integration tests in parallel (since the migration library had a limitation forcing us to run in band).

What once took 5 minutes will now take... much less than that (TBD let's see)!