### PR TITLE
Fix actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
       - name: Lint GitHub Action workflows
         uses: raven-actions/actionlint@v2
 


### PR DESCRIPTION
This PR fixes an issue where the actionlint job wasn't running on a specified version of node (which means it was running on a version that is older than required).