### PR TITLE
Implement `Proposal` permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated data provider permissions to the unified `permission_grants` table. Data provider permissions should now be managed via the `/permissionGrants` endpoints.
 - Migrated opportunity permissions to the unified `permission_grants` table. Opportunity permissions should now be managed via the `/permissionGrants` endpoints.
 - The `permissions` property has been removed from the `User` type entirely. All permission checks are now performed asynchronously via the permission_grants table.
+- Viewing proposals, proposal versions, and changemaker-proposal associations now requires `view | proposal` scope instead of inheriting from `view | funder` or `view | changemaker`. The `view | proposal` scope can be granted at the proposal, opportunity, funder, or changemaker context level and will be inherited appropriately.
 
 ### Removed
 

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -227,7 +227,7 @@ context key).
 | view   | funder   | View the funder's opportunities                                   |
 |        |          | View application forms associated with the funder's opportunities |
 |        |          | View bulk upload tasks associated with the funder                 |
-|        |          | View proposals associated with the funder's opportunities         |
+| view   | proposal | View proposals associated with the funder's opportunities         |
 |        |          | View proposal versions associated with the funder's opportunities |
 |        |          | View changemaker-proposal associations for the funder's proposals |
 | create | proposal | Create proposals for the funder's opportunities                   |
@@ -248,9 +248,9 @@ context key).
 
 | Verb | Scope       | What It Enables                                            |
 | ---- | ----------- | ---------------------------------------------------------- |
-| view | changemaker | View proposals associated with the changemaker             |
+| view | changemaker | View changemaker field values for the changemaker          |
+| view | proposal    | View proposals associated with the changemaker             |
 |      |             | View proposal versions associated with the changemaker     |
-|      |             | View changemaker field values for the changemaker          |
 |      |             | View changemaker-proposal associations for the changemaker |
 | edit | changemaker | Create or update changemaker field values                  |
 |      |             | Create sources associated with the changemaker             |
@@ -263,10 +263,25 @@ context key). Opportunity permissions inherit from the parent funder, so a
 funder's opportunities. Opportunity-level grants provide more granular control
 for specific opportunities.
 
-| Verb   | Scope       | What It Enables                               |
-| ------ | ----------- | --------------------------------------------- |
-| view   | opportunity | View the specific opportunity                 |
-| create | proposal    | Create proposals for the specific opportunity |
+| Verb   | Scope       | What It Enables                                                        |
+| ------ | ----------- | ---------------------------------------------------------------------- |
+| view   | opportunity | View the specific opportunity                                          |
+| view   | proposal    | View proposals associated with the opportunity                         |
+|        |             | View proposal versions for the opportunity's proposals                 |
+|        |             | View changemaker-proposal associations for the opportunity's proposals |
+| create | proposal    | Create proposals for the specific opportunity                          |
+
+### Proposal Permissions
+
+Permissions granted directly against a proposal (using the proposal's `id` as
+the context key). This provides the most granular access control for individual
+proposals.
+
+| Verb | Scope    | What It Enables                                         |
+| ---- | -------- | ------------------------------------------------------- |
+| view | proposal | View the specific proposal                              |
+|      |          | View proposal versions for the proposal                 |
+|      |          | View changemaker-proposal associations for the proposal |
 
 ### Data Provider Permissions
 
@@ -279,10 +294,9 @@ Permissions granted against a data provider (using the data provider's
 
 ### Other Contexts
 
-The permission system data model includes additional contexts (`proposal`,
-`proposalVersion`, `applicationForm`, `applicationFormField`,
-`proposalFieldValue`, `source`, `bulkUpload`, `changemakerFieldValue`) that can
-have permission grants created. However, these contexts do not currently have
-permission checks enforced in the codebase. Access to these entities is
-controlled through the parent entity permissions described above (funder or
-changemaker).
+The permission system data model includes additional contexts (`proposalVersion`,
+`applicationForm`, `applicationFormField`, `proposalFieldValue`, `source`,
+`bulkUpload`, `changemakerFieldValue`) that can have permission grants created.
+However, these contexts do not currently have permission checks enforced in the
+codebase. Access to these entities is controlled through the parent entity
+permissions described above (funder, changemaker, opportunity, or proposal).

--- a/src/__tests__/changemakerProposals.int.test.ts
+++ b/src/__tests__/changemakerProposals.int.test.ts
@@ -70,7 +70,10 @@ describe('/changemakerProposals', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: visibleFunder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
+				scope: [
+					PermissionGrantEntityType.FUNDER,
+					PermissionGrantEntityType.PROPOSAL,
+				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -78,7 +81,10 @@ describe('/changemakerProposals', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
 				changemakerId: visibleChangemaker.id,
-				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				scope: [
+					PermissionGrantEntityType.CHANGEMAKER,
+					PermissionGrantEntityType.PROPOSAL,
+				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
 			const visibleOpportunity = await createOpportunity(db, null, {
@@ -362,16 +368,11 @@ describe('/changemakerProposals', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: systemFunder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
-				verbs: [PermissionGrantVerb.EDIT],
-			});
-			await createPermissionGrant(db, systemUserAuthContext, {
-				granteeType: PermissionGrantGranteeType.USER,
-				granteeUserKeycloakUserId: testUser.keycloakUserId,
-				contextEntityType: PermissionGrantEntityType.FUNDER,
-				funderShortCode: systemFunder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
-				verbs: [PermissionGrantVerb.VIEW],
+				scope: [
+					PermissionGrantEntityType.FUNDER,
+					PermissionGrantEntityType.PROPOSAL,
+				],
+				verbs: [PermissionGrantVerb.VIEW, PermissionGrantVerb.EDIT],
 			});
 			const opportunity = await createOpportunity(db, null, {
 				title: '🔥',
@@ -431,7 +432,10 @@ describe('/changemakerProposals', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: systemFunder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
+				scope: [
+					PermissionGrantEntityType.FUNDER,
+					PermissionGrantEntityType.PROPOSAL,
+				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
 			const opportunity = await createOpportunity(db, null, {

--- a/src/__tests__/permissionGrants.int.test.ts
+++ b/src/__tests__/permissionGrants.int.test.ts
@@ -540,7 +540,7 @@ describe('/permissionGrants', () => {
 					granteeUserKeycloakUserId: testUserKeycloakUserId,
 					contextEntityType: 'changemaker',
 					changemakerId: changemaker.id,
-					scope: ['changemaker', 'proposal'],
+					scope: ['changemaker', 'funder'],
 					verbs: ['view'],
 				})
 				.expect(400);

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -111,7 +111,10 @@ describe('/proposalVersions', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: systemFunder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
+				scope: [
+					PermissionGrantEntityType.FUNDER,
+					PermissionGrantEntityType.PROPOSAL,
+				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
 			const opportunity = await createOpportunity(db, null, {
@@ -159,7 +162,10 @@ describe('/proposalVersions', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
 				changemakerId: visibleChangemaker.id,
-				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				scope: [
+					PermissionGrantEntityType.CHANGEMAKER,
+					PermissionGrantEntityType.PROPOSAL,
+				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
 			const opportunity = await createOpportunity(db, null, {
@@ -311,16 +317,11 @@ describe('/proposalVersions', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: systemFunder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
-				verbs: [PermissionGrantVerb.EDIT],
-			});
-			await createPermissionGrant(db, systemUserAuthContext, {
-				granteeType: PermissionGrantGranteeType.USER,
-				granteeUserKeycloakUserId: testUser.keycloakUserId,
-				contextEntityType: PermissionGrantEntityType.FUNDER,
-				funderShortCode: systemFunder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
-				verbs: [PermissionGrantVerb.VIEW],
+				scope: [
+					PermissionGrantEntityType.FUNDER,
+					PermissionGrantEntityType.PROPOSAL,
+				],
+				verbs: [PermissionGrantVerb.VIEW, PermissionGrantVerb.EDIT],
 			});
 			await createOpportunity(db, null, {
 				title: '🔥',

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -100,7 +100,10 @@ describe('/proposals', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: visibleFunder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
+				scope: [
+					PermissionGrantEntityType.FUNDER,
+					PermissionGrantEntityType.PROPOSAL,
+				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -108,7 +111,10 @@ describe('/proposals', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
 				changemakerId: visibleChangemaker.id,
-				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				scope: [
+					PermissionGrantEntityType.CHANGEMAKER,
+					PermissionGrantEntityType.PROPOSAL,
+				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
 			const visibleOpportunity = await createOpportunity(db, null, {

--- a/src/database/initialization/has_proposal_permission.sql
+++ b/src/database/initialization/has_proposal_permission.sql
@@ -1,0 +1,73 @@
+CREATE OR REPLACE FUNCTION has_proposal_permission(
+	user_keycloak_user_id uuid,
+	user_is_admin boolean,
+	proposal_id int,
+	permission permission_grant_verb_t,
+	scope permission_grant_entity_type_t
+) RETURNS boolean AS $$
+DECLARE
+	has_permission boolean;
+BEGIN
+	-- If the user is an administrator, they have all permissions
+	IF user_is_admin THEN
+		RETURN TRUE;
+	END IF;
+
+	-- Check if the user has the specified permission on the specified proposal
+	-- via direct user grant, group membership, or inherited from parent entities
+	SELECT EXISTS (
+		SELECT 1
+		FROM proposals p
+		INNER JOIN opportunities o ON p.opportunity_id = o.id
+		LEFT JOIN changemakers_proposals cp ON p.id = cp.proposal_id
+		INNER JOIN permission_grants pg ON (
+			-- Direct proposal grant
+			(
+				pg.context_entity_type = 'proposal'
+				AND pg.proposal_id = p.id
+				AND has_proposal_permission.scope = ANY(pg.scope)
+			)
+			-- Inherited from opportunity with proposal scope
+			OR (
+				pg.context_entity_type = 'opportunity'
+				AND pg.opportunity_id = p.opportunity_id
+				AND 'proposal' = ANY(pg.scope)
+			)
+			-- Inherited from funder with proposal scope
+			OR (
+				pg.context_entity_type = 'funder'
+				AND pg.funder_short_code = o.funder_short_code
+				AND 'proposal' = ANY(pg.scope)
+			)
+			-- Inherited from changemaker with proposal scope
+			OR (
+				pg.context_entity_type = 'changemaker'
+				AND pg.changemaker_id = cp.changemaker_id
+				AND 'proposal' = ANY(pg.scope)
+			)
+		)
+		WHERE p.id = has_proposal_permission.proposal_id
+			AND has_proposal_permission.permission = ANY(pg.verbs)
+			AND (
+				(
+					pg.grantee_type = 'user'
+					AND pg.grantee_user_keycloak_user_id
+						= has_proposal_permission.user_keycloak_user_id
+				)
+				OR (
+					pg.grantee_type = 'userGroup'
+					AND EXISTS (
+						SELECT 1
+						FROM ephemeral_user_group_associations euga
+						WHERE euga.user_keycloak_user_id
+							= has_proposal_permission.user_keycloak_user_id
+							AND euga.user_group_keycloak_organization_id
+								= pg.grantee_keycloak_organization_id
+					)
+				)
+			)
+	) INTO has_permission;
+
+	RETURN has_permission;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/migrations/0089-add-proposal-scope-to-existing-permissions.sql
+++ b/src/database/migrations/0089-add-proposal-scope-to-existing-permissions.sql
@@ -1,0 +1,13 @@
+-- Add 'proposal' scope to existing funder and changemaker permissions to
+-- maintain backward compatibility with the previous implicit proposal access.
+--
+-- Previously, having funder-scope permission on a funder or changemaker-scope
+-- permission on a changemaker implicitly granted access to associated
+-- proposals. Now that proposal permissions are explicit, we need to add the
+-- proposal scope to preserve this behavior.
+
+UPDATE permission_grants
+SET scope = array_append(scope, 'proposal'::permission_grant_entity_type_t)
+WHERE
+	context_entity_type IN ('funder', 'changemaker')
+	AND NOT ('proposal' = any(scope));

--- a/src/database/operations/authorization/hasProposalPermission.ts
+++ b/src/database/operations/authorization/hasProposalPermission.ts
@@ -1,0 +1,8 @@
+import { generateHasPermissionOperation } from '../generators';
+
+const hasProposalPermission = generateHasPermissionOperation(
+	'authorization.hasProposalPermission',
+	'proposalId',
+);
+
+export { hasProposalPermission };

--- a/src/database/operations/authorization/index.ts
+++ b/src/database/operations/authorization/index.ts
@@ -2,3 +2,4 @@ export { hasChangemakerPermission } from './hasChangemakerPermission';
 export { hasDataProviderPermission } from './hasDataProviderPermission';
 export { hasFunderPermission } from './hasFunderPermission';
 export { hasOpportunityPermission } from './hasOpportunityPermission';
+export { hasProposalPermission } from './hasProposalPermission';

--- a/src/database/queries/authorization/hasProposalPermission.sql
+++ b/src/database/queries/authorization/hasProposalPermission.sql
@@ -1,0 +1,7 @@
+SELECT has_proposal_permission(
+	:userKeycloakUserId,
+	:isAdministrator,
+	:proposalId,
+	:permission::permission_grant_verb_t,
+	:scope::permission_grant_entity_type_t
+) AS "hasPermission";

--- a/src/database/queries/changemakersProposals/selectWithPagination.sql
+++ b/src/database/queries/changemakersProposals/selectWithPagination.sql
@@ -1,35 +1,24 @@
 SELECT changemaker_proposal_to_json(changemakers_proposals.*) AS object
 FROM changemakers_proposals
-	INNER JOIN proposals ON changemakers_proposals.proposal_id = proposals.id
-	INNER JOIN opportunities ON proposals.opportunity_id = opportunities.id
 WHERE
 	CASE
 		WHEN :changemakerId::integer IS NULL THEN
 			TRUE
 		ELSE
-			changemakers_proposals.changemaker_id = :changemakerId
+			changemaker_id = :changemakerId
 	END
 	AND CASE
 		WHEN :proposalId::integer IS NULL THEN
 			TRUE
 		ELSE
-			changemakers_proposals.proposal_id = :proposalId
+			proposal_id = :proposalId
 	END
-	AND (
-		has_funder_permission(
-			:authContextKeycloakUserId,
-			:authContextIsAdministrator,
-			opportunities.funder_short_code,
-			'view',
-			'funder'
-		)
-		OR has_changemaker_permission(
-			:authContextKeycloakUserId,
-			:authContextIsAdministrator,
-			changemakers_proposals.changemaker_id,
-			'view',
-			'changemaker'
-		)
+	AND has_proposal_permission(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		proposal_id,
+		'view',
+		'proposal'
 	)
-ORDER BY changemakers_proposals.id DESC
+ORDER BY id DESC
 LIMIT :limit OFFSET :offset;

--- a/src/database/queries/proposalVersions/selectById.sql
+++ b/src/database/queries/proposalVersions/selectById.sql
@@ -2,32 +2,10 @@ SELECT proposal_version_to_json(proposal_versions.*) AS object
 FROM proposal_versions
 WHERE
 	proposal_versions.id = :proposalVersionId
-	AND (
-		EXISTS (
-			SELECT 1
-			FROM proposals
-				INNER JOIN opportunities ON proposals.opportunity_id = opportunities.id
-			WHERE
-				proposals.id = proposal_versions.proposal_id
-				AND has_funder_permission(
-					:authContextKeycloakUserId,
-					:authContextIsAdministrator,
-					opportunities.funder_short_code,
-					'view',
-					'funder'
-				)
-		)
-		OR EXISTS (
-			SELECT 1
-			FROM changemakers_proposals
-			WHERE
-				changemakers_proposals.proposal_id = proposal_versions.proposal_id
-				AND has_changemaker_permission(
-					:authContextKeycloakUserId,
-					:authContextIsAdministrator,
-					changemakers_proposals.changemaker_id,
-					'view',
-					'changemaker'
-				)
-		)
+	AND has_proposal_permission(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		proposal_versions.proposal_id,
+		'view',
+		'proposal'
 	);

--- a/src/database/queries/proposals/selectById.sql
+++ b/src/database/queries/proposals/selectById.sql
@@ -2,31 +2,10 @@ SELECT proposal_to_json(proposals.*) AS object
 FROM proposals
 WHERE
 	proposals.id = :proposalId
-	AND (
-		EXISTS (
-			SELECT 1
-			FROM opportunities
-			WHERE
-				opportunities.id = proposals.opportunity_id
-				AND has_funder_permission(
-					:authContextKeycloakUserId,
-					:authContextIsAdministrator,
-					opportunities.funder_short_code,
-					'view',
-					'funder'
-				)
-		)
-		OR EXISTS (
-			SELECT 1
-			FROM changemakers_proposals
-			WHERE
-				changemakers_proposals.proposal_id = proposals.id
-				AND has_changemaker_permission(
-					:authContextKeycloakUserId,
-					:authContextIsAdministrator,
-					changemakers_proposals.changemaker_id,
-					'view',
-					'changemaker'
-				)
-		)
+	AND has_proposal_permission(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		proposals.id,
+		'view',
+		'proposal'
 	);

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -49,27 +49,12 @@ WHERE
 		ELSE
 			opportunities.funder_short_code = :funderShortCode
 	END
-	AND (
-		has_funder_permission(
-			:authContextKeycloakUserId,
-			:authContextIsAdministrator,
-			opportunities.funder_short_code,
-			'view',
-			'funder'
-		)
-		OR EXISTS (
-			SELECT 1
-			FROM changemakers_proposals AS permission_cp
-			WHERE
-				permission_cp.proposal_id = proposals.id
-				AND has_changemaker_permission(
-					:authContextKeycloakUserId,
-					:authContextIsAdministrator,
-					permission_cp.changemaker_id,
-					'view',
-					'changemaker'
-				)
-		)
+	AND has_proposal_permission(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		proposals.id,
+		'view',
+		'proposal'
 	)
 GROUP BY proposals.id
 ORDER BY proposals.id DESC

--- a/src/types/PermissionGrantEntityType.ts
+++ b/src/types/PermissionGrantEntityType.ts
@@ -91,8 +91,12 @@ const allowedScopesForContextEntityType: Record<
 > = {
 	[PermissionGrantEntityType.CHANGEMAKER]: [
 		PermissionGrantEntityType.CHANGEMAKER,
+		PermissionGrantEntityType.PROPOSAL,
 	],
-	[PermissionGrantEntityType.FUNDER]: [PermissionGrantEntityType.FUNDER],
+	[PermissionGrantEntityType.FUNDER]: [
+		PermissionGrantEntityType.FUNDER,
+		PermissionGrantEntityType.PROPOSAL,
+	],
 	[PermissionGrantEntityType.DATA_PROVIDER]: [
 		PermissionGrantEntityType.DATA_PROVIDER,
 	],


### PR DESCRIPTION
This PR expands our permission system to use the `Proposal` permission grants, and to move towards the more granular grants for parent objects (prior to this PR permissions on a funder translated to permissions on proposals associated with that funder's opportunity).

Related to #2161