### PR TITLE
Update `ProposalFieldValue` checks to incorporate sensitivity

### DIFF
--- a/src/database/initialization/changemaker_to_json.sql
+++ b/src/database/initialization/changemaker_to_json.sql
@@ -63,7 +63,6 @@ BEGIN
 				ON pv.source_id = s.id
 			WHERE op.changemaker_id = changemaker.id
 				AND bf.category = 'organization'
-				AND bf.sensitivity_classification != 'forbidden'
 				AND pfv.is_valid
 				-- Guard against possible removal of NON NULL constraint on users table:
 				AND u.keycloak_user_id IS NOT NULL

--- a/src/database/initialization/proposal_version_to_json.sql
+++ b/src/database/initialization/proposal_version_to_json.sql
@@ -16,21 +16,13 @@ BEGIN
 	)
 	INTO proposal_field_values_json
 	FROM proposal_field_values
-	INNER JOIN application_form_fields
-		ON proposal_field_values.application_form_field_id = application_form_fields.id
-	INNER JOIN base_fields
-		ON application_form_fields.base_field_short_code = base_fields.short_code
 	WHERE proposal_field_values.proposal_version_id = proposal_version.id
-		AND base_fields.sensitivity_classification != 'forbidden'
-		AND (
-			auth_context_is_administrator
-			OR has_proposal_field_value_permission(
-				auth_context_keycloak_user_id,
-				auth_context_is_administrator,
-				proposal_field_values.id,
-				'view',
-				'proposalFieldValue'
-			)
+		AND has_proposal_field_value_permission(
+			auth_context_keycloak_user_id,
+			auth_context_is_administrator,
+			proposal_field_values.id,
+			'view',
+			'proposalFieldValue'
 		);
 
 	SELECT source_to_json(


### PR DESCRIPTION
This PR consolidates logic for checking base field sensitivity to determine visibility of proposal field values

It doesn't change that logic; it just puts it in a more correct place (which decreases the odds of bugs down the line)

Related to #2243