### PR TITLE
Lock major version of postgres-schema-migrations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       timezone: 'Etc/UTC'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
     ignore:
       - dependency-name: 'mock-jwks'
         update-types: ['version-update:semver-major']
@@ -37,7 +36,6 @@ updates:
       timezone: 'Etc/UTC'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 2
 
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'


### PR DESCRIPTION
This PR prevents dependabot bumping to a version our repo won't support.

I also took out the pr limits since we can handle whatever we need!