### PR TITLE
Enable `strict-void-return` lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,8 +82,6 @@ export default defineConfig([
 					caughtErrors: 'none',
 				},
 			],
-			// These are temporarily disabled so we can turn them on alongside necessary code changes
-			'@typescript-eslint/strict-void-return': 'off',
 		},
 		settings: {
 			'import/resolver': {

--- a/src/middleware/__tests__/errorHandler.unit.test.ts
+++ b/src/middleware/__tests__/errorHandler.unit.test.ts
@@ -3,6 +3,7 @@ import { UnauthorizedError } from 'express-jwt';
 import { errorHandler } from '../errorHandler';
 import { DatabaseError } from '../../errors';
 import { getMockRequest, getMockResponse } from '../../test/mockExpress';
+import { getMockNextFunction } from '../../test/utils';
 
 describe('errorHandler', () => {
 	it('should process errors that are not Errors', () => {
@@ -15,7 +16,7 @@ describe('errorHandler', () => {
 		res.status = statusMock;
 		res.contentType = contentTypeMock;
 		res.send = sendMock;
-		const next = jest.fn();
+		const next = getMockNextFunction();
 		errorHandler(err, req, res, next);
 		expect(statusMock).toHaveBeenCalledWith(500);
 		expect(sendMock).toHaveBeenCalledWith(
@@ -37,7 +38,7 @@ describe('errorHandler', () => {
 		res.status = statusMock;
 		res.contentType = contentTypeMock;
 		res.send = sendMock;
-		const next = jest.fn();
+		const next = getMockNextFunction();
 		errorHandler(err, req, res, next);
 		expect(statusMock).toHaveBeenCalledWith(401);
 		expect(sendMock).toHaveBeenCalledWith(
@@ -59,7 +60,7 @@ describe('errorHandler', () => {
 		res.status = statusMock;
 		res.contentType = contentTypeMock;
 		res.send = sendMock;
-		const next = jest.fn();
+		const next = getMockNextFunction();
 		errorHandler(err, req, res, next);
 		expect(statusMock).toHaveBeenCalledWith(503);
 		expect(sendMock).toHaveBeenCalledWith(
@@ -88,7 +89,7 @@ describe('errorHandler', () => {
 		res.status = statusMock;
 		res.contentType = contentTypeMock;
 		res.send = sendMock;
-		const next = jest.fn();
+		const next = getMockNextFunction();
 		errorHandler(err, req, res, next);
 		expect(statusMock).toHaveBeenCalledWith(500);
 		expect(sendMock).toHaveBeenCalledWith(

--- a/src/middleware/__tests__/processJwt.int.test.ts
+++ b/src/middleware/__tests__/processJwt.int.test.ts
@@ -7,11 +7,11 @@ import { processJwt } from '../processJwt';
 import {
 	allowNextToResolve,
 	generateNextWithAssertions,
+	getMockNextFunction,
 } from '../../test/utils';
 import { mockJwt as authHeader, getMockJwt } from '../../test/mockJwt';
 import { getMockRequest, getMockResponse } from '../../test/mockExpress';
 import { expectNumber } from '../../test/asymettricMatchers';
-import type { NextFunction } from 'express';
 import type { JwtPayload } from 'jsonwebtoken';
 import type { AuthenticatedRequest } from '../../types';
 
@@ -152,7 +152,7 @@ DcIUm2m37s+QJR4qBRUsmd/aIiH/xeA0Y1VIMMso3U1vW9iYfDWHkaaiYUWzYI5u
 	it('does not call next twice if middleware throws an error after calling next', async () => {
 		const req = getMockRequest() as AuthenticatedRequest;
 		const res = getMockResponse();
-		const nextMock: NextFunction = jest.fn();
+		const nextMock = getMockNextFunction();
 		customMiddleware.mockReset();
 		customMiddleware.mockImplementation(
 			/* eslint-disable-next-line @typescript-eslint/require-await --
@@ -174,7 +174,7 @@ DcIUm2m37s+QJR4qBRUsmd/aIiH/xeA0Y1VIMMso3U1vW9iYfDWHkaaiYUWzYI5u
 	it('calls next if middleware throws an error before calling next', async () => {
 		const req = getMockRequest() as AuthenticatedRequest;
 		const res = getMockResponse();
-		const nextMock: NextFunction = jest.fn();
+		const nextMock = getMockNextFunction();
 		customMiddleware.mockReset();
 
 		/* eslint-disable-next-line @typescript-eslint/require-await --

--- a/src/middleware/__tests__/requireAuthentication.int.test.ts
+++ b/src/middleware/__tests__/requireAuthentication.int.test.ts
@@ -1,27 +1,27 @@
 import { requireAuthentication } from '../requireAuthentication';
 import { UnauthorizedError } from '../../errors';
-import { allowNextToResolve, loadTestUser } from '../../test/utils';
+import {
+	allowNextToResolve,
+	getMockNextFunction,
+	loadTestUser,
+} from '../../test/utils';
 import { getMockRequest, getMockResponse } from '../../test/mockExpress';
-import type { NextFunction } from 'express';
 import type { AuthenticatedRequest } from '../../types';
 
 describe('requireAuthentication', () => {
 	it('calls next with an UnauthorizedError when no auth value is provided', async () => {
 		const req = getMockRequest();
 		const res = getMockResponse();
-		const nextMock = jest.fn();
+		const nextMock = getMockNextFunction();
 		requireAuthentication(req, res, nextMock);
 		await allowNextToResolve();
 
-		expect(nextMock).toHaveBeenCalled();
-		/* eslint-disable @typescript-eslint/no-unsafe-member-access --
-		 * We know that the first `calls` is populated due to the passage of `.toHaveBeenCalled`
-		 */
-		expect(nextMock.mock.calls[0][0]).toBeInstanceOf(UnauthorizedError);
-		expect(nextMock.mock.calls[0][0].message).toEqual(
-			'No authorization token was found.',
+		expect(nextMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: 'No authorization token was found.',
+			}),
 		);
-		/* eslint-enable @typescript-eslint/no-unsafe-member-access */
+		expect(nextMock.mock.calls[0]?.[0]).toBeInstanceOf(UnauthorizedError);
 	});
 
 	it('calls next with an UnauthorizedError when no auth sub is provided', async () => {
@@ -29,19 +29,17 @@ describe('requireAuthentication', () => {
 		const res = getMockResponse();
 		req.auth = {};
 		req.user = await loadTestUser();
-		const nextMock = jest.fn();
+		const nextMock = getMockNextFunction();
 		requireAuthentication(req, res, nextMock);
 		await allowNextToResolve();
 
-		expect(nextMock).toHaveBeenCalled();
-		/* eslint-disable @typescript-eslint/no-unsafe-member-access --
-		 * We know that the first `calls` is populated due to the passage of `.toHaveBeenCalled`
-		 */
-		expect(nextMock.mock.calls[0][0]).toBeInstanceOf(UnauthorizedError);
-		expect(nextMock.mock.calls[0][0].message).toEqual(
-			'The authentication token must have a non-empty value for `auth.sub`.',
+		expect(nextMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message:
+					'The authentication token must have a non-empty value for `auth.sub`.',
+			}),
 		);
-		/* eslint-enable @typescript-eslint/no-unsafe-member-access */
+		expect(nextMock.mock.calls[0]?.[0]).toBeInstanceOf(UnauthorizedError);
 	});
 
 	it('calls next with an UnauthorizedError when a blank auth sub is provided', async () => {
@@ -51,19 +49,17 @@ describe('requireAuthentication', () => {
 			sub: '',
 		};
 		req.user = await loadTestUser();
-		const nextMock = jest.fn();
+		const nextMock = getMockNextFunction();
 		requireAuthentication(req, res, nextMock);
 		await allowNextToResolve();
 
-		expect(nextMock).toHaveBeenCalled();
-		/* eslint-disable @typescript-eslint/no-unsafe-member-access --
-		 * We know that the first `calls` is populated due to the passage of `.toHaveBeenCalled`
-		 */
-		expect(nextMock.mock.calls[0][0]).toBeInstanceOf(UnauthorizedError);
-		expect(nextMock.mock.calls[0][0].message).toEqual(
-			'The authentication token must have a non-empty value for `auth.sub`.',
+		expect(nextMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message:
+					'The authentication token must have a non-empty value for `auth.sub`.',
+			}),
 		);
-		/* eslint-enable @typescript-eslint/no-unsafe-member-access */
+		expect(nextMock.mock.calls[0]?.[0]).toBeInstanceOf(UnauthorizedError);
 	});
 
 	it('calls next with an UnauthorizedError when there is no user provided', async () => {
@@ -73,19 +69,16 @@ describe('requireAuthentication', () => {
 			sub: 'test@example.com',
 			name: 'Norbert',
 		};
-		const nextMock = jest.fn();
+		const nextMock = getMockNextFunction();
 		requireAuthentication(req, res, nextMock);
 		await allowNextToResolve();
 
-		expect(nextMock).toHaveBeenCalled();
-		/* eslint-disable @typescript-eslint/no-unsafe-member-access --
-		 * We know that the first `calls` is populated due to the passage of `.toHaveBeenCalled`
-		 */
-		expect(nextMock.mock.calls[0][0]).toBeInstanceOf(UnauthorizedError);
-		expect(nextMock.mock.calls[0][0].message).toEqual(
-			'The request lacks an AuthContext.',
+		expect(nextMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: 'The request lacks an AuthContext.',
+			}),
 		);
-		/* eslint-enable @typescript-eslint/no-unsafe-member-access */
+		expect(nextMock.mock.calls[0]?.[0]).toBeInstanceOf(UnauthorizedError);
 	});
 
 	it('calls next when an auth value is provided', async () => {
@@ -99,7 +92,7 @@ describe('requireAuthentication', () => {
 			isAdministrator: false,
 		};
 		req.user = await loadTestUser();
-		const nextMock: NextFunction = jest.fn();
+		const nextMock = getMockNextFunction();
 		requireAuthentication(req, res, nextMock);
 		await allowNextToResolve();
 

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -14,15 +14,19 @@ export const allowNextToResolve = async (): Promise<void> => {
 export const generateNextWithAssertions = (
 	runAssertions: (err?: unknown) => void | Promise<void>,
 	done: (value?: unknown) => unknown,
-): jest.Mock =>
-	jest.fn(async (err?) => {
-		try {
-			await Promise.resolve(runAssertions(err));
-		} catch (thrownError) {
-			done(thrownError);
-			return;
-		}
-		done();
+): jest.Mock<void, unknown[]> =>
+	jest.fn((...args: unknown[]) => {
+		const [err] = args;
+		Promise.resolve()
+			.then(async () => {
+				await runAssertions(err);
+			})
+			.then(() => {
+				done();
+			})
+			.catch((thrownError: unknown) => {
+				done(thrownError);
+			});
 	});
 
 export const getTestUserKeycloakUserId = (): KeycloakId =>
@@ -62,6 +66,9 @@ export const getTestAuthContext = async (
 	isAdministrator = true,
 ): Promise<AuthContext> =>
 	getAuthContext(await loadTestUser(), isAdministrator);
+
+export const getMockNextFunction = (): jest.Mock<void, unknown[]> =>
+	jest.fn((): void => undefined);
 
 export const NO_OFFSET = 0;
 


### PR DESCRIPTION
This PR enables a rule we had temporarily disabled during a recent eslint version bump.