### PR TITLE
Add search to `GET /funders`

### DIFF
--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -12,7 +12,12 @@ import {
 	createPermissionGrant,
 } from '../database';
 import { getAuthContext, loadTestUser } from '../test/utils';
-import { expectArray, expectTimestamp } from '../test/asymettricMatchers';
+import {
+	expectArray,
+	expectArrayContaining,
+	expectObjectContaining,
+	expectTimestamp,
+} from '../test/asymettricMatchers';
 import { createTestFunder } from '../test/factories';
 import {
 	mockJwt as authHeader,
@@ -116,6 +121,93 @@ describe('/funders', () => {
 					systemFunder,
 				],
 				total: 3,
+			});
+		});
+
+		it('returns a subset of funders when search is provided', async () => {
+			const db = getDatabase();
+			await createTestFunder(db, null, {
+				shortCode: 'greenFund',
+				name: 'Green Environment Fund',
+			});
+			await createTestFunder(db, null, {
+				shortCode: 'techGrants',
+				name: 'Tech Innovation Grants',
+			});
+
+			const response = await agent
+				.get('/funders?_content=environment')
+				.set(authHeader)
+				.expect(200);
+			expect(response.body).toEqual({
+				total: 1,
+				entries: [
+					{
+						shortCode: 'greenFund',
+						createdAt: expectTimestamp(),
+						name: 'Green Environment Fund',
+						keycloakOrganizationId: null,
+						isCollaborative: false,
+					},
+				],
+			});
+		});
+
+		it('returns no funders when search does not match', async () => {
+			const db = getDatabase();
+			await createTestFunder(db, null, {
+				shortCode: 'greenFund',
+				name: 'Green Environment Fund',
+			});
+
+			const response = await agent
+				.get('/funders?_content=xyznonexistent')
+				.set(authHeader)
+				.expect(200);
+			expect(response.body).toEqual({
+				total: 0,
+				entries: [],
+			});
+		});
+
+		it('returns a collaborative funder when search matches a member funder name', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const collaborative = await createTestFunder(db, null, {
+				shortCode: 'climateCollab',
+				name: 'Climate Collaborative',
+				isCollaborative: true,
+			});
+			const memberFunder = await createTestFunder(db, null, {
+				shortCode: 'solarFund',
+				name: 'Solar Energy Fund',
+			});
+			await createTestFunder(db, null, {
+				shortCode: 'unrelatedFund',
+				name: 'Unrelated Fund',
+			});
+			await createOrUpdateFunderCollaborativeMember(db, systemUserAuthContext, {
+				funderCollaborativeShortCode: collaborative.shortCode,
+				memberFunderShortCode: memberFunder.shortCode,
+			});
+
+			const response = await agent
+				.get('/funders?_content=solar')
+				.set(authHeader)
+				.expect(200);
+			expect(response.body).toEqual({
+				total: 2,
+				entries: expectArrayContaining([
+					expectObjectContaining({
+						shortCode: 'solarFund',
+						name: 'Solar Energy Fund',
+					}),
+					expectObjectContaining({
+						shortCode: 'climateCollab',
+						name: 'Climate Collaborative',
+					}),
+				]),
 			});
 		});
 	});

--- a/src/database/migrations/0101-alter-funders-add-name_search.sql
+++ b/src/database/migrations/0101-alter-funders-add-name_search.sql
@@ -1,0 +1,7 @@
+ALTER TABLE funders
+ADD COLUMN name_search tsvector
+GENERATED ALWAYS AS (to_tsvector('english', name)) STORED;
+
+CREATE INDEX idx_funders_name_search
+ON funders
+USING gin (name_search);

--- a/src/database/operations/funders/loadFunderBundle.ts
+++ b/src/database/operations/funders/loadFunderBundle.ts
@@ -1,9 +1,9 @@
 import { generateLoadBundleOperation } from '../generators';
 import type { Funder } from '../../../types';
 
-const loadFunderBundle = generateLoadBundleOperation<Funder, []>(
-	'funders.selectWithPagination',
-	[],
-);
+const loadFunderBundle = generateLoadBundleOperation<
+	Funder,
+	[search: string | undefined]
+>('funders.selectWithPagination', ['search']);
 
 export { loadFunderBundle };

--- a/src/database/queries/funders/selectWithPagination.sql
+++ b/src/database/queries/funders/selectWithPagination.sql
@@ -1,7 +1,34 @@
 WITH
+	search_query AS (
+		SELECT
+			CASE
+				WHEN (
+					:search::text IS NULL
+					OR :search = ''
+				) THEN
+					NULL
+				ELSE
+					websearch_to_tsquery('english', :search::text)
+			END AS tsquery
+	),
+
 	candidate_entries AS NOT MATERIALIZED (
 		SELECT funders.*
 		FROM funders
+			CROSS JOIN search_query
+		WHERE
+			search_query.tsquery IS NULL
+			OR funders.name_search @@ search_query.tsquery
+			OR EXISTS (
+				SELECT 1
+				FROM funder_collaborative_members AS fcm
+					INNER JOIN funders AS member_f
+						ON fcm.member_funder_short_code = member_f.short_code
+				WHERE
+					fcm.funder_collaborative_short_code = funders.short_code
+					AND NOT is_expired(fcm.not_after)
+					AND member_f.name_search @@ search_query.tsquery
+			)
 	),
 
 	entry_count AS (

--- a/src/handlers/fundersHandlers.ts
+++ b/src/handlers/fundersHandlers.ts
@@ -8,7 +8,10 @@ import {
 } from '../database';
 import { isAuthContext, isWritableFunder } from '../types';
 import { FailedMiddlewareError, InputValidationError } from '../errors';
-import { extractPaginationParameters } from '../queryParameters';
+import {
+	extractPaginationParameters,
+	extractSearchParameters,
+} from '../queryParameters';
 import { coerceParams } from '../coercion';
 import { isShortCode } from '../types/ShortCode';
 import type { Request, Response } from 'express';
@@ -20,7 +23,8 @@ const getFunders = async (req: Request, res: Response): Promise<void> => {
 	const db = getDatabase();
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
-	const funderBundle = await loadFunderBundle(db, req, limit, offset);
+	const { search } = extractSearchParameters(req);
+	const funderBundle = await loadFunderBundle(db, req, search, limit, offset);
 
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.OK)

--- a/src/openapi/paths/funders.json
+++ b/src/openapi/paths/funders.json
@@ -10,7 +10,8 @@
 		],
 		"parameters": [
 			{ "$ref": "../components/parameters/pageParam.json" },
-			{ "$ref": "../components/parameters/countParam.json" }
+			{ "$ref": "../components/parameters/countParam.json" },
+			{ "$ref": "../components/parameters/searchParam.json" }
 		],
 		"responses": {
 			"200": {


### PR DESCRIPTION
This PR adds support for search to the `GET /funders` endpoint

Resolves #1648