### PR TITLE
Drop and create PR deploy preview databases

### DIFF
--- a/.github/workflows/preview-db.yml
+++ b/.github/workflows/preview-db.yml
@@ -1,0 +1,47 @@
+name: Drop and create preview DBs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+env:
+  CONNECTION_STRING: ${{ secrets.DEPLOY_PREVIEWS_PSQL_CONNECTION_STRING }}
+  DATABASE_NAME: preview_${{ github.event.pull_request.number }}
+
+concurrency:
+  group: preview-db-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  create-db:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["opened", "reopened", "synchronize"]'), github.event.action)
+    container:
+      image: alpine/psql:latest
+      env:
+        CONNECTION: ${{ env.CONNECTION_STRING }}
+        DB_NAME: ${{ env.DATABASE_NAME }}
+        PGSSLMODE: verify-full
+    steps:
+      - name: Create a database for this PR on the "deploy previews" cluster
+        run: |
+          psql "${CONNECTION}" -c "DROP DATABASE IF EXISTS ${DB_NAME};"
+          psql "${CONNECTION}" -c "CREATE DATABASE ${DB_NAME} TEMPLATE pdc;"
+
+  drop-db:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.action == 'closed'
+    container:
+      image: alpine/psql:latest
+      env:
+        CONNECTION: ${{ env.CONNECTION_STRING }}
+        DB_NAME: ${{ env.DATABASE_NAME }}
+        PGSSLMODE: verify-full
+    steps:
+      - name: Drop a database for this PR on the "deploy previews" cluster
+        run: |
+          psql "${CONNECTION}" -c "DROP DATABASE IF EXISTS ${DB_NAME};"


### PR DESCRIPTION
Deploy previews of the service/framework back-end need their own database instances. For most environments we isolate data by database cluster but for the deploy preview environment we isolate by database instance within a cluster (PostgreSQL instance).

This action drops and creates deploy preview databases on a single shared database cluster. It uses the `pdc` database as a template which (as of this writing) is a snapshot of the sandbox database on April 3, 2026.

Further lifecycle changes to this script may be needed. We may not want to run this action on every PR event but condition it on other events and/or separate actions' outcomes. On the other hand, this action incurs no cost other than disk space within an existing cluster so it may be fine in this simple form.

Issue #1275 Build out PR deploy previews