### PR TITLE
Fix broken migration

### DIFF
--- a/src/database/migrations/0088-migrate-opportunity-permissions-to-permission-grants.sql
+++ b/src/database/migrations/0088-migrate-opportunity-permissions-to-permission-grants.sql
@@ -67,4 +67,4 @@ SELECT deaudit_table('user_opportunity_permissions');
 SELECT deaudit_table('user_group_opportunity_permissions');
 DROP TABLE IF EXISTS user_opportunity_permissions CASCADE;
 DROP TABLE IF EXISTS user_group_opportunity_permissions CASCADE;
-DROP TYPE IF EXISTS opportunity_permission_t;
+DROP TYPE IF EXISTS opportunity_permission_t CASCADE;


### PR DESCRIPTION
The lack of cascade means that servers with older versions of has_opportunity_permission initialized would prevent the ability to drop the type.

It's bad form to change a migration, but this is a special case because the migration really was broken for any standing instance of the software.