### PR TITLE
Document Application Form Field Rendering Hints (inputTypes)

### DIFF
--- a/docs/APPLICATION_RENDERING_HINTS.md
+++ b/docs/APPLICATION_RENDERING_HINTS.md
@@ -1,0 +1,132 @@
+# Application Form Field Rendering Hints (Input Types)
+
+The `inputType` field on an `ApplicationFormField` serves as a rendering hint
+for UIs that display application forms. It allows form designers to specify
+how a field should be presented to the user, independently of the field's
+underlying data type.
+
+## Overview
+
+Each `ApplicationFormField` has two related but distinct attributes that
+together describe how a field should be handled:
+
+- **`baseField.dataType`** — describes the _semantic type_ of the data being
+  collected (e.g., `string`, `number`, `email`, `url`). The PDC service uses
+  this for data validation.
+- **`inputType`** — describes the _preferred UI control_ for collecting that
+  data. This is purely a rendering hint; the service does not enforce
+  constraints based on `inputType`.
+
+When `inputType` is `null`, the UI should fall back to a sensible default
+rendering based on `baseField.dataType`, that enforces the data type
+at the user experience level.
+
+## Input Type Values
+
+These are the currently supported inputType values in the
+service.
+
+| Value         | Description                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| `shortText`   | A single-line text input. Suitable for brief, unformatted responses.                                  |
+| `longText`    | A multi-line textarea. Suitable for narrative or free-form responses.                                 |
+| `radio`       | A set of mutually exclusive options displayed as radio buttons.                                       |
+| `dropdown`    | A set of mutually exclusive options displayed in a dropdown (select) menu.                            |
+| `multiselect` | A control that allows one or more options to be selected simultaneously.                              |
+| `hidden`      | The field is not displayed to the applicant. Useful for tracking metadata or system-populated values. |
+
+## Relationship to `baseField.dataType`
+
+The `inputType` and `dataType` are independent of each other in the API, but
+UIs should use them together to render fields sensibly. For example, a field
+with `dataType: "string"` could reasonably be rendered as `shortText`,
+`longText`, `radio`, `dropdown`, or `multiselect` depending on the intended
+use. A field with `dataType: "boolean"` might be rendered as `radio` buttons
+offering "Yes" / "No" options.
+
+The service does not validate that a given `inputType` is appropriate for a
+given `dataType`; that responsibility lies with form designers and the
+consuming UI.
+
+## Null `inputType`
+
+An `inputType` of `null` means no rendering hint has been specified. UIs
+encountering a `null` `inputType` should apply their own default rendering
+logic based on `baseField.dataType`. For instance:
+
+- `string` → single-line text input
+- `number` or `currency` → numeric input
+- `boolean` → checkbox or radio buttons
+- `email` → email input
+- `url` → URL input
+- `phone_number` → telephone input
+- `file` → file upload control
+
+## API Usage
+
+The `inputType` field is returned in `ApplicationFormField` responses. It can
+be set at creation time or updated later via patch.
+
+### Setting `inputType` when creating an application form
+
+`ApplicationFormField` records are created as part of `POST /applicationForms`.
+Include `inputType` in each entry of the `fields` array:
+
+```json
+{
+	"opportunityId": 3203,
+	"name": "2025 Grant Application",
+	"fields": [
+		{
+			"baseFieldShortCode": "project_description",
+			"position": 2,
+			"label": "Describe your project",
+			"instructions": "Please provide a detailed description of your proposed project.",
+			"inputType": "longText"
+		}
+	]
+}
+```
+
+### Patching `inputType` on an existing application form field
+
+Use `PATCH /applicationFormFields/{applicationFormFieldId}` to update `label`,
+`instructions`, and/or `inputType` on an existing field:
+
+```json
+{
+	"inputType": "radio"
+}
+```
+
+To clear a previously set `inputType` and revert to default rendering, patch
+the field with `"inputType": null`.
+
+### Example `ApplicationFormField` response
+
+```json
+{
+	"id": 42,
+	"applicationFormId": 7,
+	"baseFieldShortCode": "project_description",
+	"position": 2,
+	"label": "Describe your project",
+	"instructions": "Please provide a detailed description of your proposed project.",
+	"inputType": "longText",
+	"createdAt": "2026-01-15T12:00:00Z",
+	"baseField": {
+		"shortCode": "project_description",
+		"label": "Project Description",
+		"description": "A description of the project for which funding is sought.",
+		"dataType": "string",
+		"category": "project",
+		"valueRelevanceHours": null,
+		"sensitivityClassification": "public",
+		"localizations": {},
+		"createdAt": "2025-06-01T00:00:00Z"
+	}
+}
+```
+
+The OpenAPI schema for the enumerated values is defined in
+`src/openapi/components/schemas/ApplicationFormFieldInputType.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1056,6 +1056,7 @@
 			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
@@ -2748,6 +2749,7 @@
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -4484,6 +4486,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
 			"integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -4687,6 +4690,7 @@
 			"integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.54.0",
 				"@typescript-eslint/types": "8.54.0",
@@ -5204,6 +5208,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5245,6 +5250,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -5739,6 +5745,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001718",
 				"electron-to-chromium": "^1.5.160",
@@ -6960,6 +6967,7 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7769,6 +7777,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -9306,6 +9315,7 @@
 			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.2.0",
 				"@jest/types": "30.2.0",
@@ -11103,6 +11113,7 @@
 			"integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/mobx"
@@ -11180,6 +11191,7 @@
 			"resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.13.tgz",
 			"integrity": "sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"fp-ts": "^2.5.0"
 			}
@@ -11277,6 +11289,7 @@
 			"integrity": "sha512-u5xUnYE+UOOBA6SpELJheMCtj2Laqx15Vl70QxKo43Wz/6nMHXS7PrEioXLjXAwhmawdEMNImwKCcPhBJWbKVw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@mswjs/interceptors": "^0.41.0",
 				"json-stringify-safe": "^5.0.1",
@@ -11900,6 +11913,7 @@
 			"version": "8.11.3",
 			"resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
 			"integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
+			"peer": true,
 			"dependencies": {
 				"buffer-writer": "2.0.0",
 				"packet-reader": "1.0.0",
@@ -12524,6 +12538,7 @@
 			"integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -12534,6 +12549,7 @@
 			"integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -13755,6 +13771,7 @@
 			"integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@emotion/is-prop-valid": "1.2.2",
 				"@emotion/unitless": "0.8.1",
@@ -14085,6 +14102,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -14305,6 +14323,7 @@
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -14513,6 +14532,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -14620,6 +14640,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.2.2"
 			},

--- a/src/openapi/paths/applicationFormField.json
+++ b/src/openapi/paths/applicationFormField.json
@@ -1,7 +1,7 @@
 {
 	"patch": {
 		"operationId": "updateApplicationFormFieldById",
-		"summary": "Updates the label and/or instructions of a specific application form field.",
+		"summary": "Updates the label, instructions, and/or inputType of a specific application form field.",
 		"tags": ["Application Forms"],
 		"security": [
 			{


### PR DESCRIPTION
This PR adds explicit documentation for the intended usage of applicationFormField inputTypes, which are intended as rendering 'hints' (not enforced at the data level) for UIs consuming the pdc. Importantly, baseField DataTypes are the data type that will be enforced by the service, and should be considered the 'root' definition of how the input should be rendered (i.e an applicationFormField may have a null inputType, but a 'number' basefield datatype, in which case the basefield datatype will be the defining field for how the input is rendered).

Closes #2263