### PR TITLE
Check `Proposal` scope for `ProposalVersion` actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ProposalVersion creation now requires `edit | proposal` scope (checked via `has_proposal_permission`) instead of `edit | funder` scope. Existing funder permission grants with `edit` verb and `funder` scope have been migrated to also include `proposal` scope.
 - Opportunity creation now requires `create | opportunity` scope on funder permission grants (previously `edit | funder`).
 - Viewing opportunities, application forms, application form fields, and bulk upload tasks now uses `opportunity` scope instead of `funder` scope.
 - Creating and editing application forms and application form fields now uses `edit | opportunity` scope instead of `edit | funder`.

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -235,9 +235,9 @@ context key).
 | create | proposal           | Create proposals for the funder's opportunities                   |
 |        |                    | Create bulk upload tasks for the funder's opportunities           |
 | edit   | opportunity        | Create or update application forms and fields for the funder      |
-| edit   | funder             | Create or update proposal versions for the funder's proposals     |
-|        |                    | Create or update changemaker-proposal associations                |
+| edit   | funder             | Create or update changemaker-proposal associations                |
 |        |                    | Create sources associated with the funder                         |
+| edit   | proposal           | Create or update proposal versions for the funder's proposals     |
 | manage | funder             | View, send, and respond to funder collaborative invitations       |
 |        |                    | View collaborative members for the funder                         |
 
@@ -246,15 +246,16 @@ context key).
 Permissions granted against a changemaker (using the changemaker's `id` as the
 context key).
 
-| Verb | Scope              | What It Enables                                            |
-| ---- | ------------------ | ---------------------------------------------------------- |
-| view | changemaker        | View changemaker field values for the changemaker          |
-| view | proposal           | View proposals associated with the changemaker             |
-|      |                    | View proposal versions associated with the changemaker     |
-|      |                    | View changemaker-proposal associations for the changemaker |
-| view | proposalFieldValue | View proposal field values for the changemaker's proposals |
-| edit | changemaker        | Create or update changemaker field values                  |
-|      |                    | Create sources associated with the changemaker             |
+| Verb | Scope              | What It Enables                                                    |
+| ---- | ------------------ | ------------------------------------------------------------------ |
+| view | changemaker        | View changemaker field values for the changemaker                  |
+| view | proposal           | View proposals associated with the changemaker                     |
+|      |                    | View proposal versions associated with the changemaker             |
+|      |                    | View changemaker-proposal associations for the changemaker         |
+| view | proposalFieldValue | View proposal field values for the changemaker's proposals         |
+| edit | changemaker        | Create or update changemaker field values                          |
+|      |                    | Create sources associated with the changemaker                     |
+| edit | proposal           | Create or update proposal versions for the changemaker's proposals |
 
 ### Opportunity Permissions
 
@@ -273,6 +274,7 @@ for specific opportunities.
 | view   | proposalFieldValue | View proposal field values for the opportunity's proposals             |
 | create | proposal           | Create proposals for the specific opportunity                          |
 |        |                    | Create bulk upload tasks for the specific opportunity                  |
+| edit   | proposal           | Create or update proposal versions for the opportunity's proposals     |
 
 ### Proposal Permissions
 
@@ -286,6 +288,7 @@ proposals.
 |      |                    | View proposal versions for the proposal                 |
 |      |                    | View changemaker-proposal associations for the proposal |
 | view | proposalFieldValue | View proposal field values for the proposal             |
+| edit | proposal           | Create or update proposal versions for the proposal     |
 
 ### ProposalFieldValue Permissions
 

--- a/src/database/migrations/0093-add-proposal-scope-to-funder-edit-grants.sql
+++ b/src/database/migrations/0093-add-proposal-scope-to-funder-edit-grants.sql
@@ -1,0 +1,7 @@
+UPDATE permission_grants
+SET scope = array_append(scope, 'proposal'::permission_grant_entity_type_t)
+WHERE
+	context_entity_type = 'funder'
+	AND 'edit' = any(verbs)
+	AND 'funder' = any(scope)
+	AND NOT ('proposal' = any(scope));

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -3,10 +3,9 @@ import {
 	createProposalFieldValue,
 	createProposalVersion,
 	db,
-	hasFunderPermission,
+	hasProposalPermission,
 	loadApplicationForm,
 	loadApplicationFormField,
-	loadOpportunity,
 	loadProposal,
 	loadProposalVersion,
 } from '../database';
@@ -140,12 +139,11 @@ const postProposalVersion = async (
 	const { sourceId, fieldValues, proposalId, applicationFormId } = body;
 	try {
 		const proposal = await loadProposal(db, req, proposalId);
-		const opportunity = await loadOpportunity(db, req, proposal.opportunityId);
 		if (
-			!(await hasFunderPermission(db, req, {
-				funderShortCode: opportunity.funderShortCode,
+			!(await hasProposalPermission(db, req, {
+				proposalId: proposal.id,
 				permission: PermissionGrantVerb.EDIT,
-				scope: PermissionGrantEntityType.FUNDER,
+				scope: PermissionGrantEntityType.PROPOSAL,
 			}))
 		) {
 			throw new UnprocessableEntityError(


### PR DESCRIPTION
This PR updates our permission checks for `ProposalVersion` operations to use the `Proposal` scope.  This means that if a user has the right to edit a *proposal* (not a funder) they will have the right to create new proposal versions.

Resolves #2256