### PR TITLE
Use gold database for tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,18 @@ PGUSER=${PGUSER}
 PGPASSWORD=${PGPASSWORD}
 PGDATABASE=${PGDATABASE}
 
+# Test Database Settings
+# Integration tests create and drop temporary databases, which requires the
+# CREATEDB privilege. To limit blast radius, tests use a dedicated PostgreSQL
+# user that is separate from the application user. All TEST_PG* variables must
+# be set to run integration tests.
+# The test user must have the CREATEDB privilege:
+#   CREATE USER pdc_test WITH PASSWORD 'pdc_test' CREATEDB;
+TEST_PGHOST=${TEST_PGHOST}
+TEST_PGPORT=${TEST_PGPORT}
+TEST_PGUSER=${TEST_PGUSER}
+TEST_PGPASSWORD=${TEST_PGPASSWORD}
+
 # `AUTH_SERVER_ISSUER` serves two purposes related to authentication via JSON Web Tokens (JWTs):
 # 1. The "issuer" of a Bearer JWT in the Authorization header needs to match this value.
 # 2. The public key of the JWT issuer is found via

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,11 @@ jobs:
           PGPORT: 5432
           PGUSER: postgres
           PGPASSWORD: postgres
+          PGDATABASE: postgres
+          TEST_PGHOST: localhost
+          TEST_PGPORT: 5432
+          TEST_PGUSER: postgres
+          TEST_PGPASSWORD: postgres
           AUTH_SERVER_ISSUER: https://totally-fake-server-name/realms/pdc
           OPENAPI_DOCS_AUTH_CLIENT_ID: pdc-fake-client-id
           S3_ACCESS_KEY_ID: fake-access-key-id

--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -15,12 +15,17 @@ module.exports = {
 	...config,
 	collectCoverage: true,
 	collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.*', '!src/test/**'],
+	// Each worker uses up to 11 PostgreSQL connections (10 pool + 1 admin).
+	// Cap at 9 workers to stay within PostgreSQL's default max_connections of 100.
+	maxWorkers: 9,
 	projects: [
 		{
 			...commonProjectConfig,
 			displayName: 'integration',
 			testMatch: ['**/*.int.test.ts'],
 			setupFilesAfterEnv: ['<rootDir>/src/test/integrationSuiteSetup.ts'],
+			globalSetup: '<rootDir>/src/test/integrationGlobalSetup.ts',
+			globalTeardown: '<rootDir>/src/test/integrationGlobalTeardown.ts',
 		},
 		{
 			...commonProjectConfig,

--- a/jest.config.int.js
+++ b/jest.config.int.js
@@ -1,4 +1,9 @@
 var config = require('./jest.config.base.js');
 config.testMatch = ['**/?(*.)+(int).(spec|test).[jt]s?(x)'];
 config.setupFilesAfterEnv = ['<rootDir>/src/test/integrationSuiteSetup.ts'];
+config.globalSetup = '<rootDir>/src/test/integrationGlobalSetup.ts';
+config.globalTeardown = '<rootDir>/src/test/integrationGlobalTeardown.ts';
+// Each worker uses up to 11 PostgreSQL connections (10 pool + 1 admin).
+// Cap at 9 workers to stay within PostgreSQL's default max_connections of 100.
+config.maxWorkers = 9;
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
 		"start": "ts-node src/index.ts | pino-pretty",
 		"test": "npm run test:unit && npm run test:integration",
 		"test:unit": "jest --config=jest.config.unit.js",
-		"test:integration": "jest --config=jest.config.int.js --runInBand",
-		"test:ci": "jest --config=jest.config.ci.js --runInBand"
+		"test:integration": "jest --config=jest.config.int.js",
+		"test:ci": "jest --config=jest.config.ci.js"
 	},
 	"repository": {
 		"type": "git",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './exitCodes';
 export * from './httpStatus';
 export * from './numbers';
+export * from './testDatabasePrefix';
 export * from './time';

--- a/src/constants/testDatabasePrefix.ts
+++ b/src/constants/testDatabasePrefix.ts
@@ -1,0 +1,9 @@
+/**
+ * All test databases are named with this prefix. The test infrastructure
+ * enforces this on CREATE/DROP, and the application refuses to start if
+ * PGDATABASE matches it, preventing accidental use of a test database
+ * in a non-test context.
+ */
+const TEST_DATABASE_PREFIX = 'pdc_test';
+
+export { TEST_DATABASE_PREFIX };

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -17,13 +17,26 @@ const getDatabase = (): TinyPg => {
 	return db;
 };
 
-const setDatabase = (newDb: TinyPg): void => {
+const createAndSetDatabase = (connectionString?: string): TinyPg => {
+	const newDb = createDatabase(connectionString);
 	db = newDb;
+	return newDb;
 };
 
-const createDatabase = (): TinyPg => {
+const closeDatabase = async (): Promise<void> => {
+	const current = db;
+	if (current !== null) {
+		db = null;
+		await current.close();
+	}
+};
+
+const createDatabase = (connectionString?: string): TinyPg => {
 	const newDb = new TinyPg({
 		root_dir: [path.resolve(__dirname, 'queries')],
+		...(connectionString === undefined
+			? {}
+			: { connection_string: connectionString }),
 	});
 
 	newDb.pool.on('connect', (client) => {
@@ -33,6 +46,14 @@ const createDatabase = (): TinyPg => {
 	});
 
 	return newDb;
+};
+
+const getDatabaseName = async (db: TinyPg): Promise<string> => {
+	const { rows } = await db.query<{ current_database: string }>(
+		'SELECT current_database()',
+	);
+	const [row] = rows;
+	return row?.current_database ?? '';
 };
 
 const initializeDatabase = async (db: TinyPg): Promise<TinyPg> => {
@@ -51,4 +72,11 @@ const initializeDatabase = async (db: TinyPg): Promise<TinyPg> => {
 	return db;
 };
 
-export { createDatabase, initializeDatabase, setDatabase, getDatabase };
+export {
+	closeDatabase,
+	createAndSetDatabase,
+	createDatabase,
+	getDatabase,
+	getDatabaseName,
+	initializeDatabase,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-import { createDatabase, initializeDatabase, setDatabase } from './database';
+import {
+	closeDatabase,
+	createAndSetDatabase,
+	getDatabaseName,
+	initializeDatabase,
+} from './database';
+import { TEST_DATABASE_PREFIX } from './constants';
 import { app } from './app';
 import { startJobQueue } from './jobQueue';
 import { getLogger } from './logger';
@@ -12,11 +18,21 @@ const host = process.env.HOST ?? 'localhost';
 
 const start = async (): Promise<void> => {
 	try {
-		const db = createDatabase();
+		const db = createAndSetDatabase();
+		const dbName = await getDatabaseName(db);
+		if (dbName.startsWith(TEST_DATABASE_PREFIX)) {
+			throw new Error(
+				`Connected to database "${dbName}" which starts with test prefix ` +
+					`"${TEST_DATABASE_PREFIX}". Refusing to start to avoid ` +
+					`operating on a test database.`,
+			);
+		}
 		await initializeDatabase(db);
-		setDatabase(db);
 	} catch (err) {
 		logger.error(err, 'Database failed to initialize');
+		await closeDatabase().catch((closeErr: unknown) => {
+			logger.error(closeErr, 'Failed to close database during error cleanup');
+		});
 		throw err;
 	}
 	try {

--- a/src/test/harnessFunctions.ts
+++ b/src/test/harnessFunctions.ts
@@ -1,67 +1,79 @@
+import { closeDatabase, createAndSetDatabase } from '../database';
+import { TEST_DATABASE_PREFIX } from '../constants';
 import {
-	createDatabase,
-	getDatabase,
-	initializeDatabase,
-	migrate,
-	setDatabase,
-} from '../database';
-import type { TinyPg } from 'tinypg';
+	assertTestDatabaseName,
+	createTestAdminClient,
+	getTestPgConfig,
+	GOLD_DATABASE_NAME,
+} from './testDatabase';
+import type { Client } from 'pg';
 
-const generateSchemaName = (workerId: string): string => `test_${workerId}`;
+const buildConnectionString = (database: string): string => {
+	const config = getTestPgConfig();
+	const user = encodeURIComponent(config.user);
+	const password = encodeURIComponent(config.password);
+	return `postgresql://${user}:${password}@${config.host}:${config.port}/${database}`;
+};
 
-const getSchemaNameForCurrentTestWorker = (): string => {
-	if (process.env.NODE_ENV !== 'test') {
+const getWorkerDatabaseName = (): string => {
+	const {
+		env: { JEST_WORKER_ID },
+	} = process;
+	if (JEST_WORKER_ID === undefined || JEST_WORKER_ID === '') {
 		throw new Error(
-			'You cannot get a test schema name outside of a test environment.',
+			'JEST_WORKER_ID is not set. This function must be called within a Jest worker.',
 		);
 	}
-	if (process.env.JEST_WORKER_ID === undefined) {
+	return `${TEST_DATABASE_PREFIX}_worker_${JEST_WORKER_ID}`;
+};
+
+let adminClient: Client | null = null;
+
+const initializeWorker = async (): Promise<void> => {
+	adminClient = createTestAdminClient();
+	await adminClient.connect();
+};
+
+const createWorkerDatabase = async (): Promise<void> => {
+	if (adminClient === null) {
 		throw new Error(
-			'You cannot get a test schema name if jest has not specified a worker ID.',
+			'Admin client not initialized. Call initializeWorker first.',
 		);
 	}
-	return generateSchemaName(process.env.JEST_WORKER_ID);
+	const workerDbName = getWorkerDatabaseName();
+	assertTestDatabaseName(workerDbName);
+	await adminClient.query(`DROP DATABASE IF EXISTS ${workerDbName}`);
+	await adminClient.query(
+		`CREATE DATABASE ${workerDbName} TEMPLATE ${GOLD_DATABASE_NAME}`,
+	);
+	const connectionString = buildConnectionString(workerDbName);
+	createAndSetDatabase(connectionString);
 };
 
-const createSchema = async (db: TinyPg, schemaName: string): Promise<void> => {
-	await db.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName};`);
+const destroyWorkerDatabase = async (): Promise<void> => {
+	if (adminClient === null) {
+		throw new Error(
+			'Admin client not initialized. Call initializeWorker first.',
+		);
+	}
+	await closeDatabase();
+	const workerDbName = getWorkerDatabaseName();
+	assertTestDatabaseName(workerDbName);
+	await adminClient.query(`DROP DATABASE IF EXISTS ${workerDbName}`);
 };
 
-const setSchemaForCurrentPoolConnection = async (
-	db: TinyPg,
-	schemaName: string,
-): Promise<void> => {
-	await db.query(`SET search_path TO ${schemaName};`);
+const closeAdminClient = async (): Promise<void> => {
+	const client = adminClient;
+	if (client !== null) {
+		adminClient = null;
+		await client.end();
+	}
 };
 
-const setSchemaForFuturePoolConnections = (schemaName: string): void => {
-	process.env.PGOPTIONS = `-c search_path=${schemaName}`;
-};
-
-const setSchema = async (db: TinyPg, schemaName: string): Promise<void> => {
-	await setSchemaForCurrentPoolConnection(db, schemaName);
-	setSchemaForFuturePoolConnections(schemaName);
-};
-
-const dropSchema = async (db: TinyPg, schemaName: string): Promise<void> => {
-	await db.query(`DROP SCHEMA ${schemaName} CASCADE;`);
-};
-
-export const createAndSetDatabase = (): void => {
-	const db = createDatabase();
-	setDatabase(db);
-};
-
-export const prepareDatabaseForCurrentWorker = async (): Promise<void> => {
-	const db = getDatabase();
-	const schemaName = getSchemaNameForCurrentTestWorker();
-	await createSchema(db, schemaName);
-	await setSchema(db, schemaName);
-	await migrate(db, schemaName);
-	await initializeDatabase(db);
-};
-
-export const cleanupDatabaseForCurrentWorker = async (): Promise<void> => {
-	const schemaName = getSchemaNameForCurrentTestWorker();
-	await dropSchema(getDatabase(), schemaName);
+export {
+	buildConnectionString,
+	closeAdminClient,
+	createWorkerDatabase,
+	destroyWorkerDatabase,
+	initializeWorker,
 };

--- a/src/test/integrationGlobalSetup.ts
+++ b/src/test/integrationGlobalSetup.ts
@@ -1,0 +1,63 @@
+/* eslint-disable import/no-default-export --
+ * Jest expects a single default function to be exported from this file.
+ */
+import { requireEnv } from 'require-env-variable';
+import {
+	createDatabase,
+	createOrUpdateUser,
+	initializeDatabase,
+	loadOrCreateS3Bucket,
+	migrate,
+} from '../database';
+import {
+	assertTestDatabaseName,
+	createTestAdminClient,
+	GOLD_DATABASE_NAME,
+} from './testDatabase';
+import { buildConnectionString } from './harnessFunctions';
+import {
+	getTestUserKeycloakUserId,
+	getTestUserKeycloakUserName,
+} from './utils';
+import baseGlobalSetup from './globalSetup';
+import type { Config } from 'jest';
+
+export default async (
+	globalConfig: Config,
+	projectConfig: Config,
+): Promise<void> => {
+	baseGlobalSetup(globalConfig, projectConfig);
+
+	const { S3_BUCKET, S3_REGION, S3_ENDPOINT } = requireEnv(
+		'S3_BUCKET',
+		'S3_REGION',
+		'S3_ENDPOINT',
+	);
+
+	assertTestDatabaseName(GOLD_DATABASE_NAME);
+	const adminClient = createTestAdminClient();
+	await adminClient.connect();
+	await adminClient.query(`DROP DATABASE IF EXISTS ${GOLD_DATABASE_NAME}`);
+	await adminClient.query(`CREATE DATABASE ${GOLD_DATABASE_NAME}`);
+	await adminClient.end();
+
+	const connectionString = buildConnectionString(GOLD_DATABASE_NAME);
+	const goldDb = createDatabase(connectionString);
+	try {
+		await migrate(goldDb);
+		await initializeDatabase(goldDb);
+
+		await createOrUpdateUser(goldDb, null, {
+			keycloakUserId: getTestUserKeycloakUserId(),
+			keycloakUserName: getTestUserKeycloakUserName(),
+		});
+
+		await loadOrCreateS3Bucket(goldDb, null, {
+			name: S3_BUCKET,
+			region: S3_REGION,
+			endpoint: S3_ENDPOINT,
+		});
+	} finally {
+		await goldDb.close();
+	}
+};

--- a/src/test/integrationGlobalTeardown.ts
+++ b/src/test/integrationGlobalTeardown.ts
@@ -1,0 +1,16 @@
+/* eslint-disable import/no-default-export --
+ * Jest expects a single default function to be exported from this file.
+ */
+import {
+	assertTestDatabaseName,
+	createTestAdminClient,
+	GOLD_DATABASE_NAME,
+} from './testDatabase';
+
+export default async (): Promise<void> => {
+	assertTestDatabaseName(GOLD_DATABASE_NAME);
+	const adminClient = createTestAdminClient();
+	await adminClient.connect();
+	await adminClient.query(`DROP DATABASE IF EXISTS ${GOLD_DATABASE_NAME}`);
+	await adminClient.end();
+};

--- a/src/test/integrationSuiteSetup.ts
+++ b/src/test/integrationSuiteSetup.ts
@@ -3,46 +3,36 @@ import nock from 'nock';
  * This file is loaded by jest, as specified by the integration test jest configuration file
  * via `setupFilesAfterEnv`.
  */
-import { getDatabase } from '../database';
 import { loadConfig } from '../config';
 import { resetTestPermissionGrantFactory } from './factories';
 import {
-	createAndSetDatabase,
-	prepareDatabaseForCurrentWorker,
-	cleanupDatabaseForCurrentWorker,
+	closeAdminClient,
+	createWorkerDatabase,
+	destroyWorkerDatabase,
+	initializeWorker,
 } from './harnessFunctions';
 import { mockJwks } from './mockJwt';
-import { createTestUser } from './utils';
 
-// This mock prevents our queue manager from actually being invoked.
-// It's necessary because of the way we leverage PGOPTIONS to specify
-// the schema / search path when preparing the test worker to interact
-// with specific schemas.
-//
-// We may eventually want to be able to write tests that interact with the queue
-// and we may eventually face issues with blunt mocking of graphile-worker.
-// When that happens, we'll need to remove this mock and change the way we're
-// setting the schema / path.
+// This mock prevents graphile-worker from running background jobs during tests.
 jest.mock('graphile-worker');
 
-beforeAll(() => {
-	createAndSetDatabase();
+beforeAll(async () => {
+	await initializeWorker();
 });
 
 afterAll(async () => {
-	await getDatabase().close();
+	await closeAdminClient();
 });
 
 beforeEach(async () => {
 	resetTestPermissionGrantFactory();
 	mockJwks.start();
-	await prepareDatabaseForCurrentWorker();
+	await createWorkerDatabase();
 	await loadConfig();
-	await createTestUser(getDatabase());
 });
 
 afterEach(async () => {
-	await cleanupDatabaseForCurrentWorker();
+	await destroyWorkerDatabase();
 	jest.restoreAllMocks();
 	mockJwks.stop();
 	nock.cleanAll();

--- a/src/test/testDatabase.ts
+++ b/src/test/testDatabase.ts
@@ -1,0 +1,74 @@
+import { Client } from 'pg';
+import { requireEnv } from 'require-env-variable';
+import { TEST_DATABASE_PREFIX } from '../constants';
+
+const GOLD_DATABASE_NAME = `${TEST_DATABASE_PREFIX}_gold`;
+const TEST_ADMIN_DATABASE = 'postgres';
+
+/**
+ * Validates that a database name starts with the test prefix.
+ * This is a safety guard to prevent test infrastructure from
+ * accidentally issuing CREATE or DROP against a non-test database.
+ */
+const assertTestDatabaseName = (name: string): void => {
+	if (!name.startsWith(TEST_DATABASE_PREFIX)) {
+		throw new Error(
+			`Refusing to operate on database "${name}": ` +
+				`test database names must start with "${TEST_DATABASE_PREFIX}".`,
+		);
+	}
+};
+
+/**
+ * Returns PostgreSQL connection config for test infrastructure.
+ *
+ * Requires TEST_PG* env vars to be explicitly set. This ensures tests
+ * use a dedicated PostgreSQL user with CREATEDB privilege, separate
+ * from the application user. This limits blast radius: even if a name
+ * validation bug occurs, the test user can only drop databases it owns.
+ *
+ * The admin database is hardcoded to 'postgres' and validated to not
+ * match the test database prefix, preventing the admin client from
+ * accidentally connecting to (or operating on) a test database.
+ */
+interface TestPgConfig {
+	host: string;
+	port: number;
+	user: string;
+	password: string;
+	database: string;
+}
+
+const getTestPgConfig = (): TestPgConfig => {
+	const { TEST_PGHOST, TEST_PGPORT, TEST_PGUSER } = requireEnv(
+		'TEST_PGHOST',
+		'TEST_PGPORT',
+		'TEST_PGUSER',
+	);
+	const {
+		env: { TEST_PGPASSWORD },
+	} = process;
+	return {
+		host: TEST_PGHOST,
+		port: Number(TEST_PGPORT),
+		user: TEST_PGUSER,
+		password: TEST_PGPASSWORD ?? '',
+		database: TEST_ADMIN_DATABASE,
+	};
+};
+
+/**
+ * Creates a pg Client using test credentials.
+ * Used for admin operations (CREATE/DROP DATABASE) in test setup/teardown.
+ */
+const createTestAdminClient = (): Client => {
+	const config = getTestPgConfig();
+	return new Client(config);
+};
+
+export {
+	assertTestDatabaseName,
+	createTestAdminClient,
+	getTestPgConfig,
+	GOLD_DATABASE_NAME,
+};


### PR DESCRIPTION
This PR changes how our tests run, so that instead of using a test db schema it actually uses separate databases for each test runner (and a gold database).  It also adds some guardrails to ensure tests never run against a "real" database.

For devs this means we now need to populate test db environment variables.

Resolves #2167 