### PR TITLE
Utilize `ProposalFieldValue` permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Viewing proposal field values now requires explicit `view | proposalFieldValue` scope. This scope can be granted at the proposalFieldValue, proposal, opportunity, funder, or changemaker context level. Users with only `view | proposal` scope will see proposals with empty `fieldValues` arrays.
+- Existing permissions with `proposal` scope have been migrated to also include `proposalFieldValue` scope, ensuring backward compatibility.
 - Migrated changemaker permissions to the unified `permission_grants` table. Changemaker permissions should now be managed via the `/permissionGrants` endpoints.
 - Migrated funder permissions to the unified `permission_grants` table. Funder permissions should now be managed via the `/permissionGrants` endpoints.
 - Migrated data provider permissions to the unified `permission_grants` table. Data provider permissions should now be managed via the `/permissionGrants` endpoints.

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -222,38 +222,40 @@ combinations, only those listed below affect access control.
 Permissions granted against a funder (using the funder's `shortCode` as the
 context key).
 
-| Verb   | Scope    | What It Enables                                                   |
-| ------ | -------- | ----------------------------------------------------------------- |
-| view   | funder   | View the funder's opportunities                                   |
-|        |          | View application forms associated with the funder's opportunities |
-|        |          | View bulk upload tasks associated with the funder                 |
-| view   | proposal | View proposals associated with the funder's opportunities         |
-|        |          | View proposal versions associated with the funder's opportunities |
-|        |          | View changemaker-proposal associations for the funder's proposals |
-| create | proposal | Create proposals for the funder's opportunities                   |
-| edit   | funder   | Create or update opportunities for the funder                     |
-|        |          | Create or update application forms for the funder's opportunities |
-|        |          | Create or update application form fields                          |
-|        |          | Create or update proposal versions for the funder's proposals     |
-|        |          | Create bulk upload tasks for the funder                           |
-|        |          | Create or update changemaker-proposal associations                |
-|        |          | Create sources associated with the funder                         |
-| manage | funder   | View, send, and respond to funder collaborative invitations       |
-|        |          | View collaborative members for the funder                         |
+| Verb   | Scope              | What It Enables                                                   |
+| ------ | ------------------ | ----------------------------------------------------------------- |
+| view   | funder             | View the funder's opportunities                                   |
+|        |                    | View application forms associated with the funder's opportunities |
+|        |                    | View bulk upload tasks associated with the funder                 |
+| view   | proposal           | View proposals associated with the funder's opportunities         |
+|        |                    | View proposal versions associated with the funder's opportunities |
+|        |                    | View changemaker-proposal associations for the funder's proposals |
+| view   | proposalFieldValue | View proposal field values for the funder's proposals             |
+| create | proposal           | Create proposals for the funder's opportunities                   |
+| edit   | funder             | Create or update opportunities for the funder                     |
+|        |                    | Create or update application forms for the funder's opportunities |
+|        |                    | Create or update application form fields                          |
+|        |                    | Create or update proposal versions for the funder's proposals     |
+|        |                    | Create bulk upload tasks for the funder                           |
+|        |                    | Create or update changemaker-proposal associations                |
+|        |                    | Create sources associated with the funder                         |
+| manage | funder             | View, send, and respond to funder collaborative invitations       |
+|        |                    | View collaborative members for the funder                         |
 
 ### Changemaker Permissions
 
 Permissions granted against a changemaker (using the changemaker's `id` as the
 context key).
 
-| Verb | Scope       | What It Enables                                            |
-| ---- | ----------- | ---------------------------------------------------------- |
-| view | changemaker | View changemaker field values for the changemaker          |
-| view | proposal    | View proposals associated with the changemaker             |
-|      |             | View proposal versions associated with the changemaker     |
-|      |             | View changemaker-proposal associations for the changemaker |
-| edit | changemaker | Create or update changemaker field values                  |
-|      |             | Create sources associated with the changemaker             |
+| Verb | Scope              | What It Enables                                            |
+| ---- | ------------------ | ---------------------------------------------------------- |
+| view | changemaker        | View changemaker field values for the changemaker          |
+| view | proposal           | View proposals associated with the changemaker             |
+|      |                    | View proposal versions associated with the changemaker     |
+|      |                    | View changemaker-proposal associations for the changemaker |
+| view | proposalFieldValue | View proposal field values for the changemaker's proposals |
+| edit | changemaker        | Create or update changemaker field values                  |
+|      |                    | Create sources associated with the changemaker             |
 
 ### Opportunity Permissions
 
@@ -263,13 +265,14 @@ context key). Opportunity permissions inherit from the parent funder, so a
 funder's opportunities. Opportunity-level grants provide more granular control
 for specific opportunities.
 
-| Verb   | Scope       | What It Enables                                                        |
-| ------ | ----------- | ---------------------------------------------------------------------- |
-| view   | opportunity | View the specific opportunity                                          |
-| view   | proposal    | View proposals associated with the opportunity                         |
-|        |             | View proposal versions for the opportunity's proposals                 |
-|        |             | View changemaker-proposal associations for the opportunity's proposals |
-| create | proposal    | Create proposals for the specific opportunity                          |
+| Verb   | Scope              | What It Enables                                                        |
+| ------ | ------------------ | ---------------------------------------------------------------------- |
+| view   | opportunity        | View the specific opportunity                                          |
+| view   | proposal           | View proposals associated with the opportunity                         |
+|        |                    | View proposal versions for the opportunity's proposals                 |
+|        |                    | View changemaker-proposal associations for the opportunity's proposals |
+| view   | proposalFieldValue | View proposal field values for the opportunity's proposals             |
+| create | proposal           | Create proposals for the specific opportunity                          |
 
 ### Proposal Permissions
 
@@ -277,11 +280,35 @@ Permissions granted directly against a proposal (using the proposal's `id` as
 the context key). This provides the most granular access control for individual
 proposals.
 
-| Verb | Scope    | What It Enables                                         |
-| ---- | -------- | ------------------------------------------------------- |
-| view | proposal | View the specific proposal                              |
-|      |          | View proposal versions for the proposal                 |
-|      |          | View changemaker-proposal associations for the proposal |
+| Verb | Scope              | What It Enables                                         |
+| ---- | ------------------ | ------------------------------------------------------- |
+| view | proposal           | View the specific proposal                              |
+|      |                    | View proposal versions for the proposal                 |
+|      |                    | View changemaker-proposal associations for the proposal |
+| view | proposalFieldValue | View proposal field values for the proposal             |
+
+### ProposalFieldValue Permissions
+
+Permissions to view proposal field values can be granted in two ways:
+
+1. **Direct grants**: A `view | proposalFieldValue` permission can be granted
+   directly on a proposal field value (using the field value's `id` as the
+   context key). This provides the most granular control.
+
+2. **Inherited grants**: The `proposalFieldValue` scope can be included in
+   permissions granted at the proposal, opportunity, funder, or changemaker
+   level. Users with such permissions can view field values for any proposals
+   covered by that grant.
+
+| Context     | Scope              | What It Enables                                        |
+| ----------- | ------------------ | ------------------------------------------------------ |
+| funder      | proposalFieldValue | View field values for all proposals under the funder   |
+| changemaker | proposalFieldValue | View field values for all proposals of the changemaker |
+| opportunity | proposalFieldValue | View field values for proposals in the opportunity     |
+| proposal    | proposalFieldValue | View field values for the specific proposal            |
+
+Note: Users who only have `view | proposal` scope (without `proposalFieldValue`)
+can still view proposals but will see empty `fieldValues` arrays.
 
 ### Data Provider Permissions
 

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -146,11 +146,18 @@ describe('/sources', () => {
 				.expect(201);
 			const after = await loadTableMetrics('sources');
 			expect(before.count).toEqual(1);
+			// Source response includes a shallow changemaker (no fields/fiscalSponsors)
 			expect(result.body).toMatchObject({
 				id: 2,
 				label: 'Example Corp',
 				changemakerId: changemaker.id,
-				changemaker,
+				changemaker: {
+					id: changemaker.id,
+					taxId: changemaker.taxId,
+					name: changemaker.name,
+					keycloakOrganizationId: changemaker.keycloakOrganizationId,
+					createdAt: changemaker.createdAt,
+				},
 				createdAt: expectTimestamp(),
 			});
 			expect(after.count).toEqual(2);
@@ -272,11 +279,18 @@ describe('/sources', () => {
 				})
 				.expect(201);
 			const after = await loadTableMetrics('sources');
+			// Source response includes a shallow changemaker (no fields/fiscalSponsors)
 			expect(result.body).toMatchObject({
 				id: 2,
 				label: 'Example Corp',
 				changemakerId: changemaker.id,
-				changemaker,
+				changemaker: {
+					id: changemaker.id,
+					taxId: changemaker.taxId,
+					name: changemaker.name,
+					keycloakOrganizationId: changemaker.keycloakOrganizationId,
+					createdAt: changemaker.createdAt,
+				},
 				createdAt: expectTimestamp(),
 			});
 			expect(after.count).toEqual(before.count + 1);

--- a/src/database/initialization/bulk_upload_task_to_json.sql
+++ b/src/database/initialization/bulk_upload_task_to_json.sql
@@ -15,7 +15,11 @@ DECLARE
   attachments_archive_file_json JSONB;
   created_by_user_json JSONB;
 BEGIN
-  SELECT source_to_json(sources.*)
+  SELECT source_to_json(
+    sources.*,
+    auth_context_keycloak_user_id,
+    auth_context_is_administrator
+  )
   INTO source_json
   FROM sources
   WHERE sources.id = bulk_upload_task.source_id;

--- a/src/database/initialization/changemaker_field_value_batch_to_json.sql
+++ b/src/database/initialization/changemaker_field_value_batch_to_json.sql
@@ -1,13 +1,19 @@
 SELECT drop_function('changemaker_field_value_batch_to_json');
 
 CREATE FUNCTION changemaker_field_value_batch_to_json(
-	changemaker_field_value_batch changemaker_field_value_batches
+	changemaker_field_value_batch changemaker_field_value_batches,
+	auth_context_keycloak_user_id uuid DEFAULT NULL,
+	auth_context_is_administrator boolean DEFAULT FALSE
 )
 RETURNS jsonb AS $$
 DECLARE
 	source_json JSONB;
 BEGIN
-	SELECT source_to_json(sources.*)
+	SELECT source_to_json(
+		sources.*,
+		auth_context_keycloak_user_id,
+		auth_context_is_administrator
+	)
 	INTO source_json
 	FROM sources
 	WHERE sources.id = changemaker_field_value_batch.source_id;

--- a/src/database/initialization/changemaker_field_value_to_json.sql
+++ b/src/database/initialization/changemaker_field_value_to_json.sql
@@ -1,7 +1,9 @@
 SELECT drop_function('changemaker_field_value_to_json');
 
 CREATE FUNCTION changemaker_field_value_to_json(
-	changemaker_field_value changemaker_field_values
+	changemaker_field_value changemaker_field_values,
+	auth_context_keycloak_user_id uuid DEFAULT NULL,
+	auth_context_is_administrator boolean DEFAULT FALSE
 )
 RETURNS jsonb AS $$
 DECLARE
@@ -28,7 +30,11 @@ BEGIN
 	FROM base_fields
 	WHERE base_fields.short_code = changemaker_field_value.base_field_short_code;
 
-	SELECT changemaker_field_value_batch_to_json(changemaker_field_value_batches.*)
+	SELECT changemaker_field_value_batch_to_json(
+		changemaker_field_value_batches.*,
+		auth_context_keycloak_user_id,
+		auth_context_is_administrator
+	)
 	INTO batch_json
 	FROM changemaker_field_value_batches
 	WHERE changemaker_field_value_batches.id = changemaker_field_value.batch_id;

--- a/src/database/initialization/changemaker_proposal_to_json.sql
+++ b/src/database/initialization/changemaker_proposal_to_json.sql
@@ -1,19 +1,29 @@
 SELECT drop_function('changemaker_proposal_to_json');
 
 CREATE FUNCTION changemaker_proposal_to_json(
-	changemaker_proposal changemakers_proposals
+	changemaker_proposal changemakers_proposals,
+	auth_context_keycloak_user_id uuid DEFAULT NULL,
+	auth_context_is_administrator boolean DEFAULT FALSE
 )
 RETURNS jsonb AS $$
 DECLARE
   proposal_json JSONB;
   changemaker_json JSONB;
 BEGIN
-  SELECT proposal_to_json(proposals.*)
+  SELECT proposal_to_json(
+    proposals.*,
+    auth_context_keycloak_user_id,
+    auth_context_is_administrator
+  )
   INTO proposal_json
   FROM proposals
   WHERE proposals.id = changemaker_proposal.proposal_id;
 
-  SELECT changemaker_to_json(changemakers.*)
+  SELECT changemaker_to_json(
+    changemakers.*,
+    auth_context_keycloak_user_id,
+    auth_context_is_administrator
+  )
   INTO changemaker_json
   FROM changemakers
   WHERE changemakers.id = changemaker_proposal.changemaker_id;

--- a/src/database/initialization/has_proposal_field_value_permission.sql
+++ b/src/database/initialization/has_proposal_field_value_permission.sql
@@ -1,0 +1,81 @@
+CREATE OR REPLACE FUNCTION has_proposal_field_value_permission(
+	user_keycloak_user_id uuid,
+	user_is_admin boolean,
+	proposal_field_value_id int,
+	permission permission_grant_verb_t,
+	scope permission_grant_entity_type_t
+) RETURNS boolean AS $$
+DECLARE
+	has_permission boolean;
+BEGIN
+	-- If the user is an administrator, they have all permissions
+	IF user_is_admin THEN
+		RETURN TRUE;
+	END IF;
+
+	-- Check if the user has the specified permission on the specified proposal field value
+	-- via direct user grant, group membership, or inherited from parent entities
+	SELECT EXISTS (
+		SELECT 1
+		FROM proposal_field_values pfv
+		INNER JOIN proposal_versions pv ON pfv.proposal_version_id = pv.id
+		INNER JOIN proposals p ON pv.proposal_id = p.id
+		INNER JOIN opportunities o ON p.opportunity_id = o.id
+		LEFT JOIN changemakers_proposals cp ON p.id = cp.proposal_id
+		INNER JOIN permission_grants pg ON (
+			-- Direct proposalFieldValue grant
+			(
+				pg.context_entity_type = 'proposalFieldValue'
+				AND pg.proposal_field_value_id = pfv.id
+				AND has_proposal_field_value_permission.scope = ANY(pg.scope)
+			)
+			-- Inherited from proposal with proposalFieldValue scope
+			OR (
+				pg.context_entity_type = 'proposal'
+				AND pg.proposal_id = pv.proposal_id
+				AND 'proposalFieldValue' = ANY(pg.scope)
+			)
+			-- Inherited from opportunity with proposalFieldValue scope
+			OR (
+				pg.context_entity_type = 'opportunity'
+				AND pg.opportunity_id = p.opportunity_id
+				AND 'proposalFieldValue' = ANY(pg.scope)
+			)
+			-- Inherited from funder with proposalFieldValue scope
+			OR (
+				pg.context_entity_type = 'funder'
+				AND pg.funder_short_code = o.funder_short_code
+				AND 'proposalFieldValue' = ANY(pg.scope)
+			)
+			-- Inherited from changemaker with proposalFieldValue scope
+			OR (
+				pg.context_entity_type = 'changemaker'
+				AND pg.changemaker_id = cp.changemaker_id
+				AND 'proposalFieldValue' = ANY(pg.scope)
+			)
+		)
+		WHERE pfv.id = has_proposal_field_value_permission.proposal_field_value_id
+			AND has_proposal_field_value_permission.permission = ANY(pg.verbs)
+			AND (
+				(
+					pg.grantee_type = 'user'
+					AND pg.grantee_user_keycloak_user_id
+						= has_proposal_field_value_permission.user_keycloak_user_id
+				)
+				OR (
+					pg.grantee_type = 'userGroup'
+					AND EXISTS (
+						SELECT 1
+						FROM ephemeral_user_group_associations euga
+						WHERE euga.user_keycloak_user_id
+							= has_proposal_field_value_permission.user_keycloak_user_id
+							AND euga.user_group_keycloak_organization_id
+								= pg.grantee_keycloak_organization_id
+					)
+				)
+			)
+	) INTO has_permission;
+
+	RETURN has_permission;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/initialization/organization_to_json.sql
+++ b/src/database/initialization/organization_to_json.sql
@@ -11,9 +11,9 @@ DECLARE
   data_provider_json JSONB := NULL::JSONB;
   funder_json JSONB := NULL::JSONB;
 BEGIN
-  -- Shallow changemaker (3rd arg) because the purpose is to get the changemaker ID.
-  -- Not passing the auth context (2nd arg) because we want shallow fields anyway.
-  SELECT changemaker_to_json(changemakers.*, NULL, TRUE)
+  -- Shallow changemaker (4th arg) because the purpose is to get the changemaker ID.
+  -- Not passing the auth context (2nd/3rd args) because we want shallow fields anyway.
+  SELECT changemaker_to_json(changemakers.*, NULL, FALSE, TRUE)
   INTO changemaker_json
   FROM changemakers
   WHERE changemakers.keycloak_organization_id = keycloak_id

--- a/src/database/initialization/proposal_to_json.sql
+++ b/src/database/initialization/proposal_to_json.sql
@@ -1,13 +1,21 @@
 SELECT drop_function('proposal_to_json');
 
-CREATE FUNCTION proposal_to_json(proposal proposals)
+CREATE FUNCTION proposal_to_json(
+	proposal proposals,
+	auth_context_keycloak_user_id uuid DEFAULT NULL,
+	auth_context_is_administrator boolean DEFAULT FALSE
+)
 RETURNS jsonb AS $$
 DECLARE
   proposal_versions_json JSONB;
   opportunity_json JSONB;
 BEGIN
   SELECT jsonb_agg(
-    proposal_version_to_json(proposal_versions.*)
+    proposal_version_to_json(
+      proposal_versions.*,
+      auth_context_keycloak_user_id,
+      auth_context_is_administrator
+    )
     ORDER BY proposal_versions.version DESC, proposal_versions.id DESC
   )
   INTO proposal_versions_json

--- a/src/database/migrations/0091-add-proposalFieldValue-scope-to-existing-permissions.sql
+++ b/src/database/migrations/0091-add-proposalFieldValue-scope-to-existing-permissions.sql
@@ -1,0 +1,13 @@
+-- Add 'proposalFieldValue' scope to existing permissions that have
+-- 'proposal' scope.  This ensures backward compatibility: users who
+-- previously could see proposals (including their field values) retain
+-- that access under the new permission model.
+
+UPDATE permission_grants
+SET
+	scope
+	= array_append(scope, 'proposalFieldValue'::permission_grant_entity_type_t)
+WHERE
+	context_entity_type IN ('funder', 'changemaker', 'opportunity', 'proposal')
+	AND 'proposal' = any(scope)
+	AND NOT ('proposalFieldValue' = any(scope));

--- a/src/database/operations/authorization/hasProposalFieldValuePermission.ts
+++ b/src/database/operations/authorization/hasProposalFieldValuePermission.ts
@@ -1,0 +1,8 @@
+import { generateHasPermissionOperation } from '../generators';
+
+const hasProposalFieldValuePermission = generateHasPermissionOperation(
+	'authorization.hasProposalFieldValuePermission',
+	'proposalFieldValueId',
+);
+
+export { hasProposalFieldValuePermission };

--- a/src/database/operations/authorization/index.ts
+++ b/src/database/operations/authorization/index.ts
@@ -2,4 +2,5 @@ export { hasChangemakerPermission } from './hasChangemakerPermission';
 export { hasDataProviderPermission } from './hasDataProviderPermission';
 export { hasFunderPermission } from './hasFunderPermission';
 export { hasOpportunityPermission } from './hasOpportunityPermission';
+export { hasProposalFieldValuePermission } from './hasProposalFieldValuePermission';
 export { hasProposalPermission } from './hasProposalPermission';

--- a/src/database/queries/authorization/hasProposalFieldValuePermission.sql
+++ b/src/database/queries/authorization/hasProposalFieldValuePermission.sql
@@ -1,0 +1,7 @@
+SELECT has_proposal_field_value_permission(
+	:userKeycloakUserId,
+	:isAdministrator,
+	:proposalFieldValueId,
+	:permission::permission_grant_verb_t,
+	:scope::permission_grant_entity_type_t
+) AS "hasPermission";

--- a/src/database/queries/changemakerFieldValueBatches/insertOne.sql
+++ b/src/database/queries/changemakerFieldValueBatches/insertOne.sql
@@ -7,5 +7,8 @@ INSERT INTO changemaker_field_value_batches (
 	:notes,
 	:authContextKeycloakUserId
 )
-RETURNING changemaker_field_value_batch_to_json(changemaker_field_value_batches)
-	AS object;
+RETURNING changemaker_field_value_batch_to_json(
+	changemaker_field_value_batches,
+	:authContextKeycloakUserId,
+	:authContextIsAdministrator
+) AS object;

--- a/src/database/queries/changemakerFieldValueBatches/selectById.sql
+++ b/src/database/queries/changemakerFieldValueBatches/selectById.sql
@@ -1,6 +1,8 @@
 SELECT
 	changemaker_field_value_batch_to_json(
-		changemaker_field_value_batches.*
+		changemaker_field_value_batches.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
 	) AS object
 FROM changemaker_field_value_batches
 WHERE

--- a/src/database/queries/changemakerFieldValueBatches/selectWithPagination.sql
+++ b/src/database/queries/changemakerFieldValueBatches/selectWithPagination.sql
@@ -1,6 +1,9 @@
 SELECT
-	changemaker_field_value_batch_to_json(changemaker_field_value_batches.*)
-		AS object
+	changemaker_field_value_batch_to_json(
+		changemaker_field_value_batches.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM changemaker_field_value_batches
 WHERE
 	:authContextIsAdministrator::boolean

--- a/src/database/queries/changemakers/selectById.sql
+++ b/src/database/queries/changemakers/selectById.sql
@@ -1,3 +1,8 @@
-SELECT changemaker_to_json(changemakers.*, :authContextKeycloakUserId) AS object
+SELECT
+	changemaker_to_json(
+		changemakers.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM changemakers
 WHERE id = :changemakerId;

--- a/src/database/queries/changemakers/selectWithPagination.sql
+++ b/src/database/queries/changemakers/selectWithPagination.sql
@@ -1,6 +1,10 @@
 SELECT DISTINCT
 	o.id,
-	changemaker_to_json(o.*, :authContextKeycloakUserId) AS object
+	changemaker_to_json(
+		o.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM changemakers AS o
 	LEFT JOIN changemakers_proposals AS op ON o.id = op.changemaker_id
 WHERE

--- a/src/database/queries/changemakers/updateById.sql
+++ b/src/database/queries/changemakers/updateById.sql
@@ -8,4 +8,8 @@ SET
 		keycloak_organization_id
 	)
 WHERE id = :changemakerId
-RETURNING changemaker_to_json(changemakers) AS object;
+RETURNING changemaker_to_json(
+	changemakers,
+	:authContextKeycloakUserId,
+	:authContextIsAdministrator
+) AS object;

--- a/src/database/queries/changemakersProposals/insertOne.sql
+++ b/src/database/queries/changemakersProposals/insertOne.sql
@@ -5,4 +5,8 @@ INSERT INTO changemakers_proposals (
 	:changemakerId,
 	:proposalId
 )
-RETURNING changemaker_proposal_to_json(changemakers_proposals) AS object;
+RETURNING changemaker_proposal_to_json(
+	changemakers_proposals,
+	:authContextKeycloakUserId,
+	:authContextIsAdministrator
+) AS object;

--- a/src/database/queries/changemakersProposals/selectWithPagination.sql
+++ b/src/database/queries/changemakersProposals/selectWithPagination.sql
@@ -1,4 +1,9 @@
-SELECT changemaker_proposal_to_json(changemakers_proposals.*) AS object
+SELECT
+	changemaker_proposal_to_json(
+		changemakers_proposals.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM changemakers_proposals
 WHERE
 	CASE

--- a/src/database/queries/proposalVersions/insertOne.sql
+++ b/src/database/queries/proposalVersions/insertOne.sql
@@ -18,4 +18,8 @@ INSERT INTO proposal_versions (
 		1
 	)
 )
-RETURNING proposal_version_to_json(proposal_versions) AS object;
+RETURNING proposal_version_to_json(
+	proposal_versions,
+	:authContextKeycloakUserId,
+	:authContextIsAdministrator
+) AS object;

--- a/src/database/queries/proposalVersions/selectById.sql
+++ b/src/database/queries/proposalVersions/selectById.sql
@@ -1,11 +1,16 @@
-SELECT proposal_version_to_json(proposal_versions.*) AS object
+SELECT
+	proposal_version_to_json(
+		proposal_versions.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM proposal_versions
 WHERE
-	proposal_versions.id = :proposalVersionId
+	id = :proposalVersionId
 	AND has_proposal_permission(
 		:authContextKeycloakUserId,
 		:authContextIsAdministrator,
-		proposal_versions.proposal_id,
+		proposal_id,
 		'view',
 		'proposal'
 	);

--- a/src/database/queries/proposals/selectById.sql
+++ b/src/database/queries/proposals/selectById.sql
@@ -1,11 +1,16 @@
-SELECT proposal_to_json(proposals.*) AS object
+SELECT
+	proposal_to_json(
+		proposals.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM proposals
 WHERE
-	proposals.id = :proposalId
+	id = :proposalId
 	AND has_proposal_permission(
 		:authContextKeycloakUserId,
 		:authContextIsAdministrator,
-		proposals.id,
+		id,
 		'view',
 		'proposal'
 	);

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -1,4 +1,9 @@
-SELECT proposal_to_json(proposals.*) AS object
+SELECT
+	proposal_to_json(
+		proposals.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM proposals
 	INNER JOIN opportunities
 		ON proposals.opportunity_id = opportunities.id

--- a/src/database/queries/sources/deleteOne.sql
+++ b/src/database/queries/sources/deleteOne.sql
@@ -1,4 +1,8 @@
 DELETE FROM sources
 WHERE
 	id = :sourceId
-RETURNING source_to_json(sources) AS object;
+RETURNING source_to_json(
+	sources,
+	:authContextKeycloakUserId,
+	:authContextIsAdministrator
+) AS object;

--- a/src/database/queries/sources/insertOne.sql
+++ b/src/database/queries/sources/insertOne.sql
@@ -10,4 +10,8 @@ VALUES (
 	:funderShortCode,
 	:changemakerId
 )
-RETURNING source_to_json(sources) AS object;
+RETURNING source_to_json(
+	sources,
+	:authContextKeycloakUserId,
+	:authContextIsAdministrator
+) AS object;

--- a/src/database/queries/sources/selectById.sql
+++ b/src/database/queries/sources/selectById.sql
@@ -1,3 +1,8 @@
-SELECT source_to_json(sources.*) AS object
+SELECT
+	source_to_json(
+		sources.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM sources
 WHERE id = :sourceId;

--- a/src/database/queries/sources/selectSystemSource.sql
+++ b/src/database/queries/sources/selectSystemSource.sql
@@ -1,3 +1,8 @@
-SELECT source_to_json(sources.*) AS object
+SELECT
+	source_to_json(
+		sources.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM sources
 WHERE id = system_source_id();

--- a/src/database/queries/sources/selectWithPagination.sql
+++ b/src/database/queries/sources/selectWithPagination.sql
@@ -1,4 +1,9 @@
-SELECT source_to_json(sources.*) AS object
+SELECT
+	source_to_json(
+		sources.*,
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator
+	) AS object
 FROM sources
-ORDER BY sources.id DESC
+ORDER BY id DESC
 LIMIT :limit OFFSET :offset;

--- a/src/types/PermissionGrantEntityType.ts
+++ b/src/types/PermissionGrantEntityType.ts
@@ -92,10 +92,12 @@ const allowedScopesForContextEntityType: Record<
 	[PermissionGrantEntityType.CHANGEMAKER]: [
 		PermissionGrantEntityType.CHANGEMAKER,
 		PermissionGrantEntityType.PROPOSAL,
+		PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
 	],
 	[PermissionGrantEntityType.FUNDER]: [
 		PermissionGrantEntityType.FUNDER,
 		PermissionGrantEntityType.PROPOSAL,
+		PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
 	],
 	[PermissionGrantEntityType.DATA_PROVIDER]: [
 		PermissionGrantEntityType.DATA_PROVIDER,
@@ -103,8 +105,12 @@ const allowedScopesForContextEntityType: Record<
 	[PermissionGrantEntityType.OPPORTUNITY]: [
 		PermissionGrantEntityType.OPPORTUNITY,
 		PermissionGrantEntityType.PROPOSAL,
+		PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
 	],
-	[PermissionGrantEntityType.PROPOSAL]: [PermissionGrantEntityType.PROPOSAL],
+	[PermissionGrantEntityType.PROPOSAL]: [
+		PermissionGrantEntityType.PROPOSAL,
+		PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
+	],
 	[PermissionGrantEntityType.PROPOSAL_VERSION]: [
 		PermissionGrantEntityType.PROPOSAL_VERSION,
 	],


### PR DESCRIPTION
This PR creates permission support for `ProposalFieldValues`

Part of this involved making sure we were consistently passing in auth context to various `to_json` calls

Related to #2161