### PR TITLE
Add nullable `name` field to `ApplicationForm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `GET /files` endpoint to retrieve a paginated list of files. Users see only files they created; administrators can see all files and filter by creator using the `createdBy` parameter.
+- Added optional `name` field to `ApplicationForm` entity for human-readable display.
 
 ### Changed
 

--- a/src/__tests__/applicationFormFields.int.test.ts
+++ b/src/__tests__/applicationFormFields.int.test.ts
@@ -37,6 +37,7 @@ describe('/applicationFormFields', () => {
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			const baseField = await createOrUpdateBaseField(db, null, {
@@ -103,6 +104,7 @@ describe('/applicationFormFields', () => {
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			const baseField = await createOrUpdateBaseField(db, null, {
@@ -169,6 +171,7 @@ describe('/applicationFormFields', () => {
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			const baseField = await createOrUpdateBaseField(db, null, {
@@ -237,6 +240,7 @@ describe('/applicationFormFields', () => {
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			const baseField = await createOrUpdateBaseField(db, null, {
@@ -303,6 +307,7 @@ describe('/applicationFormFields', () => {
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			const baseField = await createOrUpdateBaseField(db, null, {
@@ -369,6 +374,7 @@ describe('/applicationFormFields', () => {
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			const baseField = await createOrUpdateBaseField(db, null, {
@@ -428,6 +434,7 @@ describe('/applicationFormFields', () => {
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			const baseField = await createOrUpdateBaseField(db, null, {
@@ -503,6 +510,7 @@ describe('/applicationFormFields', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			const baseField = await createOrUpdateBaseField(db, null, {

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -87,12 +87,15 @@ describe('/applicationForms', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 2,
+				name: null,
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 2,
+				name: null,
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 3,
+				name: null,
 			});
 			const response = await request(app)
 				.get('/applicationForms')
@@ -158,12 +161,15 @@ describe('/applicationForms', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 2,
+				name: null,
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 2,
+				name: null,
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 3,
+				name: null,
 			});
 			const response = await request(app)
 				.get('/applicationForms')
@@ -175,6 +181,7 @@ describe('/applicationForms', () => {
 						createdAt: expectTimestamp(),
 						id: 1,
 						opportunityId: 1,
+						name: null,
 						fields: [],
 						version: 1,
 					},
@@ -182,6 +189,7 @@ describe('/applicationForms', () => {
 						createdAt: expectTimestamp(),
 						id: 2,
 						opportunityId: 2,
+						name: null,
 						fields: [],
 						version: 1,
 					},
@@ -189,6 +197,7 @@ describe('/applicationForms', () => {
 						createdAt: expectTimestamp(),
 						id: 3,
 						opportunityId: 2,
+						name: null,
 						fields: [],
 						version: 2,
 					},
@@ -215,12 +224,15 @@ describe('/applicationForms', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 2,
+				name: null,
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 2,
+				name: null,
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 3,
+				name: null,
 			});
 			await createTestBaseFields();
 			await createApplicationFormField(db, null, {
@@ -316,6 +328,7 @@ describe('/applicationForms', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 2,
+				name: null,
 			});
 			await createTestBaseFields();
 			await createApplicationFormField(db, null, {
@@ -396,6 +409,7 @@ describe('/applicationForms', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 2,
+				name: null,
 			});
 			await createTestBaseFields();
 			await createApplicationFormField(db, null, {
@@ -466,6 +480,7 @@ describe('/applicationForms', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const forbiddenBaseField = await createOrUpdateBaseField(db, null, {
 				label: 'Forbidden Field',
@@ -529,6 +544,7 @@ describe('/applicationForms', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 2,
+				name: null,
 			});
 			await createTestBaseFields();
 			await createApplicationFormField(db, null, {
@@ -584,6 +600,7 @@ describe('/applicationForms', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			await createTestBaseFields();
 			await createApplicationFormField(db, null, {
@@ -632,6 +649,7 @@ describe('/applicationForms', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			await createTestBaseFields();
 
@@ -677,6 +695,7 @@ describe('/applicationForms', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			const result = await request(app)
@@ -707,6 +726,7 @@ describe('/applicationForms', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 
 			await request(app)
@@ -753,6 +773,7 @@ describe('/applicationForms', () => {
 				.set(authHeader)
 				.send({
 					opportunityId: opportunity.id,
+					name: null,
 					fields: [],
 				})
 				.expect(201);
@@ -761,6 +782,7 @@ describe('/applicationForms', () => {
 			expect(result.body).toMatchObject({
 				id: 2,
 				opportunityId: 2,
+				name: null,
 				version: 1,
 				fields: [],
 				createdAt: expectTimestamp(),
@@ -781,6 +803,7 @@ describe('/applicationForms', () => {
 				.set(authHeaderWithAdminRole)
 				.send({
 					opportunityId: opportunity.id,
+					name: null,
 					fields: [],
 				})
 				.expect(201);
@@ -788,11 +811,76 @@ describe('/applicationForms', () => {
 			expect(result.body).toMatchObject({
 				id: 2,
 				opportunityId: 2,
+				name: null,
 				version: 1,
 				fields: [],
 				createdAt: expectTimestamp(),
 			});
 			expect(after.count).toEqual(before.count + 1);
+		});
+
+		it('creates an application form with a name', async () => {
+			const systemFunder = await loadSystemFunder(db, null);
+			const opportunity = await createOpportunity(db, null, {
+				title: 'Tremendous opportunity 👌',
+				funderShortCode: systemFunder.shortCode,
+			});
+			const result = await request(app)
+				.post('/applicationForms')
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					opportunityId: opportunity.id,
+					name: '2025 Grant Application',
+					fields: [],
+				})
+				.expect(201);
+			expect(result.body).toMatchObject({
+				id: 2,
+				opportunityId: 2,
+				name: '2025 Grant Application',
+				version: 1,
+				fields: [],
+				createdAt: expectTimestamp(),
+			});
+		});
+
+		it('creates an application form with null name', async () => {
+			const systemFunder = await loadSystemFunder(db, null);
+			const opportunity = await createOpportunity(db, null, {
+				title: 'Tremendous opportunity 👌',
+				funderShortCode: systemFunder.shortCode,
+			});
+			const result = await request(app)
+				.post('/applicationForms')
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					opportunityId: opportunity.id,
+					name: null,
+					fields: [],
+				})
+				.expect(201);
+			expect(result.body).toMatchObject({
+				id: 2,
+				opportunityId: 2,
+				name: null,
+				version: 1,
+				fields: [],
+				createdAt: expectTimestamp(),
+			});
+		});
+
+		it('returns 400 bad request when no name is provided', async () => {
+			await request(app)
+				.post('/applicationForms')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					opportunityId: 1,
+					fields: [],
+				})
+				.expect(400);
 		});
 
 		it(`returns 401 unauthorized if the user does not have edit permission on the associated opportunity's funder`, async () => {
@@ -827,6 +915,7 @@ describe('/applicationForms', () => {
 				.set(authHeader)
 				.send({
 					opportunityId: opportunity.id,
+					name: null,
 					fields: [],
 				})
 				.expect(401);
@@ -849,6 +938,7 @@ describe('/applicationForms', () => {
 				.set(authHeaderWithAdminRole)
 				.send({
 					opportunityId: opportunity.id,
+					name: null,
 					fields: [
 						{
 							baseFieldShortCode: 'organizationName',
@@ -865,6 +955,7 @@ describe('/applicationForms', () => {
 			expect(result.body).toMatchObject({
 				id: 2,
 				opportunityId: 2,
+				name: null,
 				version: 1,
 				fields: [
 					{
@@ -890,9 +981,11 @@ describe('/applicationForms', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const result = await request(app)
 				.post('/applicationForms')
@@ -900,6 +993,7 @@ describe('/applicationForms', () => {
 				.set(authHeaderWithAdminRole)
 				.send({
 					opportunityId: opportunity.id,
+					name: null,
 					fields: [],
 				})
 				.expect(201);
@@ -934,6 +1028,7 @@ describe('/applicationForms', () => {
 				.set(authHeaderWithAdminRole)
 				.send({
 					opportunityId: opportunity.id,
+					name: null,
 					fields: [
 						{
 							baseFieldShortCode: forbiddenBaseField.shortCode,
@@ -976,6 +1071,7 @@ describe('/applicationForms', () => {
 				.set(authHeader)
 				.send({
 					opportunityId: 1,
+					name: null,
 					fields: [
 						{
 							foo: 'not a field',
@@ -996,6 +1092,7 @@ describe('/applicationForms', () => {
 				.set(authHeaderWithAdminRole)
 				.send({
 					opportunityId: 9999,
+					name: null,
 					fields: [],
 				})
 				.expect(422);
@@ -1035,6 +1132,7 @@ describe('/applicationForms', () => {
 				.set(authHeaderWithAdminRole)
 				.send({
 					opportunityId: opportunity.id,
+					name: null,
 					fields: [
 						{
 							baseFieldShortCode: 'organizationName',

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -98,6 +98,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: firstOpportunity.id,
+					name: null,
 				},
 			);
 			const secondOpportunity = await createOpportunity(
@@ -113,6 +114,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: secondOpportunity.id,
+					name: null,
 				},
 			);
 
@@ -171,6 +173,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -236,6 +239,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -299,6 +303,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -350,6 +355,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -440,6 +446,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -518,6 +525,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -591,6 +599,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -643,6 +652,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -688,6 +698,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -749,6 +760,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 
@@ -820,6 +832,7 @@ describe('/tasks/bulkUploads', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: opportunity.id,
+					name: null,
 				},
 			);
 

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -451,6 +451,7 @@ describe('/changemakers', () => {
 					null,
 					{
 						opportunityId,
+						name: null,
 					},
 				);
 				// Older field that is valid
@@ -480,6 +481,7 @@ describe('/changemakers', () => {
 				const { id: applicationFormIdLatestValid } =
 					await createApplicationForm(db, null, {
 						opportunityId,
+						name: null,
 					});
 				const latestValidValue = await createProposalFieldValue(db, null, {
 					proposalVersionId: (
@@ -509,6 +511,7 @@ describe('/changemakers', () => {
 					null,
 					{
 						opportunityId,
+						name: null,
 					},
 				);
 				// Latest value but invalid
@@ -578,6 +581,7 @@ describe('/changemakers', () => {
 				const { id: applicationFormIdChangemakerEarliest } =
 					await createApplicationForm(db, null, {
 						opportunityId: opportunity.id,
+						name: null,
 					});
 				// Set up older field value that is from the changemaker. We'll expect this to be returned.
 				const changemakerEarliestValue = await createProposalFieldValue(
@@ -610,6 +614,7 @@ describe('/changemakers', () => {
 				const { id: applicationFormIdFunderLatest } =
 					await createApplicationForm(db, null, {
 						opportunityId: opportunity.id,
+						name: null,
 					});
 				// Set up newer field value that is from the funder.
 				await createProposalFieldValue(db, null, {
@@ -674,6 +679,7 @@ describe('/changemakers', () => {
 				const { id: applicationFormIdFunderEarliest } =
 					await createApplicationForm(db, null, {
 						opportunityId: opportunity.id,
+						name: null,
 					});
 				// Set up older field value that is from the funder. We'll expect this to be returned.
 				const funderEarliestValue = await createProposalFieldValue(db, null, {
@@ -702,6 +708,7 @@ describe('/changemakers', () => {
 				const { id: applicationFormIdDataProviderLatest } =
 					await createApplicationForm(db, null, {
 						opportunityId: opportunity.id,
+						name: null,
 					});
 				// Set up newer field value that is from the data platform provider.
 				await createProposalFieldValue(db, null, {
@@ -767,6 +774,7 @@ describe('/changemakers', () => {
 				const { id: applicationFormIdDataProviderEarliest } =
 					await createApplicationForm(db, null, {
 						opportunityId: firstFunderOpportunity.id,
+						name: null,
 					});
 				// Set up older field value.
 				await createProposalFieldValue(db, null, {
@@ -794,6 +802,7 @@ describe('/changemakers', () => {
 				const { id: applicationFormIdDataProviderLatest } =
 					await createApplicationForm(db, null, {
 						opportunityId: firstFunderOpportunity.id,
+						name: null,
 					});
 				// Set up newer field value.
 				const dataProviderNewestValue = await createProposalFieldValue(
@@ -864,6 +873,7 @@ describe('/changemakers', () => {
 				});
 				const applicationForm = await createApplicationForm(db, null, {
 					opportunityId: opportunity.id,
+					name: null,
 				});
 				const applicationFormField = await createApplicationFormField(
 					db,
@@ -1595,6 +1605,7 @@ describe('/changemakers', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const proposalVersion = await createProposalVersion(
 				db,
@@ -1868,6 +1879,7 @@ describe('/changemakers', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const proposalVersion = await createProposalVersion(
 				db,

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -81,6 +81,7 @@ describe('/proposalVersions', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const proposalVersion = await createProposalVersion(
 				db,
@@ -127,6 +128,7 @@ describe('/proposalVersions', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const proposalVersion = await createProposalVersion(
 				db,
@@ -178,6 +180,7 @@ describe('/proposalVersions', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const proposalVersion = await createProposalVersion(
 				db,
@@ -243,6 +246,7 @@ describe('/proposalVersions', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const proposalVersion = await createProposalVersion(
 				db,
@@ -280,6 +284,7 @@ describe('/proposalVersions', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 1,
+				name: null,
 			});
 			const before = await loadTableMetrics('proposal_versions');
 			logger.debug('before: %o', before);
@@ -333,6 +338,7 @@ describe('/proposalVersions', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 1,
+				name: null,
 			});
 			const before = await loadTableMetrics('proposal_versions');
 			const result = await request(app)
@@ -370,6 +376,7 @@ describe('/proposalVersions', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 1,
+				name: null,
 			});
 			await createTestBaseFields();
 			await createApplicationFormField(db, null, {
@@ -458,6 +465,7 @@ describe('/proposalVersions', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const forbiddenBaseField = await createOrUpdateBaseField(db, null, {
 				label: 'Forbidden Field',
@@ -592,6 +600,7 @@ describe('/proposalVersions', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 1,
+				name: null,
 			});
 			const result = await request(app)
 				.post('/proposalVersions')
@@ -630,6 +639,7 @@ describe('/proposalVersions', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 1,
+				name: null,
 			});
 			await request(app)
 				.post('/proposalVersions')
@@ -659,6 +669,7 @@ describe('/proposalVersions', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const before = await loadTableMetrics('proposal_field_values');
 			logger.debug('before: %o', before);
@@ -707,9 +718,11 @@ describe('/proposalVersions', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity1.id,
+				name: null,
 			});
 			const wrongForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity2.id,
+				name: null,
 			});
 			const before = await loadTableMetrics('proposal_field_values');
 			logger.debug('before: %o', before);
@@ -756,6 +769,7 @@ describe('/proposalVersions', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 1,
+				name: null,
 			});
 			const before = await loadTableMetrics('proposal_field_values');
 			logger.debug('before: %o', before);
@@ -808,9 +822,11 @@ describe('/proposalVersions', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 1,
+				name: null,
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: 1,
+				name: null,
 			});
 			await createTestBaseFields();
 			await createApplicationFormField(db, null, {

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -311,6 +311,7 @@ describe('/proposals', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			await createProposalVersion(db, testUserAuthContext, {
 				proposalId: 1,
@@ -436,6 +437,7 @@ describe('/proposals', () => {
 			});
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			const proposalVersion = await createProposalVersion(
 				db,
@@ -640,6 +642,7 @@ describe('/proposals', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			await createProposalVersion(db, testUserAuthContext, {
 				proposalId: 1,
@@ -943,6 +946,7 @@ describe('/proposals', () => {
 			await createTestBaseFields();
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
@@ -1190,6 +1194,7 @@ describe('/proposals', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			await createApplicationFormField(db, null, {
 				applicationFormId: 1,
@@ -1446,6 +1451,7 @@ describe('/proposals', () => {
 			});
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
+				name: null,
 			});
 			await createApplicationFormField(db, null, {
 				applicationFormId: 1,

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -638,6 +638,7 @@ describe('/sources', () => {
 				systemUserAuthContext,
 				{
 					opportunityId: 1,
+					name: null,
 				},
 			);
 			await createProposalVersion(db, systemUserAuthContext, {

--- a/src/database/initialization/__tests__/proposal_field_value_to_json.int.test.ts
+++ b/src/database/initialization/__tests__/proposal_field_value_to_json.int.test.ts
@@ -36,6 +36,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 		const applicationForm = await createApplicationForm(db, null, {
 			opportunityId: opportunity.id,
+			name: null,
 		});
 		const forbiddenBaseField = await createOrUpdateBaseField(db, null, {
 			label: 'Forbidden Field',
@@ -103,6 +104,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 		const applicationForm = await createApplicationForm(db, null, {
 			opportunityId: opportunity.id,
+			name: null,
 		});
 
 		const fileBaseField = await createOrUpdateBaseField(db, null, {
@@ -191,6 +193,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 		const applicationForm = await createApplicationForm(db, null, {
 			opportunityId: opportunity.id,
+			name: null,
 		});
 
 		// Create a file base field
@@ -274,6 +277,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 		const applicationForm = await createApplicationForm(db, null, {
 			opportunityId: opportunity.id,
+			name: null,
 		});
 
 		// Create a file base field
@@ -349,6 +353,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 		const applicationForm = await createApplicationForm(db, null, {
 			opportunityId: opportunity.id,
+			name: null,
 		});
 
 		// Create a file base field
@@ -424,6 +429,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 		const applicationForm = await createApplicationForm(db, null, {
 			opportunityId: opportunity.id,
+			name: null,
 		});
 
 		// Create a string base field

--- a/src/database/initialization/application_form_to_json.sql
+++ b/src/database/initialization/application_form_to_json.sql
@@ -18,6 +18,7 @@ BEGIN
   RETURN jsonb_build_object(
     'id', application_form.id,
     'opportunityId', application_form.opportunity_id,
+    'name', application_form.name,
     'version', application_form.version,
     'fields', COALESCE(application_form_fields_json, '[]'::JSONB),
     'createdAt', application_form.created_at

--- a/src/database/migrations/0090-alter-application_forms-add-name.sql
+++ b/src/database/migrations/0090-alter-application_forms-add-name.sql
@@ -1,0 +1,5 @@
+ALTER TABLE application_forms
+ADD COLUMN name text;
+
+COMMENT ON COLUMN application_forms.name IS
+'An optional display name for the application form.';

--- a/src/database/operations/applicationForms/createApplicationForm.ts
+++ b/src/database/operations/applicationForms/createApplicationForm.ts
@@ -5,6 +5,6 @@ const createApplicationForm = generateCreateOrUpdateItemOperation<
 	ApplicationForm,
 	WritableApplicationForm,
 	[]
->('applicationForms.insertOne', ['opportunityId'], []);
+>('applicationForms.insertOne', ['opportunityId', 'name'], []);
 
 export { createApplicationForm };

--- a/src/database/queries/applicationForms/insertOne.sql
+++ b/src/database/queries/applicationForms/insertOne.sql
@@ -1,8 +1,10 @@
 INSERT INTO application_forms (
 	opportunity_id,
+	name,
 	version
 ) VALUES (
 	:opportunityId,
+	:name,
 	coalesce(
 		(
 			SELECT max(af.version) + 1

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -84,7 +84,7 @@ const postApplicationForms = async (
 		);
 	}
 
-	const { fields, opportunityId } = body;
+	const { fields, opportunityId, name } = body;
 	try {
 		const opportunity = await loadOpportunity(db, req, opportunityId);
 		if (
@@ -99,6 +99,7 @@ const postApplicationForms = async (
 		const finalApplicationForm = await db.transaction(async (transactionDb) => {
 			const applicationForm = await createApplicationForm(transactionDb, null, {
 				opportunityId,
+				name,
 			});
 			const applicationFormFields = await Promise.all(
 				fields.map(

--- a/src/openapi/components/schemas/ApplicationForm.json
+++ b/src/openapi/components/schemas/ApplicationForm.json
@@ -10,6 +10,10 @@
 			"type": "integer",
 			"example": 3203
 		},
+		"name": {
+			"type": ["string", "null"],
+			"example": "2025 Grant Application"
+		},
 		"version": {
 			"type": "integer",
 			"readOnly": true,
@@ -27,5 +31,5 @@
 			"readOnly": true
 		}
 	},
-	"required": ["id", "opportunityId", "version", "fields", "createdAt"]
+	"required": ["id", "opportunityId", "name", "version", "fields", "createdAt"]
 }

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -59,6 +59,7 @@ const createTestApplicationForm = async (
 	});
 	const applicationForm = await createApplicationForm(db, authContext, {
 		opportunityId: opportunity.id,
+		name: null,
 	});
 	await Promise.all(
 		shortCodes.map(

--- a/src/types/ApplicationForm.ts
+++ b/src/types/ApplicationForm.ts
@@ -10,6 +10,7 @@ import type { Writable } from './Writable';
 interface ApplicationForm {
 	readonly id: number;
 	opportunityId: number;
+	name: string | null;
 	readonly version: number;
 	readonly fields: ApplicationFormField[];
 	readonly createdAt: string;
@@ -28,12 +29,20 @@ const writableApplicationFormWithFieldsSchema: JSONSchemaType<WritableApplicatio
 			opportunityId: {
 				type: 'number',
 			},
+			name: {
+				type: 'string',
+				/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion --
+				 * This is a workaround for the fact that AJV does not support nullable types in TypeScript.
+				 * See: https://github.com/ajv-validator/ajv/issues/2163
+				 */
+				nullable: true as false,
+			},
 			fields: {
 				type: 'array',
 				items: writableApplicationFormFieldWithApplicationContextSchema,
 			},
 		},
-		required: ['opportunityId', 'fields'],
+		required: ['opportunityId', 'name', 'fields'],
 	};
 
 const isWritableApplicationFormWithFields = ajv.compile(


### PR DESCRIPTION
This PR adds a human-identifiable name for application forms, which in turn should help when selecting them from things like dropdown lists.

This is a require field, though it can be set to null.

Resolves #2203