### PR TITLE
Ignore expired user group associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Permission checks for userGroup-based grants now correctly ignore expired ephemeral user group associations.
+
 ## 0.31.0 2026-02-12
 
 ### Added

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -3,6 +3,7 @@ import { app } from '../app';
 import {
 	db,
 	createChangemaker,
+	createEphemeralUserGroupAssociation,
 	createOrUpdateDataProvider,
 	createOrUpdateFunder,
 	createSource,
@@ -27,6 +28,7 @@ import {
 	PermissionGrantGranteeType,
 	PermissionGrantVerb,
 	PostgresErrorCode,
+	stringToKeycloakId,
 } from '../types';
 
 const agent = request.agent(app);
@@ -321,6 +323,24 @@ describe('/sources', () => {
 				scope: [PermissionGrantEntityType.CHANGEMAKER],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
+
+			// Also create a userGroup permission grant with EDIT verb but an EXPIRED association
+			// to verify that expired associations don't grant access
+			const expiredOrgId = 'eeeeeeee-1111-2222-3333-444444444444';
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER_GROUP,
+				granteeKeycloakOrganizationId: stringToKeycloakId(expiredOrgId),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.EDIT],
+			});
+			await createEphemeralUserGroupAssociation(db, null, {
+				userKeycloakUserId: testUser.keycloakUserId,
+				userGroupKeycloakOrganizationId: stringToKeycloakId(expiredOrgId),
+				notAfter: new Date(Date.now() - 3600000).toISOString(), // Expired 1 hour ago
+			});
+
 			const before = await loadTableMetrics('sources');
 			const result = await agent
 				.post('/sources')
@@ -435,6 +455,24 @@ describe('/sources', () => {
 				scope: [PermissionGrantEntityType.FUNDER],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
+
+			// Also create a userGroup permission grant with EDIT verb but an EXPIRED association
+			// to verify that expired associations don't grant access
+			const expiredOrgId = 'ffffffff-1111-2222-3333-444444444444';
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER_GROUP,
+				granteeKeycloakOrganizationId: stringToKeycloakId(expiredOrgId),
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: funder.shortCode,
+				scope: [PermissionGrantEntityType.FUNDER],
+				verbs: [PermissionGrantVerb.EDIT],
+			});
+			await createEphemeralUserGroupAssociation(db, null, {
+				userKeycloakUserId: testUser.keycloakUserId,
+				userGroupKeycloakOrganizationId: stringToKeycloakId(expiredOrgId),
+				notAfter: new Date(Date.now() - 3600000).toISOString(), // Expired 1 hour ago
+			});
+
 			const before = await loadTableMetrics('sources');
 			const result = await agent
 				.post('/sources')
@@ -538,6 +576,24 @@ describe('/sources', () => {
 				scope: [PermissionGrantEntityType.DATA_PROVIDER],
 				verbs: [PermissionGrantVerb.MANAGE, PermissionGrantVerb.VIEW],
 			});
+
+			// Also create a userGroup permission grant with EDIT verb but an EXPIRED association
+			// to verify that expired associations don't grant access
+			const expiredOrgId = '11111111-aaaa-bbbb-cccc-dddddddddddd';
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER_GROUP,
+				granteeKeycloakOrganizationId: stringToKeycloakId(expiredOrgId),
+				contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
+				dataProviderShortCode: dataProvider.shortCode,
+				scope: [PermissionGrantEntityType.DATA_PROVIDER],
+				verbs: [PermissionGrantVerb.EDIT],
+			});
+			await createEphemeralUserGroupAssociation(db, null, {
+				userKeycloakUserId: testUser.keycloakUserId,
+				userGroupKeycloakOrganizationId: stringToKeycloakId(expiredOrgId),
+				notAfter: new Date(Date.now() - 3600000).toISOString(), // Expired 1 hour ago
+			});
+
 			const before = await loadTableMetrics('sources');
 			const result = await agent
 				.post('/sources')

--- a/src/database/initialization/has_changemaker_permission.sql
+++ b/src/database/initialization/has_changemaker_permission.sql
@@ -38,6 +38,7 @@ BEGIN
 							= has_changemaker_permission.user_keycloak_user_id
 							AND euga.user_group_keycloak_organization_id
 								= pg.grantee_keycloak_organization_id
+							AND NOT is_expired(euga.not_after)
 					)
 				)
 			)

--- a/src/database/initialization/has_data_provider_permission.sql
+++ b/src/database/initialization/has_data_provider_permission.sql
@@ -38,6 +38,7 @@ BEGIN
 							= has_data_provider_permission.user_keycloak_user_id
 							AND euga.user_group_keycloak_organization_id
 								= pg.grantee_keycloak_organization_id
+							AND NOT is_expired(euga.not_after)
 					)
 				)
 			)

--- a/src/database/initialization/has_funder_permission.sql
+++ b/src/database/initialization/has_funder_permission.sql
@@ -38,6 +38,7 @@ BEGIN
 							= has_funder_permission.user_keycloak_user_id
 							AND euga.user_group_keycloak_organization_id
 								= pg.grantee_keycloak_organization_id
+							AND NOT is_expired(euga.not_after)
 					)
 				)
 			)

--- a/src/database/initialization/has_opportunity_permission.sql
+++ b/src/database/initialization/has_opportunity_permission.sql
@@ -48,6 +48,7 @@ BEGIN
 							= has_opportunity_permission.user_keycloak_user_id
 							AND euga.user_group_keycloak_organization_id
 								= pg.grantee_keycloak_organization_id
+							AND NOT is_expired(euga.not_after)
 					)
 				)
 			)

--- a/src/database/initialization/has_proposal_field_value_permission.sql
+++ b/src/database/initialization/has_proposal_field_value_permission.sql
@@ -71,6 +71,7 @@ BEGIN
 							= has_proposal_field_value_permission.user_keycloak_user_id
 							AND euga.user_group_keycloak_organization_id
 								= pg.grantee_keycloak_organization_id
+							AND NOT is_expired(euga.not_after)
 					)
 				)
 			)

--- a/src/database/initialization/has_proposal_permission.sql
+++ b/src/database/initialization/has_proposal_permission.sql
@@ -63,6 +63,7 @@ BEGIN
 							= has_proposal_permission.user_keycloak_user_id
 							AND euga.user_group_keycloak_organization_id
 								= pg.grantee_keycloak_organization_id
+							AND NOT is_expired(euga.not_after)
 					)
 				)
 			)


### PR DESCRIPTION
This PR fixes an issue where expired organization associations were still considered during permission checks.


Resolves #2241