### PR TITLE
Add `GET /files` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `GET /files` endpoint to retrieve a paginated list of files. Users see only files they created; administrators can see all files and filter by creator using the `createdBy` parameter.
+
 ### Changed
 
 - Migrated changemaker permissions to the unified `permission_grants` table. Changemaker permissions should now be managed via the `/permissionGrants` endpoints.

--- a/src/__tests__/files.int.test.ts
+++ b/src/__tests__/files.int.test.ts
@@ -2,18 +2,192 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { S3Client } from '@aws-sdk/client-s3';
 import request from 'supertest';
 import { app } from '../app';
-import { mockJwt as authHeader } from '../test/mockJwt';
+import { db, loadSystemUser } from '../database';
 import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
+} from '../test/mockJwt';
+import {
+	expectArrayContaining,
 	expectNumber,
+	expectObjectContaining,
 	expectString,
 	expectTimestamp,
 } from '../test/asymettricMatchers';
+import { getAuthContext } from '../test/utils';
+import { createTestFile } from '../test/factories';
 
 const s3Mock = mockClient(S3Client);
 
 describe('/files', () => {
 	beforeEach(() => {
 		s3Mock.reset();
+	});
+
+	describe('GET /', () => {
+		it('requires authentication', async () => {
+			await request(app).get('/files').expect(401);
+		});
+
+		it('returns an empty bundle when no files exist', async () => {
+			const response = await request(app)
+				.get('/files')
+				.set(authHeader)
+				.expect(200);
+
+			expect(response.body).toEqual({
+				entries: [],
+				total: 0,
+			});
+		});
+
+		it('returns files created by the authenticated user', async () => {
+			// Create a file first
+			await request(app)
+				.post('/files')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					name: 'get-test.pdf',
+					mimeType: 'application/pdf',
+					size: 2048,
+				})
+				.expect(201);
+
+			const response = await request(app)
+				.get('/files')
+				.set(authHeader)
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				entries: expectArrayContaining([
+					expectObjectContaining({
+						id: expectNumber(),
+						name: 'get-test.pdf',
+						mimeType: 'application/pdf',
+						size: 2048,
+						storageKey: expectString(),
+						s3BucketName: process.env.S3_BUCKET,
+						createdBy: expectString(),
+						createdAt: expectTimestamp(),
+						downloadUrl: expectString(),
+					}),
+				]),
+			});
+		});
+
+		it('supports pagination parameters', async () => {
+			// Create two files for pagination test
+			await request(app)
+				.post('/files')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					name: 'pagination-test-1.pdf',
+					mimeType: 'application/pdf',
+					size: 100,
+				})
+				.expect(201);
+
+			await request(app)
+				.post('/files')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					name: 'pagination-test-2.pdf',
+					mimeType: 'application/pdf',
+					size: 200,
+				})
+				.expect(201);
+
+			const response = await request(app)
+				.get('/files?_count=1')
+				.set(authHeader)
+				.expect(200);
+
+			// With _count=1, we should get exactly 1 entry but total should reflect all files
+			expect(response.body).toMatchObject({
+				entries: [expect.objectContaining({ id: expectNumber() })],
+			});
+		});
+
+		it('includes downloadUrl in each file entry', async () => {
+			await request(app)
+				.post('/files')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					name: 'download-url-test.pdf',
+					mimeType: 'application/pdf',
+					size: 512,
+				})
+				.expect(201);
+
+			const response = await request(app)
+				.get('/files')
+				.set(authHeader)
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				entries: expectArrayContaining([
+					expectObjectContaining({
+						name: 'download-url-test.pdf',
+						downloadUrl: expectString(),
+					}),
+				]),
+			});
+		});
+
+		it('does not return files created by other users for non-admin users', async () => {
+			// Create a file as the system user (different from the test user)
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			await createTestFile(db, systemUserAuthContext, {
+				name: 'system-user-file.pdf',
+				mimeType: 'application/pdf',
+				size: 1024,
+			});
+
+			// List files as the regular test user (non-admin)
+			const response = await request(app)
+				.get('/files')
+				.set(authHeader)
+				.expect(200);
+
+			// Should not see the file created by the system user
+			// Note: total reflects all files in the database, not just accessible ones
+			expect(response.body).toMatchObject({
+				entries: [],
+			});
+		});
+
+		it('returns files created by other users for admin users', async () => {
+			// Create a file as the system user (different from the test user)
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const file = await createTestFile(db, systemUserAuthContext, {
+				name: 'admin-visible-file.pdf',
+				mimeType: 'application/pdf',
+				size: 2048,
+			});
+
+			// List files as an admin user
+			const response = await request(app)
+				.get('/files')
+				.set(authHeaderWithAdminRole)
+				.expect(200);
+
+			// Admin should see the file created by the system user
+			expect(response.body).toMatchObject({
+				entries: expectArrayContaining([
+					expectObjectContaining({
+						id: file.id,
+						name: 'admin-visible-file.pdf',
+						createdBy: systemUser.keycloakUserId,
+					}),
+				]),
+			});
+		});
 	});
 
 	describe('POST /', () => {

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -200,6 +200,9 @@
 			"File": {
 				"$ref": "./components/schemas/File.json"
 			},
+			"FileBundle": {
+				"$ref": "./components/schemas/FileBundle.json"
+			},
 			"S3Bucket": {
 				"$ref": "./components/schemas/S3Bucket.json"
 			},

--- a/src/openapi/components/schemas/FileBundle.json
+++ b/src/openapi/components/schemas/FileBundle.json
@@ -1,0 +1,19 @@
+{
+	"allOf": [
+		{
+			"$ref": "./Bundle.json"
+		},
+		{
+			"type": "object",
+			"properties": {
+				"entries": {
+					"type": "array",
+					"items": {
+						"$ref": "./File.json"
+					}
+				}
+			},
+			"required": ["entries"]
+		}
+	]
+}

--- a/src/openapi/paths/files.json
+++ b/src/openapi/paths/files.json
@@ -1,4 +1,27 @@
 {
+	"get": {
+		"operationId": "getFiles",
+		"summary": "Gets a list of files.",
+		"tags": ["Files"],
+		"description": "Returns a paginated list of files created by the authenticated user. Administrators can see all files and filter by creator using the createdBy parameter.",
+		"security": [{ "auth": [] }],
+		"parameters": [
+			{ "$ref": "../components/parameters/pageParam.json" },
+			{ "$ref": "../components/parameters/countParam.json" },
+			{ "$ref": "../components/parameters/createdByParam.json" }
+		],
+		"responses": {
+			"200": {
+				"description": "A list of files.",
+				"content": {
+					"application/json": {
+						"schema": { "$ref": "../components/schemas/FileBundle.json" }
+					}
+				}
+			},
+			"401": { "$ref": "../components/responses/Unauthorized.json" }
+		}
+	},
 	"post": {
 		"operationId": "createFile",
 		"summary": "Create a new file",

--- a/src/routers/filesRouter.ts
+++ b/src/routers/filesRouter.ts
@@ -4,6 +4,7 @@ import { requireAuthentication } from '../middleware';
 
 const filesRouter = express.Router();
 
+filesRouter.get('/', requireAuthentication, filesHandlers.getFiles);
 filesRouter.post('/', requireAuthentication, filesHandlers.postFile);
 
 export { filesRouter };


### PR DESCRIPTION
This PR adds a new endpoint for loading a list of files that have been uploaded to the PDC.

This is generally only going to be used for administrative purposes for now, though eventually we can expand access as desired.

Resolves #2201 