### PR TITLE
Add date validation to date fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `BaseField` can now be of type `date` and `date_time`.
 - `GET /changemakers` now supports the `_content` query parameter to search changemakers by name using full-text search.
 - Permission grants now support optional `conditions` that restrict which entities the grant applies to based on entity data. The initial implementation supports filtering `proposalFieldValue` scope by `baseFieldCategory` using the `in` operator.
 - Permission grants can now be updated via `PUT /permissionGrants/:permissionGrantId`. All mutable fields are replaced with the provided values.

--- a/docs/APPLICATION_RENDERING_HINTS.md
+++ b/docs/APPLICATION_RENDERING_HINTS.md
@@ -61,6 +61,7 @@ logic based on `baseField.dataType`. For instance:
 - `url` → URL input
 - `phone_number` → telephone input
 - `file` → file upload control
+- `date` or `date_time` → date picker
 
 ## API Usage
 

--- a/src/__tests__/baseFields.int.test.ts
+++ b/src/__tests__/baseFields.int.test.ts
@@ -230,6 +230,70 @@ describe('/baseFields', () => {
 			expect(after.count).toEqual(1);
 		});
 
+		it('supports creation of date-type base fields', async () => {
+			const db = getDatabase();
+			const before = await loadTableMetrics(db, 'base_fields');
+			const result = await request(app)
+				.put('/baseFields/shorts')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					label: '🏷️',
+					description: '😍',
+					dataType: BaseFieldDataType.DATE,
+					category: BaseFieldCategory.PROJECT,
+					valueRelevanceHours: null,
+					sensitivityClassification: BaseFieldSensitivityClassification.PUBLIC,
+				})
+				.expect(200);
+			const after = await loadTableMetrics(db, 'base_fields');
+			expect(before.count).toEqual(0);
+			expect(result.body).toMatchObject({
+				label: '🏷️',
+				description: '😍',
+				shortCode: 'shorts',
+				dataType: BaseFieldDataType.DATE,
+				category: BaseFieldCategory.PROJECT,
+				valueRelevanceHours: null,
+				sensitivityClassification: BaseFieldSensitivityClassification.PUBLIC,
+				localizations: {},
+				createdAt: expectTimestamp(),
+			});
+			expect(after.count).toEqual(1);
+		});
+
+		it('supports creation of date_time-type base fields', async () => {
+			const db = getDatabase();
+			const before = await loadTableMetrics(db, 'base_fields');
+			const result = await request(app)
+				.put('/baseFields/shorts')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					label: '🏷️',
+					description: '😍',
+					dataType: BaseFieldDataType.DATETIME,
+					category: BaseFieldCategory.PROJECT,
+					valueRelevanceHours: null,
+					sensitivityClassification: BaseFieldSensitivityClassification.PUBLIC,
+				})
+				.expect(200);
+			const after = await loadTableMetrics(db, 'base_fields');
+			expect(before.count).toEqual(0);
+			expect(result.body).toMatchObject({
+				label: '🏷️',
+				description: '😍',
+				shortCode: 'shorts',
+				dataType: BaseFieldDataType.DATETIME,
+				category: BaseFieldCategory.PROJECT,
+				valueRelevanceHours: null,
+				sensitivityClassification: BaseFieldSensitivityClassification.PUBLIC,
+				localizations: {},
+				createdAt: expectTimestamp(),
+			});
+			expect(after.count).toEqual(1);
+		});
+
 		it('returns 400 bad request when no label is sent', async () => {
 			const result = await request(app)
 				.put('/baseFields/shorts')

--- a/src/__tests__/fieldValidation.unit.test.ts
+++ b/src/__tests__/fieldValidation.unit.test.ts
@@ -7,6 +7,37 @@ describe('field value validation against BaseFieldDataType', () => {
 			true,
 		);
 	});
+	test('validate a valid date-only string as DATE', () => {
+		expect(fieldValueIsValid('2014-12-01', BaseFieldDataType.DATE)).toBe(true);
+	});
+	test('validate a invalid date-only string as DATE', () => {
+		expect(fieldValueIsValid('10-12-01', BaseFieldDataType.DATE)).toBe(false);
+		expect(fieldValueIsValid('2025-02-30', BaseFieldDataType.DATE)).toBe(false);
+		expect(fieldValueIsValid('2005', BaseFieldDataType.DATE)).toBe(false);
+		expect(fieldValueIsValid('12/1/2001', BaseFieldDataType.DATE)).toBe(false);
+		expect(fieldValueIsValid('March 5, 1999', BaseFieldDataType.DATE)).toBe(
+			false,
+		);
+	});
+	test('validate a valid date-time string as DATETIME', () => {
+		expect(
+			fieldValueIsValid('1985-04-12T23:20:50.52Z', BaseFieldDataType.DATETIME),
+		).toBe(true);
+		expect(
+			fieldValueIsValid(
+				'1996-12-19T16:39:57-08:00',
+				BaseFieldDataType.DATETIME,
+			),
+		).toBe(true);
+	});
+	test('validate a invalid date-time string as DATETIME', () => {
+		expect(
+			fieldValueIsValid('2025-01-30T00:10:39', BaseFieldDataType.DATETIME),
+		).toBe(false);
+		expect(
+			fieldValueIsValid('2025-02-30 10pm', BaseFieldDataType.DATETIME),
+		).toBe(false);
+	});
 	test('validate a valid numeric string as NUMBER', () => {
 		expect(fieldValueIsValid('123456', BaseFieldDataType.NUMBER)).toBe(true);
 		expect(fieldValueIsValid(' 123456 ', BaseFieldDataType.NUMBER)).toBe(true);

--- a/src/ajv.ts
+++ b/src/ajv.ts
@@ -21,6 +21,6 @@ ajv.addKeyword({
 });
 
 ajvKeywords(ajv, 'instanceof');
-addFormats(ajv, ['email', 'uri', 'uuid']);
+addFormats(ajv, ['email', 'uri', 'uuid', 'date', 'date-time']);
 
 export { ajv, type TypeGuardWithAjvErrors };

--- a/src/database/migrations/0100-alter-base_fields-add-date-datetime.sql
+++ b/src/database/migrations/0100-alter-base_fields-add-date-datetime.sql
@@ -1,0 +1,17 @@
+CREATE TYPE updated_field_type AS ENUM (
+	'string',
+	'number',
+	'phone_number',
+	'email',
+	'url',
+	'boolean',
+	'currency',
+	'file',
+	'date',
+	'date_time'
+);
+ALTER TABLE base_fields
+ALTER COLUMN data_type TYPE updated_field_type USING
+data_type::text::updated_field_type;
+DROP TYPE field_type CASCADE;
+ALTER TYPE updated_field_type RENAME TO field_type;

--- a/src/fieldValidation.ts
+++ b/src/fieldValidation.ts
@@ -2,6 +2,16 @@ import validator from 'validator';
 import { BaseFieldDataType, isId } from './types';
 import { ajv } from './ajv';
 
+const isDateString = ajv.compile({
+	type: 'string',
+	format: 'date',
+});
+
+const isDateTimeString = ajv.compile({
+	type: 'string',
+	format: 'date-time',
+});
+
 const isEmailString = ajv.compile({
 	type: 'string',
 	format: 'email',
@@ -85,6 +95,10 @@ export const fieldValueIsValid = (
 			return isCurrencyWithCodeString(fieldValue);
 		case BaseFieldDataType.FILE:
 			return isIdString(fieldValue);
+		case BaseFieldDataType.DATE:
+			return isDateString(fieldValue);
+		case BaseFieldDataType.DATETIME:
+			return isDateTimeString(fieldValue);
 		default:
 			return isString(fieldValue);
 	}

--- a/src/openapi/components/schemas/BaseField.json
+++ b/src/openapi/components/schemas/BaseField.json
@@ -31,7 +31,9 @@
 				"url",
 				"boolean",
 				"currency",
-				"file"
+				"file",
+				"date",
+				"date_time"
 			],
 			"example": "string"
 		},

--- a/src/types/BaseField.ts
+++ b/src/types/BaseField.ts
@@ -14,6 +14,8 @@ export enum BaseFieldDataType {
 	BOOLEAN = 'boolean',
 	CURRENCY = 'currency',
 	FILE = 'file',
+	DATE = 'date',
+	DATETIME = 'date_time',
 }
 
 enum BaseFieldCategory {


### PR DESCRIPTION
Adds date validation, allowing either `date` or `date-time` (timezone required) per [ajv-formats](https://github.com/ajv-validator/ajv-formats)

Resolves #285 