### PR TITLE
Add `createdby` field to more entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `createdBy` field to funders, sources, opportunities, changemakers, and data providers.
 - `BaseField` can now be of type `date` and `date_time`.
 - `GET /changemakers` now supports the `_content` query parameter to search changemakers by name using full-text search.
 - Proposals now include a `changemakers` array containing shallow changemaker data for all associated changemakers.

--- a/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
+++ b/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
@@ -28,6 +28,7 @@ erDiagram
     string name
     uuid keycloakOrganizationId
     datetime createdAt
+    uuid createdBy FK
   }
   ChangemakerFieldValue {
     int id PK
@@ -70,6 +71,7 @@ erDiagram
     string title
     string funderShortCode FK
     datetime createdAt
+    uuid createdBy FK
   }
   ApplicationForm {
     int id PK
@@ -110,6 +112,7 @@ erDiagram
     string name
     uuid keycloakOrganizationId
     datetime createdAt
+    uuid createdBy FK
   }
   Funder {
     string shortCode PK
@@ -117,6 +120,7 @@ erDiagram
     uuid keycloakOrganizationId
     boolean isCollaborative
     datetime createdAt
+    uuid createdBy FK
   }
   Source {
     int id PK
@@ -125,6 +129,7 @@ erDiagram
     int changemakerId FK
     string dataProviderShortCode FK
     datetime createdAt
+    uuid createdBy FK
   }
   File {
     int id PK

--- a/src/__tests__/applicationFormFields.int.test.ts
+++ b/src/__tests__/applicationFormFields.int.test.ts
@@ -25,10 +25,11 @@ describe('/applicationFormFields', () => {
 		it('successfully updates the label only', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
@@ -90,10 +91,11 @@ describe('/applicationFormFields', () => {
 		it('successfully updates the instructions only', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
@@ -155,10 +157,11 @@ describe('/applicationFormFields', () => {
 		it('successfully updates both label and instructions', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
@@ -222,10 +225,11 @@ describe('/applicationFormFields', () => {
 		it('successfully updates instructions to null', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
@@ -287,10 +291,11 @@ describe('/applicationFormFields', () => {
 		it('successfully updates label to null', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
@@ -352,10 +357,11 @@ describe('/applicationFormFields', () => {
 		it('successfully updates inputType', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
@@ -417,10 +423,11 @@ describe('/applicationFormFields', () => {
 		it('returns 400 for empty request body', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
@@ -475,10 +482,11 @@ describe('/applicationFormFields', () => {
 		it('returns 400 for attempting to update read-only fields', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			const applicationForm = await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
@@ -545,11 +553,12 @@ describe('/applicationFormFields', () => {
 		it('returns 401 for user without funder EDIT permission', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const funder = await createTestFunder(db, null);
+			const funder = await createTestFunder(db, testUserAuthContext);
 
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 			});
 			const applicationForm = await createApplicationForm(db, null, {
@@ -599,10 +608,11 @@ describe('/applicationFormFields', () => {
 		it('returns 404 for non-existent applicationFormFieldId', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -76,8 +76,10 @@ describe('/applicationForms', () => {
 
 		it('returns all application forms present in the database when the user is an administrator', async () => {
 			const db = getDatabase();
-			const opportunity1 = await createTestOpportunity(db, null);
-			const opportunity2 = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity1 = await createTestOpportunity(db, testUserAuthContext);
+			const opportunity2 = await createTestOpportunity(db, testUserAuthContext);
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity1.id,
 				name: null,
@@ -127,10 +129,11 @@ describe('/applicationForms', () => {
 
 		it('returns only application forms that the user is allowed to view', async () => {
 			const db = getDatabase();
-			const visibleFunder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const testUser = await loadTestUser(db);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -139,21 +142,37 @@ describe('/applicationForms', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const otherFunder = await createTestFunder(db, null);
-			const visibleOpportunity = await createTestOpportunity(db, null, {
-				funderShortCode: visibleFunder.shortCode,
-			});
-			const hiddenOpportunity = await createTestOpportunity(db, null, {
-				funderShortCode: otherFunder.shortCode,
-			});
-			const visibleApplicationForm1 = await createApplicationForm(db, null, {
-				opportunityId: visibleOpportunity.id,
-				name: null,
-			});
-			const visibleApplicationForm2 = await createApplicationForm(db, null, {
-				opportunityId: visibleOpportunity.id,
-				name: null,
-			});
+			const otherFunder = await createTestFunder(db, testUserAuthContext);
+			const visibleOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: visibleFunder.shortCode,
+				},
+			);
+			const hiddenOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: otherFunder.shortCode,
+				},
+			);
+			const visibleApplicationForm1 = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: visibleOpportunity.id,
+					name: null,
+				},
+			);
+			const visibleApplicationForm2 = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: visibleOpportunity.id,
+					name: null,
+				},
+			);
 			await createApplicationForm(db, null, {
 				opportunityId: hiddenOpportunity.id,
 				name: null,
@@ -176,20 +195,30 @@ describe('/applicationForms', () => {
 
 		it('returns an application form with its fields when the user is an administrator', async () => {
 			const db = getDatabase();
-			const opportunity1 = await createTestOpportunity(db, null);
-			const opportunity2 = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity1 = await createTestOpportunity(db, testUserAuthContext);
+			const opportunity2 = await createTestOpportunity(db, testUserAuthContext);
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity1.id,
 				name: null,
 			});
-			const applicationForm2 = await createApplicationForm(db, null, {
-				opportunityId: opportunity1.id,
-				name: null,
-			});
-			const applicationForm3 = await createApplicationForm(db, null, {
-				opportunityId: opportunity2.id,
-				name: null,
-			});
+			const applicationForm2 = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity1.id,
+					name: null,
+				},
+			);
+			const applicationForm3 = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity2.id,
+					name: null,
+				},
+			);
 			await createTestBaseFields(db);
 			await createApplicationFormField(db, null, {
 				applicationFormId: applicationForm3.id,
@@ -269,10 +298,11 @@ describe('/applicationForms', () => {
 
 		it('returns an application form with its fields when the user has read access to the relevant funder', async () => {
 			const db = getDatabase();
-			const visibleFunder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const testUser = await loadTestUser(db);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -281,13 +311,17 @@ describe('/applicationForms', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: visibleFunder.shortCode,
 			});
-			const applicationForm = await createApplicationForm(db, null, {
-				opportunityId: opportunity.id,
-				name: null,
-			});
+			const applicationForm = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
 			await createTestBaseFields(db);
 			await createApplicationFormField(db, null, {
 				applicationFormId: applicationForm.id,
@@ -352,10 +386,11 @@ describe('/applicationForms', () => {
 		});
 		it('returns an application form with its fields when the user has read access to the relevant funder, and the instructions are null', async () => {
 			const db = getDatabase();
-			const visibleFunder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const testUser = await loadTestUser(db);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -364,13 +399,17 @@ describe('/applicationForms', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: visibleFunder.shortCode,
 			});
-			const applicationForm = await createApplicationForm(db, null, {
-				opportunityId: opportunity.id,
-				name: null,
-			});
+			const applicationForm = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
 			await createTestBaseFields(db);
 			await createApplicationFormField(db, null, {
 				applicationFormId: applicationForm.id,
@@ -436,11 +475,17 @@ describe('/applicationForms', () => {
 
 		it('does not return formFields associated with `FORBIDDEN` BaseFields', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
-			const applicationForm = await createApplicationForm(db, null, {
-				opportunityId: opportunity.id,
-				name: null,
-			});
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			const applicationForm = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
 			const forbiddenBaseField = await createOrUpdateBaseField(db, null, {
 				label: 'Forbidden Field',
 				description: 'This field should not be used in application forms',
@@ -479,14 +524,20 @@ describe('/applicationForms', () => {
 
 		it('should return 404 when the user does not have view opportunity permission', async () => {
 			const db = getDatabase();
-			const testFunder = await createTestFunder(db, null);
-			const opportunity = await createTestOpportunity(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
-			const applicationForm = await createApplicationForm(db, null, {
-				opportunityId: opportunity.id,
-				name: null,
-			});
+			const applicationForm = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
 			await request(app)
 				.get(`/applicationForms/${applicationForm.id}`)
 				.set(authHeader)
@@ -512,10 +563,11 @@ describe('/applicationForms', () => {
 
 		it('returns a CSV with labels matching the application form fields', async () => {
 			const db = getDatabase();
-			const visibleFunder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const testUser = await loadTestUser(db);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -524,13 +576,17 @@ describe('/applicationForms', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: visibleFunder.shortCode,
 			});
-			const applicationForm = await createApplicationForm(db, null, {
-				opportunityId: opportunity.id,
-				name: null,
-			});
+			const applicationForm = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
 			await createTestBaseFields(db);
 			await createApplicationFormField(db, null, {
 				applicationFormId: applicationForm.id,
@@ -563,10 +619,11 @@ describe('/applicationForms', () => {
 
 		it('returns fields in position order', async () => {
 			const db = getDatabase();
-			const visibleFunder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const testUser = await loadTestUser(db);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -575,13 +632,17 @@ describe('/applicationForms', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: visibleFunder.shortCode,
 			});
-			const applicationForm = await createApplicationForm(db, null, {
-				opportunityId: opportunity.id,
-				name: null,
-			});
+			const applicationForm = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
 			await createTestBaseFields(db);
 
 			await createApplicationFormField(db, null, {
@@ -611,10 +672,11 @@ describe('/applicationForms', () => {
 
 		it('returns an empty row for a form with no fields', async () => {
 			const db = getDatabase();
-			const visibleFunder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const testUser = await loadTestUser(db);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -623,13 +685,17 @@ describe('/applicationForms', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: visibleFunder.shortCode,
 			});
-			const applicationForm = await createApplicationForm(db, null, {
-				opportunityId: opportunity.id,
-				name: null,
-			});
+			const applicationForm = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
 
 			const result = await request(app)
 				.get(`/applicationForms/${applicationForm.id}/proposalDataCsv`)
@@ -652,11 +718,17 @@ describe('/applicationForms', () => {
 
 		it('returns 404 when the user does not have access to the funder', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
-			const applicationForm = await createApplicationForm(db, null, {
-				opportunityId: opportunity.id,
-				name: null,
-			});
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			const applicationForm = await createApplicationForm(
+				db,
+				testUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
 
 			await request(app)
 				.get(`/applicationForms/${applicationForm.id}/proposalDataCsv`)
@@ -672,10 +744,11 @@ describe('/applicationForms', () => {
 
 		it('creates exactly one application form as a user with proper permissions', async () => {
 			const db = getDatabase();
-			const testFunder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const testUser = await loadTestUser(db);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -692,7 +765,7 @@ describe('/applicationForms', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
 			const before = await loadTableMetrics(db, 'application_forms');
@@ -720,7 +793,9 @@ describe('/applicationForms', () => {
 
 		it('creates exactly one application form as an administrator', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const before = await loadTableMetrics(db, 'application_forms');
 			const result = await request(app)
 				.post('/applicationForms')
@@ -745,7 +820,9 @@ describe('/applicationForms', () => {
 
 		it('creates an application form with a name', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const result = await request(app)
 				.post('/applicationForms')
 				.type('application/json')
@@ -767,7 +844,9 @@ describe('/applicationForms', () => {
 
 		it('creates an application form with null name', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const result = await request(app)
 				.post('/applicationForms')
 				.type('application/json')
@@ -801,10 +880,11 @@ describe('/applicationForms', () => {
 
 		it(`returns 401 unauthorized if the user does not have edit permission on the associated opportunity's funder`, async () => {
 			const db = getDatabase();
-			const testFunder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const testUser = await loadTestUser(db);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -821,7 +901,7 @@ describe('/applicationForms', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.MANAGE],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
 			const before = await loadTableMetrics(db, 'application_forms');
@@ -842,7 +922,9 @@ describe('/applicationForms', () => {
 
 		it('creates exactly the number of provided fields', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createTestBaseFields(db);
 			const before = await loadTableMetrics(db, 'application_form_fields');
 			const result = await request(app)
@@ -886,7 +968,9 @@ describe('/applicationForms', () => {
 
 		it('increments version when creating a second form for an opportunity', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
 				name: null,
@@ -914,7 +998,9 @@ describe('/applicationForms', () => {
 
 		it('returns 400 when attempting to create a form field using a forbidden base field', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const forbiddenBaseField = await createOrUpdateBaseField(db, null, {
 				label: 'Forbidden Field',
 				description: 'This field should not be used in application forms',
@@ -1010,7 +1096,9 @@ describe('/applicationForms', () => {
 
 		it('returns 500 UnknownError if a generic Error is thrown when inserting the field', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createTestBaseFields(db);
 			jest
 				.spyOn(db, 'sql')

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -63,8 +63,8 @@ describe('/tasks/bulkUploads', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const visibleFunder = await createTestFunder(db, null);
-			const anotherFunder = await createTestFunder(db, null);
+			const visibleFunder = await createTestFunder(db, systemUserAuthContext);
+			const anotherFunder = await createTestFunder(db, systemUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -410,11 +410,11 @@ describe('/tasks/bulkUploads', () => {
 		it('creates exactly one bulk upload task', async () => {
 			const db = getDatabase();
 			const systemSource = await loadSystemSource(db, null);
-			const testFunder = await createTestFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -489,11 +489,11 @@ describe('/tasks/bulkUploads', () => {
 		it('creates a bulk upload task with attachments archive file', async () => {
 			const db = getDatabase();
 			const systemSource = await loadSystemSource(db, null);
-			const testFunder = await createTestFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -571,11 +571,11 @@ describe('/tasks/bulkUploads', () => {
 		it('returns 422 unprocessable entity when the user does not have create proposal permission for the associated opportunity', async () => {
 			const db = getDatabase();
 			const systemSource = await loadSystemSource(db, null);
-			const testFunder = await createTestFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
 			const proposalsDataFile = await createTestFile(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
@@ -638,10 +638,10 @@ describe('/tasks/bulkUploads', () => {
 		it('returns 400 bad request when no proposalDataFileId is provided', async () => {
 			const db = getDatabase();
 			const systemSource = await loadSystemSource(db, null);
-			const testFunder = await createTestFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -688,10 +688,10 @@ describe('/tasks/bulkUploads', () => {
 		it('returns 400 bad request when an invalid proposalDataFileId is provided', async () => {
 			const db = getDatabase();
 			const systemSource = await loadSystemSource(db, null);
-			const testFunder = await createTestFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -740,10 +740,10 @@ describe('/tasks/bulkUploads', () => {
 		it('returns 422 unprocessable entity when user tries to use a file they do not own for proposal data', async () => {
 			const db = getDatabase();
 			const systemSource = await loadSystemSource(db, null);
-			const testFunder = await createTestFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
 
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
@@ -811,11 +811,11 @@ describe('/tasks/bulkUploads', () => {
 		it('returns 422 unprocessable entity when the user is not the owner of the attachments archive file', async () => {
 			const db = getDatabase();
 			const systemSource = await loadSystemSource(db, null);
-			const testFunder = await createTestFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174001',
 				keycloakUserName: 'Alice',

--- a/src/__tests__/changemakerFieldValueBatches.int.test.ts
+++ b/src/__tests__/changemakerFieldValueBatches.int.test.ts
@@ -17,9 +17,11 @@ import { getAuthContext, loadTestUser } from '../test/utils';
 describe('POST /changemakerFieldValueBatches', () => {
 	it('Successfully creates a changemaker field value batch', async () => {
 		const db = getDatabase();
-		const changemaker = await createTestChangemaker(db, null);
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -48,9 +50,11 @@ describe('POST /changemakerFieldValueBatches', () => {
 
 	it('Accepts null for notes', async () => {
 		const db = getDatabase();
-		const changemaker = await createTestChangemaker(db, null);
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -140,9 +144,9 @@ describe('GET /changemakerFieldValueBatches', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -186,9 +190,9 @@ describe('GET /changemakerFieldValueBatches', () => {
 		});
 		const anotherUserAuthContext = getAuthContext(anotherUser);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -228,9 +232,9 @@ describe('GET /changemakerFieldValueBatches', () => {
 		});
 		const anotherUserAuthContext = getAuthContext(anotherUser);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -275,9 +279,9 @@ describe('GET /changemakerFieldValueBatches/:batchId', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -301,15 +305,17 @@ describe('GET /changemakerFieldValueBatches/:batchId', () => {
 
 	it('Returns 404 when batch belongs to another user', async () => {
 		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
 		const anotherUser = await createOrUpdateUser(db, null, {
 			keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			keycloakUserName: 'Nancy',
 		});
 		const anotherUserAuthContext = getAuthContext(anotherUser);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -335,15 +341,17 @@ describe('GET /changemakerFieldValueBatches/:batchId', () => {
 
 	it('Returns another users batch when user is an administrator', async () => {
 		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
 		const anotherUser = await createOrUpdateUser(db, null, {
 			keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 			keycloakUserName: 'Oscar',
 		});
 		const anotherUserAuthContext = getAuthContext(anotherUser);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});

--- a/src/__tests__/changemakerFieldValues.int.test.ts
+++ b/src/__tests__/changemakerFieldValues.int.test.ts
@@ -33,11 +33,11 @@ describe('POST /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -81,11 +81,11 @@ describe('POST /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -173,11 +173,11 @@ describe('POST /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -235,11 +235,11 @@ describe('POST /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -282,7 +282,7 @@ describe('POST /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		// Grant create permission on changemakerFieldValue scope
 		await createPermissionGrant(db, systemUserAuthContext, {
@@ -296,7 +296,7 @@ describe('POST /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -338,9 +338,9 @@ describe('POST /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -378,7 +378,7 @@ describe('POST /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const proposalField = await createOrUpdateBaseField(db, null, {
 			shortCode: 'test_proposal_field',
@@ -390,7 +390,7 @@ describe('POST /changemakerFieldValues', () => {
 			valueRelevanceHours: null,
 		});
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -427,7 +427,7 @@ describe('POST /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const forbiddenField = await createOrUpdateBaseField(db, null, {
 			shortCode: 'forbidden_field_test',
@@ -439,7 +439,7 @@ describe('POST /changemakerFieldValues', () => {
 			valueRelevanceHours: null,
 		});
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -473,7 +473,10 @@ describe('POST /changemakerFieldValues', () => {
 
 	it('Returns 409 when batch does not exist', async () => {
 		const db = getDatabase();
-		const changemaker = await createTestChangemaker(db, null);
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser, true);
+
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
@@ -501,11 +504,11 @@ describe('POST /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -545,11 +548,11 @@ describe('GET /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -563,23 +566,31 @@ describe('GET /changemakerFieldValues', () => {
 			},
 		);
 
-		const firstValue = await createChangemakerFieldValue(db, null, {
-			changemakerId: changemaker.id,
-			baseFieldShortCode: baseField.shortCode,
-			batchId: batch.id,
-			value: 'First value',
-			isValid: true,
-			goodAsOf: '2024-01-01T00:00:00Z',
-		});
+		const firstValue = await createChangemakerFieldValue(
+			db,
+			testUserAuthContext,
+			{
+				changemakerId: changemaker.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: batch.id,
+				value: 'First value',
+				isValid: true,
+				goodAsOf: '2024-01-01T00:00:00Z',
+			},
+		);
 
-		const secondValue = await createChangemakerFieldValue(db, null, {
-			changemakerId: changemaker.id,
-			baseFieldShortCode: baseField.shortCode,
-			batchId: batch.id,
-			value: 'Second value',
-			isValid: true,
-			goodAsOf: '2024-02-01T00:00:00Z',
-		});
+		const secondValue = await createChangemakerFieldValue(
+			db,
+			testUserAuthContext,
+			{
+				changemakerId: changemaker.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: batch.id,
+				value: 'Second value',
+				isValid: true,
+				goodAsOf: '2024-02-01T00:00:00Z',
+			},
+		);
 
 		const result = await request(app)
 			.get('/changemakerFieldValues')
@@ -597,14 +608,23 @@ describe('GET /changemakerFieldValues', () => {
 		const systemUser = await loadSystemUser(db, null);
 		const systemUserAuthContext = getAuthContext(systemUser);
 		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const visibleChangemaker = await createTestChangemaker(db, null, {
-			name: 'Visible Organization',
-		});
+		const visibleChangemaker = await createTestChangemaker(
+			db,
+			testUserAuthContext,
+			{
+				name: 'Visible Organization',
+			},
+		);
 
-		const hiddenChangemaker = await createTestChangemaker(db, null, {
-			name: 'Hidden Organization',
-		});
+		const hiddenChangemaker = await createTestChangemaker(
+			db,
+			testUserAuthContext,
+			{
+				name: 'Hidden Organization',
+			},
+		);
 
 		await createPermissionGrant(db, systemUserAuthContext, {
 			granteeType: PermissionGrantGranteeType.USER,
@@ -620,12 +640,12 @@ describe('GET /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const visibleSource = await createSource(db, null, {
+		const visibleSource = await createSource(db, testUserAuthContext, {
 			label: 'Visible Source',
 			changemakerId: visibleChangemaker.id,
 		});
 
-		const hiddenSource = await createSource(db, null, {
+		const hiddenSource = await createSource(db, testUserAuthContext, {
 			label: 'Hidden Source',
 			changemakerId: hiddenChangemaker.id,
 		});
@@ -648,14 +668,18 @@ describe('GET /changemakerFieldValues', () => {
 			},
 		);
 
-		const visibleValue = await createChangemakerFieldValue(db, null, {
-			changemakerId: visibleChangemaker.id,
-			baseFieldShortCode: baseField.shortCode,
-			batchId: visibleBatch.id,
-			value: 'Visible value',
-			isValid: true,
-			goodAsOf: '2024-01-01T00:00:00Z',
-		});
+		const visibleValue = await createChangemakerFieldValue(
+			db,
+			testUserAuthContext,
+			{
+				changemakerId: visibleChangemaker.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: visibleBatch.id,
+				value: 'Visible value',
+				isValid: true,
+				goodAsOf: '2024-01-01T00:00:00Z',
+			},
+		);
 
 		await createChangemakerFieldValue(db, null, {
 			changemakerId: hiddenChangemaker.id,
@@ -684,11 +708,11 @@ describe('GET /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -744,11 +768,11 @@ describe('GET /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -771,14 +795,18 @@ describe('GET /changemakerFieldValues', () => {
 			},
 		);
 
-		const valueInBatch1 = await createChangemakerFieldValue(db, null, {
-			changemakerId: changemaker.id,
-			baseFieldShortCode: baseField.shortCode,
-			batchId: batch1.id,
-			value: 'Value in batch 1',
-			isValid: true,
-			goodAsOf: '2024-01-01T00:00:00Z',
-		});
+		const valueInBatch1 = await createChangemakerFieldValue(
+			db,
+			testUserAuthContext,
+			{
+				changemakerId: changemaker.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: batch1.id,
+				value: 'Value in batch 1',
+				isValid: true,
+				goodAsOf: '2024-01-01T00:00:00Z',
+			},
+		);
 
 		await createChangemakerFieldValue(db, null, {
 			changemakerId: changemaker.id,
@@ -805,22 +833,22 @@ describe('GET /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker1 = await createTestChangemaker(db, null, {
+		const changemaker1 = await createTestChangemaker(db, testUserAuthContext, {
 			name: 'First Organization',
 		});
 
-		const changemaker2 = await createTestChangemaker(db, null, {
+		const changemaker2 = await createTestChangemaker(db, testUserAuthContext, {
 			name: 'Second Organization',
 		});
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source1 = await createSource(db, null, {
+		const source1 = await createSource(db, testUserAuthContext, {
 			label: 'Source 1',
 			changemakerId: changemaker1.id,
 		});
 
-		const source2 = await createSource(db, null, {
+		const source2 = await createSource(db, testUserAuthContext, {
 			label: 'Source 2',
 			changemakerId: changemaker2.id,
 		});
@@ -843,14 +871,18 @@ describe('GET /changemakerFieldValues', () => {
 			},
 		);
 
-		const valueForChangemaker1 = await createChangemakerFieldValue(db, null, {
-			changemakerId: changemaker1.id,
-			baseFieldShortCode: baseField.shortCode,
-			batchId: batch1.id,
-			value: 'Value for changemaker 1',
-			isValid: true,
-			goodAsOf: '2024-01-01T00:00:00Z',
-		});
+		const valueForChangemaker1 = await createChangemakerFieldValue(
+			db,
+			testUserAuthContext,
+			{
+				changemakerId: changemaker1.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: batch1.id,
+				value: 'Value for changemaker 1',
+				isValid: true,
+				goodAsOf: '2024-01-01T00:00:00Z',
+			},
+		);
 
 		await createChangemakerFieldValue(db, null, {
 			changemakerId: changemaker2.id,
@@ -877,11 +909,11 @@ describe('GET /changemakerFieldValues', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -904,14 +936,18 @@ describe('GET /changemakerFieldValues', () => {
 			},
 		);
 
-		const targetValue = await createChangemakerFieldValue(db, null, {
-			changemakerId: changemaker.id,
-			baseFieldShortCode: baseField.shortCode,
-			batchId: batch1.id,
-			value: 'Target value',
-			isValid: true,
-			goodAsOf: '2024-01-01T00:00:00Z',
-		});
+		const targetValue = await createChangemakerFieldValue(
+			db,
+			testUserAuthContext,
+			{
+				changemakerId: changemaker.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: batch1.id,
+				value: 'Target value',
+				isValid: true,
+				goodAsOf: '2024-01-01T00:00:00Z',
+			},
+		);
 
 		await createChangemakerFieldValue(db, null, {
 			changemakerId: changemaker.id,
@@ -957,11 +993,11 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -975,14 +1011,18 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 			},
 		);
 
-		const fieldValue = await createChangemakerFieldValue(db, null, {
-			changemakerId: changemaker.id,
-			baseFieldShortCode: baseField.shortCode,
-			batchId: batch.id,
-			value: 'Test value',
-			isValid: true,
-			goodAsOf: '2024-01-01T00:00:00Z',
-		});
+		const fieldValue = await createChangemakerFieldValue(
+			db,
+			testUserAuthContext,
+			{
+				changemakerId: changemaker.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: batch.id,
+				value: 'Test value',
+				isValid: true,
+				goodAsOf: '2024-01-01T00:00:00Z',
+			},
+		);
 
 		const result = await request(app)
 			.get(`/changemakerFieldValues/${fieldValue.id}`)
@@ -997,8 +1037,9 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 		const systemUser = await loadSystemUser(db, null);
 		const systemUserAuthContext = getAuthContext(systemUser);
 		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		await createPermissionGrant(db, systemUserAuthContext, {
 			granteeType: PermissionGrantGranteeType.USER,
@@ -1014,7 +1055,7 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -1028,14 +1069,18 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 			},
 		);
 
-		const fieldValue = await createChangemakerFieldValue(db, null, {
-			changemakerId: changemaker.id,
-			baseFieldShortCode: baseField.shortCode,
-			batchId: batch.id,
-			value: 'Test value',
-			isValid: true,
-			goodAsOf: '2024-01-01T00:00:00Z',
-		});
+		const fieldValue = await createChangemakerFieldValue(
+			db,
+			testUserAuthContext,
+			{
+				changemakerId: changemaker.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: batch.id,
+				value: 'Test value',
+				isValid: true,
+				goodAsOf: '2024-01-01T00:00:00Z',
+			},
+		);
 
 		const result = await request(app)
 			.get(`/changemakerFieldValues/${fieldValue.id}`)
@@ -1052,11 +1097,11 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 
-		const changemaker = await createTestChangemaker(db, null);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, null, {
+		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
 		});
@@ -1070,14 +1115,18 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 			},
 		);
 
-		const fieldValue = await createChangemakerFieldValue(db, null, {
-			changemakerId: changemaker.id,
-			baseFieldShortCode: baseField.shortCode,
-			batchId: batch.id,
-			value: 'Test value',
-			isValid: true,
-			goodAsOf: '2024-01-01T00:00:00Z',
-		});
+		const fieldValue = await createChangemakerFieldValue(
+			db,
+			testUserAuthContext,
+			{
+				changemakerId: changemaker.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: batch.id,
+				value: 'Test value',
+				isValid: true,
+				goodAsOf: '2024-01-01T00:00:00Z',
+			},
+		);
 
 		// Also create a userGroup permission grant with an EXPIRED association
 		// to verify that expired associations don't grant access

--- a/src/__tests__/changemakerProposals.int.test.ts
+++ b/src/__tests__/changemakerProposals.int.test.ts
@@ -41,14 +41,18 @@ import {
 	PermissionGrantGranteeType,
 	PermissionGrantVerb,
 } from '../types';
+import type { AuthContext } from '../types';
 import type { TinyPg } from 'tinypg';
 
-const insertTestChangemakers = async (db: TinyPg) => {
-	await createTestChangemaker(db, null, {
+const insertTestChangemakers = async (
+	db: TinyPg,
+	authContext: AuthContext | null,
+) => {
+	await createTestChangemaker(db, authContext, {
 		taxId: '11-1111111',
 		name: 'Example Inc.',
 	});
-	await createTestChangemaker(db, null, {
+	await createTestChangemaker(db, authContext, {
 		taxId: '22-2222222',
 		name: 'Another Inc.',
 		keycloakOrganizationId: '402b1208-be48-11ef-8af9-b767e5e8e4ee',
@@ -63,21 +67,29 @@ describe('/changemakerProposals', () => {
 
 		it('only returns the ChangemakerProposals that the user has rights to view', async () => {
 			const db = getDatabase();
-			const anotherFunder = await createTestFunder(db, null);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const visibleFunder = await createTestFunder(db, null, {
+			const anotherFunder = await createTestFunder(db, testUserAuthContext);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext, {
 				name: 'Visible Funder',
 				shortCode: 'visibleFunder',
 			});
-			const visibleChangemaker = await createTestChangemaker(db, null, {
-				name: 'Visible Changemaker',
-			});
-			const anotherChangemaker = await createTestChangemaker(db, null, {
-				name: 'Another Changemaker',
-			});
+			const visibleChangemaker = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Visible Changemaker',
+				},
+			);
+			const anotherChangemaker = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Another Changemaker',
+				},
+			);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -100,12 +112,20 @@ describe('/changemakerProposals', () => {
 				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const visibleOpportunity = await createTestOpportunity(db, null, {
-				funderShortCode: visibleFunder.shortCode,
-			});
-			const anotherOpportunity = await createTestOpportunity(db, null, {
-				funderShortCode: anotherFunder.shortCode,
-			});
+			const visibleOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: visibleFunder.shortCode,
+				},
+			);
+			const anotherOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: anotherFunder.shortCode,
+				},
+			);
 			const funderVisibleProposal = await createProposal(
 				db,
 				testUserAuthContext,
@@ -162,8 +182,8 @@ describe('/changemakerProposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
-			await insertTestChangemakers(db);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				opportunityId: opportunity.id,
 				externalId: '1',
@@ -195,6 +215,7 @@ describe('/changemakerProposals', () => {
 							taxId: '11-1111111',
 							keycloakOrganizationId: null,
 							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
 							fiscalSponsors: [],
 							fields: [],
 						},
@@ -212,6 +233,7 @@ describe('/changemakerProposals', () => {
 									taxId: '11-1111111',
 									keycloakOrganizationId: null,
 									createdAt: expectTimestamp(),
+									createdBy: testUser.keycloakUserId,
 								},
 							],
 							createdAt: expectTimestamp(),
@@ -228,6 +250,7 @@ describe('/changemakerProposals', () => {
 							taxId: '11-1111111',
 							keycloakOrganizationId: null,
 							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
 							fiscalSponsors: [],
 							fields: [],
 						},
@@ -245,6 +268,7 @@ describe('/changemakerProposals', () => {
 									taxId: '11-1111111',
 									keycloakOrganizationId: null,
 									createdAt: expectTimestamp(),
+									createdBy: testUser.keycloakUserId,
 								},
 							],
 							createdAt: expectTimestamp(),
@@ -261,8 +285,8 @@ describe('/changemakerProposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
-			await insertTestChangemakers(db);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				opportunityId: opportunity.id,
 				externalId: '1',
@@ -294,6 +318,7 @@ describe('/changemakerProposals', () => {
 							taxId: '11-1111111',
 							keycloakOrganizationId: null,
 							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
 							fiscalSponsors: [],
 							fields: [],
 						},
@@ -311,6 +336,7 @@ describe('/changemakerProposals', () => {
 									taxId: '11-1111111',
 									keycloakOrganizationId: null,
 									createdAt: expectTimestamp(),
+									createdBy: testUser.keycloakUserId,
 								},
 							],
 							createdAt: expectTimestamp(),
@@ -325,7 +351,9 @@ describe('/changemakerProposals', () => {
 
 		it('returns a 400 bad request when a non-integer ID is sent', async () => {
 			const db = getDatabase();
-			await insertTestChangemakers(db);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await request(app)
 				.get('/changemakerProposals?changemaker=foo')
 				.set(authHeader)
@@ -336,7 +364,9 @@ describe('/changemakerProposals', () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const testFunder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 
 			// Create a file-type base field (PROJECT category for proposal-only field)
 			const baseFieldFile = await createOrUpdateBaseField(db, null, {
@@ -350,7 +380,7 @@ describe('/changemakerProposals', () => {
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
 
-			const changemaker = await createTestChangemaker(db, null, {
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				taxId: '88-8888883',
 				name: 'Proposal File Decorated Changemaker',
 			});
@@ -363,13 +393,13 @@ describe('/changemakerProposals', () => {
 			});
 
 			// Create funder source
-			const funderSource = await createSource(db, null, {
+			const funderSource = await createSource(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 				label: 'Proposal Version File Funder Source',
 			});
 
 			// Create opportunity and proposal
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
 			const proposal = await createProposal(db, systemUserAuthContext, {
@@ -451,6 +481,8 @@ describe('/changemakerProposals', () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 
 			// Create a file-type base field (ORGANIZATION category for changemaker fields)
 			const baseFieldFile = await createOrUpdateBaseField(db, null, {
@@ -464,7 +496,7 @@ describe('/changemakerProposals', () => {
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
 
-			const changemaker = await createTestChangemaker(db, null, {
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				taxId: '88-8888884',
 				name: 'Changemaker File Decorated Changemaker',
 			});
@@ -477,7 +509,7 @@ describe('/changemakerProposals', () => {
 			});
 
 			// Create changemaker-sourced source and batch for changemaker field values
-			const changemakerSource = await createSource(db, null, {
+			const changemakerSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: `${changemaker.name} source`,
 			});
@@ -491,7 +523,7 @@ describe('/changemakerProposals', () => {
 			);
 
 			// Create a ChangemakerFieldValue with the file ID as the value
-			await createChangemakerFieldValue(db, systemUserAuthContext, {
+			await createChangemakerFieldValue(db, null, {
 				changemakerId: changemaker.id,
 				baseFieldShortCode: baseFieldFile.shortCode,
 				batchId: batch.id,
@@ -501,7 +533,7 @@ describe('/changemakerProposals', () => {
 			});
 
 			// Create a proposal to link to the changemaker
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, systemUserAuthContext, {
 				opportunityId: opportunity.id,
 				externalId: 'cmp-changemaker-field-test',
@@ -551,8 +583,8 @@ describe('/changemakerProposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
-			await insertTestChangemakers(db);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				opportunityId: opportunity.id,
 				externalId: '1',
@@ -578,6 +610,7 @@ describe('/changemakerProposals', () => {
 					taxId: '11-1111111',
 					keycloakOrganizationId: null,
 					createdAt: expectTimestamp(),
+					createdBy: testUser.keycloakUserId,
 					fiscalSponsors: [],
 					fields: [],
 				},
@@ -595,6 +628,7 @@ describe('/changemakerProposals', () => {
 							taxId: '11-1111111',
 							keycloakOrganizationId: null,
 							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
 						},
 					],
 					createdAt: expectTimestamp(),
@@ -611,7 +645,7 @@ describe('/changemakerProposals', () => {
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const testFunder = await createTestFunder(db, null);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -624,10 +658,10 @@ describe('/changemakerProposals', () => {
 				],
 				verbs: [PermissionGrantVerb.VIEW, PermissionGrantVerb.EDIT],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
-			await insertTestChangemakers(db);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				opportunityId: opportunity.id,
 				externalId: '1',
@@ -652,6 +686,7 @@ describe('/changemakerProposals', () => {
 					taxId: '11-1111111',
 					keycloakOrganizationId: null,
 					createdAt: expectTimestamp(),
+					createdBy: testUser.keycloakUserId,
 					fiscalSponsors: [],
 					fields: [],
 				},
@@ -669,6 +704,7 @@ describe('/changemakerProposals', () => {
 							taxId: '11-1111111',
 							keycloakOrganizationId: null,
 							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
 						},
 					],
 					createdAt: expectTimestamp(),
@@ -685,7 +721,7 @@ describe('/changemakerProposals', () => {
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const testFunder = await createTestFunder(db, null);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -698,10 +734,10 @@ describe('/changemakerProposals', () => {
 				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
-			await insertTestChangemakers(db);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				opportunityId: opportunity.id,
 				externalId: '1',
@@ -734,8 +770,8 @@ describe('/changemakerProposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
-			await insertTestChangemakers(db);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				opportunityId: opportunity.id,
 				externalId: '1',
@@ -758,8 +794,8 @@ describe('/changemakerProposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
-			await insertTestChangemakers(db);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				opportunityId: opportunity.id,
 				externalId: '1',
@@ -780,8 +816,10 @@ describe('/changemakerProposals', () => {
 
 		it('returns 422 Unprocessable Content when a non-existent proposal is sent', async () => {
 			const db = getDatabase();
-			await createTestOpportunity(db, null);
-			await insertTestChangemakers(db);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestOpportunity(db, testUserAuthContext);
+			await insertTestChangemakers(db, testUserAuthContext);
 			const result = await request(app)
 				.post('/changemakerProposals')
 				.type('application/json')
@@ -808,7 +846,7 @@ describe('/changemakerProposals', () => {
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const testFunder = await createTestFunder(db, null);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -817,7 +855,7 @@ describe('/changemakerProposals', () => {
 				scope: [PermissionGrantEntityType.FUNDER],
 				verbs: [PermissionGrantVerb.EDIT],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
 			await createProposal(db, testUserAuthContext, {
@@ -844,7 +882,7 @@ describe('/changemakerProposals', () => {
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const testFunder = await createTestFunder(db, null);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -853,10 +891,10 @@ describe('/changemakerProposals', () => {
 				scope: [PermissionGrantEntityType.FUNDER],
 				verbs: [PermissionGrantVerb.EDIT],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
-			await insertTestChangemakers(db);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				opportunityId: opportunity.id,
 				externalId: '1',

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -52,14 +52,15 @@ import {
 	stringToKeycloakId,
 } from '../types';
 import type { TinyPg } from 'tinypg';
+import type { AuthContext } from '../types';
 
-const insertTestChangemakers = async (db: TinyPg) => {
-	await createChangemaker(db, null, {
+const insertTestChangemakers = async (db: TinyPg, authContext: AuthContext) => {
+	await createChangemaker(db, authContext, {
 		taxId: '11-1111111',
 		name: 'Example Inc.',
 		keycloakOrganizationId: null,
 	});
-	await createChangemaker(db, null, {
+	await createChangemaker(db, authContext, {
 		taxId: '22-2222222',
 		name: 'Another Inc.',
 		keycloakOrganizationId: '57ceaca8-be48-11ef-8c91-5732d98a77e1',
@@ -71,6 +72,7 @@ const setupTestContext = async (db: TinyPg) => {
 	const systemUser = await loadSystemUser(db, null);
 	const systemUserAuthContext = getAuthContext(systemUser, true);
 	const testUser = await loadTestUser(db);
+	const testUserAuthContext = getAuthContext(testUser);
 	const baseFieldEmail = await createOrUpdateBaseField(db, null, {
 		label: 'Fifty one fifty three',
 		shortCode: 'fifty_one_fifty_three',
@@ -98,21 +100,25 @@ const setupTestContext = async (db: TinyPg) => {
 		valueRelevanceHours: null,
 		sensitivityClassification: BaseFieldSensitivityClassification.RESTRICTED,
 	});
-	const firstChangemaker = await createChangemaker(db, null, {
+	const firstChangemaker = await createChangemaker(db, testUserAuthContext, {
 		name: 'Five thousand one hundred forty seven reasons',
 		taxId: '05119',
 		keycloakOrganizationId: null,
 	});
-	const secondChangemaker = await createChangemaker(db, null, {
+	const secondChangemaker = await createChangemaker(db, testUserAuthContext, {
 		taxId: '5387',
 		name: 'Changemaker 5387',
 		keycloakOrganizationId: '8b15d276-be48-11ef-a061-5b4a50e82d50',
 	});
-	const { id: secondChangemakerSourceId } = await createSource(db, null, {
-		changemakerId: secondChangemaker.id,
-		label: `${secondChangemaker.name} source`,
-	});
-	const firstFunder = await createTestFunder(db, null, {
+	const { id: secondChangemakerSourceId } = await createSource(
+		db,
+		testUserAuthContext,
+		{
+			changemakerId: secondChangemaker.id,
+			label: `${secondChangemaker.name} source`,
+		},
+	);
+	const firstFunder = await createTestFunder(db, testUserAuthContext, {
 		shortCode: 'funder_5393',
 		name: 'Funder 5393',
 	});
@@ -130,23 +136,45 @@ const setupTestContext = async (db: TinyPg) => {
 		verbs: [PermissionGrantVerb.VIEW],
 	});
 
-	const firstFunderOpportunity = await createTestOpportunity(db, null, {
-		funderShortCode: firstFunder.shortCode,
-	});
-	const { id: firstFunderSourceId } = await createSource(db, null, {
-		funderShortCode: firstFunder.shortCode,
-		label: `${firstFunder.name} source`,
-	});
-	const firstDataProvider = await createTestDataProvider(db, null);
-	const secondDataProvider = await createTestDataProvider(db, null);
-	const { id: firstDataProviderSourceId } = await createSource(db, null, {
-		dataProviderShortCode: firstDataProvider.shortCode,
-		label: `${firstDataProvider.name} source`,
-	});
-	const { id: secondDataProviderSourceId } = await createSource(db, null, {
-		dataProviderShortCode: secondDataProvider.shortCode,
-		label: `${secondDataProvider.name} source`,
-	});
+	const firstFunderOpportunity = await createTestOpportunity(
+		db,
+		testUserAuthContext,
+		{
+			funderShortCode: firstFunder.shortCode,
+		},
+	);
+	const { id: firstFunderSourceId } = await createSource(
+		db,
+		testUserAuthContext,
+		{
+			funderShortCode: firstFunder.shortCode,
+			label: `${firstFunder.name} source`,
+		},
+	);
+	const firstDataProvider = await createTestDataProvider(
+		db,
+		testUserAuthContext,
+	);
+	const secondDataProvider = await createTestDataProvider(
+		db,
+		testUserAuthContext,
+	);
+	const { id: firstDataProviderSourceId } = await createSource(
+		db,
+		testUserAuthContext,
+		{
+			dataProviderShortCode: firstDataProvider.shortCode,
+			label: `${firstDataProvider.name} source`,
+		},
+	);
+	const { id: secondDataProviderSourceId } = await createSource(
+		db,
+		testUserAuthContext,
+		{
+			dataProviderShortCode: secondDataProvider.shortCode,
+			label: `${secondDataProvider.name} source`,
+		},
+	);
 
 	return {
 		systemSource,
@@ -183,7 +211,9 @@ describe('/changemakers', () => {
 
 		it('returns changemakers present in the database', async () => {
 			const db = getDatabase();
-			await insertTestChangemakers(db);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await request(app)
 				.get('/changemakers')
 				.set(authHeader)
@@ -198,6 +228,7 @@ describe('/changemakers', () => {
 								name: 'Another Inc.',
 								keycloakOrganizationId: '57ceaca8-be48-11ef-8c91-5732d98a77e1',
 								createdAt: expectTimestamp(),
+								createdBy: testUser.keycloakUserId,
 								fiscalSponsors: [],
 								fields: [],
 							},
@@ -207,6 +238,7 @@ describe('/changemakers', () => {
 								name: 'Example Inc.',
 								keycloakOrganizationId: null,
 								createdAt: expectTimestamp(),
+								createdBy: testUser.keycloakUserId,
 								fiscalSponsors: [],
 								fields: [],
 							},
@@ -217,9 +249,11 @@ describe('/changemakers', () => {
 
 		it('returns according to pagination parameters', async () => {
 			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
-				await createChangemaker(db, null, {
+				await createChangemaker(db, testUserAuthContext, {
 					taxId: '11-1111111',
 					name: `Changemaker ${i + 1}`,
 					keycloakOrganizationId: null,
@@ -243,6 +277,7 @@ describe('/changemakers', () => {
 								name: 'Changemaker 15',
 								keycloakOrganizationId: null,
 								createdAt: expectTimestamp(),
+								createdBy: testUser.keycloakUserId,
 								fiscalSponsors: [],
 								fields: [],
 							},
@@ -252,6 +287,7 @@ describe('/changemakers', () => {
 								name: 'Changemaker 14',
 								keycloakOrganizationId: null,
 								createdAt: expectTimestamp(),
+								createdBy: testUser.keycloakUserId,
 								fiscalSponsors: [],
 								fields: [],
 							},
@@ -261,6 +297,7 @@ describe('/changemakers', () => {
 								name: 'Changemaker 13',
 								keycloakOrganizationId: null,
 								createdAt: expectTimestamp(),
+								createdBy: testUser.keycloakUserId,
 								fiscalSponsors: [],
 								fields: [],
 							},
@@ -270,6 +307,7 @@ describe('/changemakers', () => {
 								name: 'Changemaker 12',
 								keycloakOrganizationId: null,
 								createdAt: expectTimestamp(),
+								createdBy: testUser.keycloakUserId,
 								fiscalSponsors: [],
 								fields: [],
 							},
@@ -279,6 +317,7 @@ describe('/changemakers', () => {
 								name: 'Changemaker 11',
 								keycloakOrganizationId: null,
 								createdAt: expectTimestamp(),
+								createdBy: testUser.keycloakUserId,
 								fiscalSponsors: [],
 								fields: [],
 							},
@@ -291,17 +330,17 @@ describe('/changemakers', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
 			});
-			await createChangemaker(db, null, {
+			await createChangemaker(db, testUserAuthContext, {
 				taxId: '123-123-123',
 				name: 'Canadian Company',
 				keycloakOrganizationId: null,
 			});
-			await createChangemaker(db, null, {
+			await createChangemaker(db, testUserAuthContext, {
 				taxId: '123-123-123',
 				name: 'Another Canadian Company',
 				keycloakOrganizationId: null,
@@ -323,6 +362,7 @@ describe('/changemakers', () => {
 						name: 'Canadian Company',
 						keycloakOrganizationId: null,
 						createdAt: expectTimestamp(),
+						createdBy: testUser.keycloakUserId,
 						fiscalSponsors: [],
 						fields: [],
 					},
@@ -334,7 +374,7 @@ describe('/changemakers', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -343,7 +383,7 @@ describe('/changemakers', () => {
 				externalId: 'proposal-2',
 				opportunityId: opportunity.id,
 			});
-			await createChangemaker(db, null, {
+			await createChangemaker(db, testUserAuthContext, {
 				taxId: '123-123-123',
 				name: 'Canadian Company',
 				keycloakOrganizationId: null,
@@ -369,6 +409,7 @@ describe('/changemakers', () => {
 						name: 'Canadian Company',
 						keycloakOrganizationId: null,
 						createdAt: expectTimestamp(),
+						createdBy: testUser.keycloakUserId,
 						fiscalSponsors: [],
 						fields: [],
 					},
@@ -378,12 +419,14 @@ describe('/changemakers', () => {
 
 		it('returns a subset of changemakers present in the database when search is provided', async () => {
 			const db = getDatabase();
-			await createChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createChangemaker(db, testUserAuthContext, {
 				taxId: '11-1111111',
 				name: 'Community Garden Foundation',
 				keycloakOrganizationId: null,
 			});
-			await createChangemaker(db, null, {
+			await createChangemaker(db, testUserAuthContext, {
 				taxId: '22-2222222',
 				name: 'Tech Innovation Labs',
 				keycloakOrganizationId: null,
@@ -401,6 +444,7 @@ describe('/changemakers', () => {
 						name: 'Community Garden Foundation',
 						keycloakOrganizationId: null,
 						createdAt: expectTimestamp(),
+						createdBy: testUser.keycloakUserId,
 						fiscalSponsors: [],
 						fields: [],
 					},
@@ -410,7 +454,9 @@ describe('/changemakers', () => {
 
 		it('returns no changemakers when search does not match', async () => {
 			const db = getDatabase();
-			await insertTestChangemakers(db);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await insertTestChangemakers(db, testUserAuthContext);
 			const response = await request(app)
 				.get('/changemakers?_content=xyznonexistent')
 				.set(authHeader)
@@ -425,17 +471,17 @@ describe('/changemakers', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
 			});
-			await createChangemaker(db, null, {
+			await createChangemaker(db, testUserAuthContext, {
 				taxId: '11-1111111',
 				name: 'Community Garden Foundation',
 				keycloakOrganizationId: null,
 			});
-			await createChangemaker(db, null, {
+			await createChangemaker(db, testUserAuthContext, {
 				taxId: '22-2222222',
 				name: 'Tech Innovation Labs',
 				keycloakOrganizationId: null,
@@ -461,6 +507,7 @@ describe('/changemakers', () => {
 						name: 'Community Garden Foundation',
 						keycloakOrganizationId: null,
 						createdAt: expectTimestamp(),
+						createdBy: testUser.keycloakUserId,
 						fiscalSponsors: [],
 						fields: [],
 					},
@@ -483,7 +530,9 @@ describe('/changemakers', () => {
 	describe('GET /:id', () => {
 		it('does not require authentication', async () => {
 			const db = getDatabase();
-			await insertTestChangemakers(db);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await request(app).get('/changemakers/1').expect(200);
 		});
 
@@ -493,7 +542,9 @@ describe('/changemakers', () => {
 
 		it('returns the specified changemaker', async () => {
 			const db = getDatabase();
-			await insertTestChangemakers(db);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await insertTestChangemakers(db, testUserAuthContext);
 			await request(app)
 				.get('/changemakers/2')
 				.set(authHeader)
@@ -505,6 +556,7 @@ describe('/changemakers', () => {
 						name: 'Another Inc.',
 						keycloakOrganizationId: '57ceaca8-be48-11ef-8c91-5732d98a77e1',
 						createdAt: expectTimestamp(),
+						createdBy: testUser.keycloakUserId,
 						fiscalSponsors: [],
 						fields: [],
 					});
@@ -655,6 +707,7 @@ describe('/changemakers', () => {
 							taxId: '05119',
 							keycloakOrganizationId: null,
 							createdAt: expectTimestamp(),
+							createdBy: getTestUserKeycloakUserId(),
 							fiscalSponsors: [],
 							fields: [latestValidValue],
 						});
@@ -757,6 +810,7 @@ describe('/changemakers', () => {
 						expect(res.body).toEqual({
 							...changemaker,
 							createdAt: expectTimestamp(),
+							createdBy: getTestUserKeycloakUserId(),
 							fields: [changemakerEarliestValue],
 						});
 					});
@@ -854,6 +908,7 @@ describe('/changemakers', () => {
 						expect(res.body).toEqual({
 							...changemaker,
 							createdAt: expectTimestamp(),
+							createdBy: getTestUserKeycloakUserId(),
 							fields: [funderEarliestValue],
 						});
 					});
@@ -954,6 +1009,7 @@ describe('/changemakers', () => {
 						expect(res.body).toEqual({
 							...changemaker,
 							createdAt: expectTimestamp(),
+							createdBy: getTestUserKeycloakUserId(),
 							fields: [dataProviderNewestValue],
 						});
 					});
@@ -1034,6 +1090,7 @@ describe('/changemakers', () => {
 						expect(res.body).toEqual({
 							...changemaker,
 							createdAt: expectTimestamp(),
+							createdBy: getTestUserKeycloakUserId(),
 							fields: [],
 						});
 					});
@@ -1067,6 +1124,7 @@ describe('/changemakers', () => {
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
 				createdAt: expectTimestamp(),
+				createdBy: getTestUserKeycloakUserId(),
 				fiscalSponsors: [],
 				fields: [],
 			});
@@ -1105,7 +1163,9 @@ describe('/changemakers', () => {
 
 		it('returns 409 conflict when an existing EIN + name combination is submitted', async () => {
 			const db = getDatabase();
-			await createChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createChangemaker(db, testUserAuthContext, {
 				taxId: '11-1111111',
 				name: 'Example Inc.',
 				keycloakOrganizationId: null,
@@ -1134,7 +1194,9 @@ describe('/changemakers', () => {
 	describe('PATCH /:id', () => {
 		it('Successfully sets a keycloakOrganizationId where previously null', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				keycloakOrganizationId: null,
 			});
 			const newOrganizationId = stringToKeycloakId(
@@ -1152,6 +1214,7 @@ describe('/changemakers', () => {
 				...changemaker,
 				keycloakOrganizationId: newOrganizationId,
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 				fields: [],
 			});
 		});
@@ -1159,7 +1222,9 @@ describe('/changemakers', () => {
 		it('Successfully changes a taxId', async () => {
 			const db = getDatabase();
 			const originalTaxId = '9804410587598905789786443694633460095646';
-			const changemaker = await createTestChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				taxId: originalTaxId,
 			});
 			const newTaxId = '7595152072656722360933945510658631139960';
@@ -1175,13 +1240,16 @@ describe('/changemakers', () => {
 				...changemaker,
 				taxId: newTaxId,
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 				fields: [],
 			});
 		});
 
 		it('Successfully changes a name and Keycloak organization ID', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				name: 'Original Name',
 				keycloakOrganizationId: stringToKeycloakId(
 					'd32693c1-d8de-40a3-8de9-a84f0737f015',
@@ -1204,6 +1272,7 @@ describe('/changemakers', () => {
 				id: changemaker.id,
 				taxId: changemaker.taxId,
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 				fiscalSponsors: [],
 				fields: [],
 			});
@@ -1268,7 +1337,9 @@ describe('/changemakers', () => {
 
 		it('Returns user error when no fields are sent', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			await request(app)
 				.patch(`/changemakers/${changemaker.id}`)
 				.type('application/json')
@@ -1279,7 +1350,9 @@ describe('/changemakers', () => {
 
 		it('Returns 400 validation error when taxId is set to null', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			const result = await request(app)
 				.patch(`/changemakers/${changemaker.id}`)
 				.type('application/json')
@@ -1296,7 +1369,9 @@ describe('/changemakers', () => {
 
 		it('Returns 400 validation error when name is set to null', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			const result = await request(app)
 				.patch(`/changemakers/${changemaker.id}`)
 				.type('application/json')
@@ -1313,7 +1388,9 @@ describe('/changemakers', () => {
 
 		it('Successfully sets keycloakOrganizationId to null', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				keycloakOrganizationId: stringToKeycloakId(
 					'12345678-1234-1234-1234-123456789abc',
 				),
@@ -1336,15 +1413,29 @@ describe('/changemakers', () => {
 	describe('PUT /:changemakerId/fiscalSponsors/:fiscalSponsorChangemakerId', () => {
 		it('Successfully adds and reflects two fiscal sponsorships', async () => {
 			const db = getDatabase();
-			const fiscalSponsee = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsee',
-			});
-			const fiscalSponsor = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor One',
-			});
-			const fiscalSponsorTwo = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor Two',
-			});
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const fiscalSponsee = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsee',
+				},
+			);
+			const fiscalSponsor = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor One',
+				},
+			);
+			const fiscalSponsorTwo = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor Two',
+				},
+			);
 			const result = await request(app)
 				.put(
 					`/changemakers/${fiscalSponsee.id}/fiscalSponsors/${fiscalSponsor.id}`,
@@ -1357,8 +1448,8 @@ describe('/changemakers', () => {
 				fiscalSponseeChangemakerId: fiscalSponsee.id,
 				fiscalSponsorChangemakerId: fiscalSponsor.id,
 				createdAt: expectTimestamp(),
-				createdBy: getTestUserKeycloakUserId(),
 				notAfter: null,
+				createdBy: testUser.keycloakUserId,
 			});
 			const resultTwo = await request(app)
 				.put(
@@ -1372,8 +1463,8 @@ describe('/changemakers', () => {
 				fiscalSponseeChangemakerId: fiscalSponsee.id,
 				fiscalSponsorChangemakerId: fiscalSponsorTwo.id,
 				createdAt: expectTimestamp(),
-				createdBy: getTestUserKeycloakUserId(),
 				notAfter: null,
+				createdBy: testUser.keycloakUserId,
 			});
 			const changemakerResult = await request(app)
 				.get(`/changemakers/${fiscalSponsee.id}`)
@@ -1382,6 +1473,7 @@ describe('/changemakers', () => {
 			expect(changemakerResult.body).toStrictEqual({
 				...fiscalSponsee,
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 				fiscalSponsors: [
 					{
 						id: fiscalSponsor.id,
@@ -1389,6 +1481,7 @@ describe('/changemakers', () => {
 						name: fiscalSponsor.name,
 						keycloakOrganizationId: fiscalSponsor.keycloakOrganizationId,
 						createdAt: fiscalSponsor.createdAt,
+						createdBy: testUser.keycloakUserId,
 					},
 					{
 						id: fiscalSponsorTwo.id,
@@ -1396,6 +1489,7 @@ describe('/changemakers', () => {
 						name: fiscalSponsorTwo.name,
 						keycloakOrganizationId: fiscalSponsorTwo.keycloakOrganizationId,
 						createdAt: fiscalSponsorTwo.createdAt,
+						createdBy: testUser.keycloakUserId,
 					},
 				],
 			});
@@ -1403,12 +1497,22 @@ describe('/changemakers', () => {
 
 		it('Requires authentication', async () => {
 			const db = getDatabase();
-			const fiscalSponsee = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsee',
-			});
-			const fiscalSponsor = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor',
-			});
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const fiscalSponsee = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsee',
+				},
+			);
+			const fiscalSponsor = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor',
+				},
+			);
 			await request(app)
 				.put(
 					`/changemakers/${fiscalSponsee.id}/fiscalSponsors/${fiscalSponsor.id}`,
@@ -1420,7 +1524,9 @@ describe('/changemakers', () => {
 
 		it('Requires sponsor to differ from sponsee', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			await request(app)
 				.put(`/changemakers/${changemaker.id}/fiscalSponsors/${changemaker.id}`)
 				.type('application/json')
@@ -1431,12 +1537,18 @@ describe('/changemakers', () => {
 
 		it('Requires integer fiscal sponsee changemaker ID', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				name: 'Fiscal Sponsee',
 			});
-			const fiscalSponsor = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor',
-			});
+			const fiscalSponsor = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor',
+				},
+			);
 			await request(app)
 				.put(
 					`/changemakers/${changemaker.name}/fiscalSponsors/${fiscalSponsor.id}`,
@@ -1449,12 +1561,18 @@ describe('/changemakers', () => {
 
 		it('Requires integer fiscal sponsor changemaker ID', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				name: 'Fiscal Sponsee',
 			});
-			const fiscalSponsor = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor',
-			});
+			const fiscalSponsor = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor',
+				},
+			);
 			await request(app)
 				.put(
 					`/changemakers/${changemaker.id}/fiscalSponsors/${fiscalSponsor.name}`,
@@ -1469,15 +1587,29 @@ describe('/changemakers', () => {
 	describe('DELETE /:changemakerId/fiscalSponsors/:fiscalSponsorChangemakerId', () => {
 		it('Successfully deletes and reflects fiscal sponsorship deletion', async () => {
 			const db = getDatabase();
-			const fiscalSponsee = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsee',
-			});
-			const fiscalSponsorToRemove = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor To Remove',
-			});
-			const fiscalSponsorToKeep = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor To Keep',
-			});
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const fiscalSponsee = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsee',
+				},
+			);
+			const fiscalSponsorToRemove = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor To Remove',
+				},
+			);
+			const fiscalSponsorToKeep = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor To Keep',
+				},
+			);
 			await request(app)
 				.put(
 					`/changemakers/${fiscalSponsee.id}/fiscalSponsors/${fiscalSponsorToRemove.id}`,
@@ -1516,6 +1648,7 @@ describe('/changemakers', () => {
 						name: fiscalSponsorToKeep.name,
 						keycloakOrganizationId: fiscalSponsorToKeep.keycloakOrganizationId,
 						createdAt: fiscalSponsorToKeep.createdAt,
+						createdBy: testUser.keycloakUserId,
 					},
 				],
 			});
@@ -1523,12 +1656,18 @@ describe('/changemakers', () => {
 
 		it('Requires integer fiscal sponsee changemaker ID', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				name: 'Fiscal Sponsee',
 			});
-			const fiscalSponsor = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor',
-			});
+			const fiscalSponsor = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor',
+				},
+			);
 			await request(app)
 				.delete(
 					`/changemakers/${changemaker.name}/fiscalSponsors/${fiscalSponsor.id}`,
@@ -1541,12 +1680,18 @@ describe('/changemakers', () => {
 
 		it('Requires integer fiscal sponsor changemaker ID', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				name: 'Fiscal Sponsee',
 			});
-			const fiscalSponsor = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor',
-			});
+			const fiscalSponsor = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor',
+				},
+			);
 			await request(app)
 				.delete(
 					`/changemakers/${changemaker.id}/fiscalSponsors/${fiscalSponsor.name}`,
@@ -1559,12 +1704,18 @@ describe('/changemakers', () => {
 
 		it('Returns 404 on non-existent row', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				name: 'Fiscal Sponsee',
 			});
-			const fiscalSponsor = await createTestChangemaker(db, null, {
-				name: 'Fiscal Sponsor',
-			});
+			const fiscalSponsor = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Fiscal Sponsor',
+				},
+			);
 			await request(app)
 				.delete(
 					`/changemakers/${changemaker.id * 5}/fiscalSponsors/${fiscalSponsor.id * 5 * 13}`,
@@ -1582,6 +1733,7 @@ describe('/changemakers', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const baseField = await createOrUpdateBaseField(db, null, {
 				label: 'Organization Mission',
 				shortCode: 'org_mission_cfv_test',
@@ -1592,9 +1744,9 @@ describe('/changemakers', () => {
 				sensitivityClassification:
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
-			const changemaker = await createTestChangemaker(db, null);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			// Create a changemaker-sourced source
-			const changemakerSource = await createSource(db, null, {
+			const changemakerSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: `${changemaker.name} source`,
 			});
@@ -1646,6 +1798,7 @@ describe('/changemakers', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const baseField = await createOrUpdateBaseField(db, null, {
 				label: 'Organization Website',
 				shortCode: 'org_website_priority_test',
@@ -1656,14 +1809,14 @@ describe('/changemakers', () => {
 				sensitivityClassification:
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
-			const changemaker = await createTestChangemaker(db, null);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 			// Create a funder and opportunity for the ProposalFieldValue
-			const funder = await createTestFunder(db, null);
-			const opportunity = await createTestOpportunity(db, null, {
+			const funder = await createTestFunder(db, testUserAuthContext);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 			});
-			const funderSource = await createSource(db, null, {
+			const funderSource = await createSource(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 				label: 'Funder Priority Source',
 			});
@@ -1708,7 +1861,7 @@ describe('/changemakers', () => {
 			});
 
 			// Create changemaker-sourced ChangemakerFieldValue (should win)
-			const changemakerSource = await createSource(db, null, {
+			const changemakerSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: `${changemaker.name} source`,
 			});
@@ -1761,6 +1914,7 @@ describe('/changemakers', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const baseField = await createOrUpdateBaseField(db, null, {
 				label: 'Organization Phone',
 				shortCode: 'org_phone_recency_test',
@@ -1771,10 +1925,10 @@ describe('/changemakers', () => {
 				sensitivityClassification:
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
-			const changemaker = await createTestChangemaker(db, null);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 			// Create changemaker-sourced source
-			const changemakerSource = await createSource(db, null, {
+			const changemakerSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: `${changemaker.name} source`,
 			});
@@ -1788,7 +1942,7 @@ describe('/changemakers', () => {
 					notes: 'Older batch',
 				},
 			);
-			await createChangemakerFieldValue(db, systemUserAuthContext, {
+			await createChangemakerFieldValue(db, null, {
 				changemakerId: changemaker.id,
 				baseFieldShortCode: baseField.shortCode,
 				batchId: olderBatch.id,
@@ -1856,9 +2010,11 @@ describe('/changemakers', () => {
 				sensitivityClassification:
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
-			const changemaker = await createTestChangemaker(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-			const changemakerSource = await createSource(db, null, {
+			const changemakerSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: `${changemaker.name} source`,
 			});
@@ -1871,7 +2027,7 @@ describe('/changemakers', () => {
 				},
 			);
 			// Create an invalid ChangemakerFieldValue
-			await createChangemakerFieldValue(db, systemUserAuthContext, {
+			await createChangemakerFieldValue(db, null, {
 				changemakerId: changemaker.id,
 				baseFieldShortCode: baseField.shortCode,
 				batchId: batch.id,
@@ -1898,6 +2054,7 @@ describe('/changemakers', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const baseFieldEmail = await createOrUpdateBaseField(db, null, {
 				label: 'Org Email Multi',
 				shortCode: 'org_email_multi_test',
@@ -1918,10 +2075,10 @@ describe('/changemakers', () => {
 				sensitivityClassification:
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
-			const changemaker = await createTestChangemaker(db, null);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 			// Create ChangemakerFieldValue for email
-			const changemakerSource = await createSource(db, null, {
+			const changemakerSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: `${changemaker.name} source`,
 			});
@@ -1933,7 +2090,7 @@ describe('/changemakers', () => {
 					notes: 'Multi test batch',
 				},
 			);
-			await createChangemakerFieldValue(db, systemUserAuthContext, {
+			await createChangemakerFieldValue(db, null, {
 				changemakerId: changemaker.id,
 				baseFieldShortCode: baseFieldEmail.shortCode,
 				batchId: batch.id,
@@ -1943,7 +2100,7 @@ describe('/changemakers', () => {
 			});
 
 			// Create ProposalFieldValue for phone
-			const funder = await createTestFunder(db, null);
+			const funder = await createTestFunder(db, testUserAuthContext);
 
 			// Grant permission with proposalFieldValue scope so test user can see field values
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -1968,10 +2125,10 @@ describe('/changemakers', () => {
 				verbs: [PermissionGrantVerb.VIEW],
 			});
 
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 			});
-			const funderSource = await createSource(db, null, {
+			const funderSource = await createSource(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 				label: 'Funder Multi Source',
 			});
@@ -2040,7 +2197,7 @@ describe('/changemakers', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-
+			const testUserAuthContext = getAuthContext(testUser);
 			const baseFieldEmail = await createOrUpdateBaseField(db, null, {
 				label: 'Org Email Perm Test',
 				shortCode: 'org_email_perm_test',
@@ -2062,21 +2219,29 @@ describe('/changemakers', () => {
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
 
-			const changemaker = await createChangemaker(db, null, {
+			const changemaker = await createChangemaker(db, testUserAuthContext, {
 				taxId: '99-9999996',
 				name: 'Test Changemaker Permission Filter',
 				keycloakOrganizationId: null,
 			});
 
 			// Create two funders with different permissions
-			const funderWithFieldValueScope = await createTestFunder(db, null, {
-				shortCode: 'funder_with_fv_scope',
-				name: 'Funder With Field Value Scope',
-			});
-			const funderWithoutFieldValueScope = await createTestFunder(db, null, {
-				shortCode: 'funder_without_fv_scope',
-				name: 'Funder Without Field Value Scope',
-			});
+			const funderWithFieldValueScope = await createTestFunder(
+				db,
+				testUserAuthContext,
+				{
+					shortCode: 'funder_with_fv_scope',
+					name: 'Funder With Field Value Scope',
+				},
+			);
+			const funderWithoutFieldValueScope = await createTestFunder(
+				db,
+				testUserAuthContext,
+				{
+					shortCode: 'funder_without_fv_scope',
+					name: 'Funder Without Field Value Scope',
+				},
+			);
 
 			// Grant permission WITH proposalFieldValue scope for first funder
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -2102,10 +2267,14 @@ describe('/changemakers', () => {
 			});
 
 			// Create proposal 1 (under funder WITH proposalFieldValue scope)
-			const opportunity1 = await createTestOpportunity(db, null, {
-				funderShortCode: funderWithFieldValueScope.shortCode,
-			});
-			const source1 = await createSource(db, null, {
+			const opportunity1 = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: funderWithFieldValueScope.shortCode,
+				},
+			);
+			const source1 = await createSource(db, testUserAuthContext, {
 				funderShortCode: funderWithFieldValueScope.shortCode,
 				label: 'Source With FV Scope',
 			});
@@ -2148,10 +2317,14 @@ describe('/changemakers', () => {
 			});
 
 			// Create proposal 2 (under funder WITHOUT proposalFieldValue scope)
-			const opportunity2 = await createTestOpportunity(db, null, {
-				funderShortCode: funderWithoutFieldValueScope.shortCode,
-			});
-			const source2 = await createSource(db, null, {
+			const opportunity2 = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: funderWithoutFieldValueScope.shortCode,
+				},
+			);
+			const source2 = await createSource(db, testUserAuthContext, {
 				funderShortCode: funderWithoutFieldValueScope.shortCode,
 				label: 'Source Without FV Scope',
 			});
@@ -2212,6 +2385,7 @@ describe('/changemakers', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 
 			// Create a restricted field (requires permission)
 			const restrictedBaseField = await createOrUpdateBaseField(db, null, {
@@ -2236,14 +2410,14 @@ describe('/changemakers', () => {
 				sensitivityClassification: BaseFieldSensitivityClassification.PUBLIC,
 			});
 
-			const changemaker = await createChangemaker(db, null, {
+			const changemaker = await createChangemaker(db, testUserAuthContext, {
 				taxId: '99-9999990',
 				name: 'Test Changemaker CFV Permissions',
 				keycloakOrganizationId: null,
 			});
 
 			// Create changemaker-sourced source and batch
-			const changemakerSource = await createSource(db, null, {
+			const changemakerSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: `${changemaker.name} source`,
 			});
@@ -2257,7 +2431,7 @@ describe('/changemakers', () => {
 			);
 
 			// Create a restricted ChangemakerFieldValue
-			await createChangemakerFieldValue(db, systemUserAuthContext, {
+			await createChangemakerFieldValue(db, null, {
 				changemakerId: changemaker.id,
 				baseFieldShortCode: restrictedBaseField.shortCode,
 				batchId: batch.id,
@@ -2267,7 +2441,7 @@ describe('/changemakers', () => {
 			});
 
 			// Create a public ChangemakerFieldValue
-			await createChangemakerFieldValue(db, systemUserAuthContext, {
+			await createChangemakerFieldValue(db, null, {
 				changemakerId: changemaker.id,
 				baseFieldShortCode: publicBaseField.shortCode,
 				batchId: batch.id,
@@ -2334,6 +2508,7 @@ describe('/changemakers', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 
 			// Create a file-type base field
 			const baseFieldFile = await createOrUpdateBaseField(db, null, {
@@ -2347,7 +2522,7 @@ describe('/changemakers', () => {
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
 
-			const changemaker = await createChangemaker(db, null, {
+			const changemaker = await createChangemaker(db, testUserAuthContext, {
 				taxId: '99-9999998',
 				name: 'Test Changemaker File Download',
 				keycloakOrganizationId: null,
@@ -2361,7 +2536,7 @@ describe('/changemakers', () => {
 			});
 
 			// Create changemaker-sourced source and batch
-			const changemakerSource = await createSource(db, null, {
+			const changemakerSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: `${changemaker.name} source`,
 			});
@@ -2375,7 +2550,7 @@ describe('/changemakers', () => {
 			);
 
 			// Create a ChangemakerFieldValue with the file ID as the value
-			await createChangemakerFieldValue(db, systemUserAuthContext, {
+			await createChangemakerFieldValue(db, null, {
 				changemakerId: changemaker.id,
 				baseFieldShortCode: baseFieldFile.shortCode,
 				batchId: batch.id,
@@ -2422,7 +2597,7 @@ describe('/changemakers', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-
+			const testUserAuthContext = getAuthContext(testUser);
 			// Create a file-type base field (must be ORGANIZATION category to appear in changemaker fields)
 			const baseFieldFile = await createOrUpdateBaseField(db, null, {
 				label: 'Organization Attachment',
@@ -2435,7 +2610,7 @@ describe('/changemakers', () => {
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
 
-			const changemaker = await createChangemaker(db, null, {
+			const changemaker = await createChangemaker(db, testUserAuthContext, {
 				taxId: '99-9999999',
 				name: 'Test Changemaker Proposal File Download',
 				keycloakOrganizationId: null,
@@ -2449,14 +2624,14 @@ describe('/changemakers', () => {
 			});
 
 			// Create funder, opportunity, and proposal for ProposalFieldValue
-			const funder = await createTestFunder(db, null, {
+			const funder = await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'funder_proposal_file_test',
 				name: 'Funder Proposal File Test',
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 			});
-			const funderSource = await createSource(db, null, {
+			const funderSource = await createSource(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 				label: 'Funder Proposal File Source',
 			});

--- a/src/__tests__/dataProviders.int.test.ts
+++ b/src/__tests__/dataProviders.int.test.ts
@@ -12,6 +12,11 @@ import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as adminUserAuthHeader,
 } from '../test/mockJwt';
+import {
+	loadTestUser,
+	getTestUserKeycloakUserId,
+	getAuthContext,
+} from '../test/utils';
 const agent = request.agent(app);
 
 describe('/dataProviders', () => {
@@ -22,9 +27,18 @@ describe('/dataProviders', () => {
 
 		it('returns all data providers present in the database', async () => {
 			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+
 			const systemDataProvider = await loadSystemDataProvider(db, null);
-			const firstDataProvider = await createTestDataProvider(db, null);
-			const secondDataProvider = await createTestDataProvider(db, null);
+			const firstDataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
+			const secondDataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
 
 			const response = await agent
 				.get('/dataProviders')
@@ -44,8 +58,13 @@ describe('/dataProviders', () => {
 
 		it('returns exactly one data provider selected by short code', async () => {
 			const db = getDatabase();
-			await createTestDataProvider(db, null);
-			const expectedDataProvider = await createTestDataProvider(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestDataProvider(db, testUserAuthContext);
+			const expectedDataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
 
 			const response = await agent
 				.get(`/dataProviders/${expectedDataProvider.shortCode}`)
@@ -56,7 +75,9 @@ describe('/dataProviders', () => {
 
 		it('returns 404 when short code is not found', async () => {
 			const db = getDatabase();
-			await createTestDataProvider(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestDataProvider(db, testUserAuthContext);
 			await agent.get('/dataProviders/nonexistent').set(authHeader).expect(404);
 		});
 	});
@@ -84,6 +105,7 @@ describe('/dataProviders', () => {
 				shortCode: 'firework',
 				name: '🎆',
 				createdAt: expectTimestamp(),
+				createdBy: getTestUserKeycloakUserId(),
 				keycloakOrganizationId: null,
 			});
 			expect(after.count).toEqual(before.count + 1);
@@ -100,10 +122,20 @@ describe('/dataProviders', () => {
 
 		it('updates an existing data provider and no others', async () => {
 			const db = getDatabase();
-			const targetDataProvider = await createTestDataProvider(db, null, {
-				name: 'Original Name',
-			});
-			const otherDataProviderBefore = await createTestDataProvider(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+
+			const targetDataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Original Name',
+				},
+			);
+			const otherDataProviderBefore = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
 			const before = await loadTableMetrics(db, 'data_providers');
 			const result = await agent
 				.put(`/dataProviders/${targetDataProvider.shortCode}`)
@@ -125,6 +157,7 @@ describe('/dataProviders', () => {
 				name: '🎆',
 				keycloakOrganizationId: '8b0163ac-bd91-11ef-8579-9fa8ab9f4b7d',
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(before.count);
 			expect(otherDataProviderAfter).toEqual(otherDataProviderBefore);

--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -11,7 +11,11 @@ import {
 	loadFunderCollaborativeMember,
 	createPermissionGrant,
 } from '../database';
-import { getAuthContext, loadTestUser } from '../test/utils';
+import {
+	getAuthContext,
+	loadTestUser,
+	getTestUserKeycloakUserId,
+} from '../test/utils';
 import {
 	expectArray,
 	expectArrayContaining,
@@ -30,9 +34,11 @@ import {
 	PermissionGrantVerb,
 } from '../types';
 import type { TinyPg } from 'tinypg';
+import type { AuthContext } from '../types';
 
 const createTestFunders = async (
 	db: TinyPg,
+	authContext: AuthContext,
 	{
 		theFundFund,
 		theFoundationFoundation,
@@ -49,32 +55,32 @@ const createTestFunders = async (
 		theFungibleFund: boolean;
 	},
 ) => {
-	await createTestFunder(db, null, {
+	await createTestFunder(db, authContext, {
 		shortCode: 'theFundFund',
 		name: 'The Fund Fund',
 		isCollaborative: theFundFund,
 	});
-	await createTestFunder(db, null, {
+	await createTestFunder(db, authContext, {
 		shortCode: 'theFoundationFoundation',
 		name: 'The Foundation Foundation',
 		isCollaborative: theFoundationFoundation,
 	});
-	await createTestFunder(db, null, {
+	await createTestFunder(db, authContext, {
 		shortCode: 'theFundersWhoFund',
 		name: 'The Funders Who Fund',
 		isCollaborative: theFundersWhoFund,
 	});
-	await createTestFunder(db, null, {
+	await createTestFunder(db, authContext, {
 		shortCode: 'theFundingFathers',
 		name: 'The Funding Fathers',
 		isCollaborative: theFundingFathers,
 	});
-	await createTestFunder(db, null, {
+	await createTestFunder(db, authContext, {
 		shortCode: 'theFunnyFunders',
 		name: 'The Funny Funders',
 		isCollaborative: theFunnyFunders,
 	});
-	await createTestFunder(db, null, {
+	await createTestFunder(db, authContext, {
 		shortCode: 'theFungibleFund',
 		name: 'The Fungible Fund',
 		isCollaborative: theFungibleFund,
@@ -92,11 +98,13 @@ describe('/funders', () => {
 		it('returns all funders present in the database', async () => {
 			const db = getDatabase();
 			const systemFunder = await loadSystemFunder(db, null);
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 			});
-			await createTestFunder(db, null, {
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 			});
@@ -107,6 +115,7 @@ describe('/funders', () => {
 					{
 						shortCode: 'theFoundationFoundation',
 						createdAt: expectTimestamp(),
+						createdBy: testUser.keycloakUserId,
 						name: 'The Foundation Foundation',
 						keycloakOrganizationId: null,
 						isCollaborative: false,
@@ -114,6 +123,7 @@ describe('/funders', () => {
 					{
 						shortCode: 'theFundFund',
 						createdAt: expectTimestamp(),
+						createdBy: testUser.keycloakUserId,
 						name: 'The Fund Fund',
 						keycloakOrganizationId: null,
 						isCollaborative: false,
@@ -126,11 +136,13 @@ describe('/funders', () => {
 
 		it('returns a subset of funders when search is provided', async () => {
 			const db = getDatabase();
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'greenFund',
 				name: 'Green Environment Fund',
 			});
-			await createTestFunder(db, null, {
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'techGrants',
 				name: 'Tech Innovation Grants',
 			});
@@ -145,6 +157,7 @@ describe('/funders', () => {
 					{
 						shortCode: 'greenFund',
 						createdAt: expectTimestamp(),
+						createdBy: testUser.keycloakUserId,
 						name: 'Green Environment Fund',
 						keycloakOrganizationId: null,
 						isCollaborative: false,
@@ -155,7 +168,9 @@ describe('/funders', () => {
 
 		it('returns no funders when search does not match', async () => {
 			const db = getDatabase();
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'greenFund',
 				name: 'Green Environment Fund',
 			});
@@ -172,18 +187,20 @@ describe('/funders', () => {
 
 		it('returns a collaborative funder when search matches a member funder name', async () => {
 			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const collaborative = await createTestFunder(db, null, {
+			const collaborative = await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'climateCollab',
 				name: 'Climate Collaborative',
 				isCollaborative: true,
 			});
-			const memberFunder = await createTestFunder(db, null, {
+			const memberFunder = await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'solarFund',
 				name: 'Solar Energy Fund',
 			});
-			await createTestFunder(db, null, {
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'unrelatedFund',
 				name: 'Unrelated Fund',
 			});
@@ -219,11 +236,13 @@ describe('/funders', () => {
 
 		it('returns exactly one funder selected by short code', async () => {
 			const db = getDatabase();
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 			});
-			await createTestFunder(db, null, {
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: '0de87edc-be40-11ef-8249-0312f1b87538',
@@ -236,6 +255,7 @@ describe('/funders', () => {
 			expect(response.body).toStrictEqual({
 				shortCode: 'theFoundationFoundation',
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 				name: 'The Foundation Foundation',
 				keycloakOrganizationId: '0de87edc-be40-11ef-8249-0312f1b87538',
 				isCollaborative: false,
@@ -244,7 +264,9 @@ describe('/funders', () => {
 
 		it('returns 404 when short code is not found', async () => {
 			const db = getDatabase();
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 			});
@@ -275,6 +297,7 @@ describe('/funders', () => {
 				shortCode: 'firework',
 				name: '🎆',
 				createdAt: expectTimestamp(),
+				createdBy: getTestUserKeycloakUserId(),
 				isCollaborative: false,
 			});
 			expect(after.count).toEqual(before.count + 1);
@@ -291,14 +314,20 @@ describe('/funders', () => {
 
 		it('updates an existing funder and no others', async () => {
 			const db = getDatabase();
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'firework',
 				name: 'boring text-based firework',
 			});
-			const anotherFunderBefore = await createTestFunder(db, null, {
-				shortCode: 'anotherFirework',
-				name: 'another boring text based firework',
-			});
+			const anotherFunderBefore = await createTestFunder(
+				db,
+				testUserAuthContext,
+				{
+					shortCode: 'anotherFirework',
+					name: 'another boring text based firework',
+				},
+			);
 			const before = await loadTableMetrics(db, 'data_providers');
 			const result = await agent
 				.put('/funders/firework')
@@ -313,6 +342,7 @@ describe('/funders', () => {
 				name: '🎆',
 				keycloakOrganizationId: null,
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 				isCollaborative: false,
 			});
 			expect(after.count).toEqual(before.count);
@@ -362,8 +392,7 @@ describe('/funders', () => {
 				const db = getDatabase();
 				const testUser = await loadTestUser(db);
 				const testUserAuthContext = getAuthContext(testUser);
-
-				await createTestFunders(db, {
+				await createTestFunders(db, testUserAuthContext, {
 					theFundFund: true,
 					theFoundationFoundation: false,
 					theFundersWhoFund: false,
@@ -437,7 +466,9 @@ describe('/funders', () => {
 
 			it('requires MANAGE permission on the funder', async () => {
 				const db = getDatabase();
-				await createTestFunders(db, {
+				const testUser = await loadTestUser(db);
+				const testUserAuthContext = getAuthContext(testUser);
+				await createTestFunders(db, testUserAuthContext, {
 					theFundFund: true,
 					theFoundationFoundation: false,
 					theFundersWhoFund: false,
@@ -462,7 +493,7 @@ describe('/funders', () => {
 				const testUserAuthContext = getAuthContext(testUser);
 				const systemUser = await loadSystemUser(db, null);
 				const systemUserAuthContext = getAuthContext(systemUser);
-				await createTestFunders(db, {
+				await createTestFunders(db, testUserAuthContext, {
 					theFundFund: true,
 					theFoundationFoundation: false,
 					theFundersWhoFund: false,
@@ -498,9 +529,10 @@ describe('/funders', () => {
 			it('throws a 404 when the funder collaborative member does not exist', async () => {
 				const db = getDatabase();
 				const testUser = await loadTestUser(db);
+				const testUserAuthContext = getAuthContext(testUser);
 				const systemUser = await loadSystemUser(db, null);
 				const systemUserAuthContext = getAuthContext(systemUser);
-				await createTestFunders(db, {
+				await createTestFunders(db, testUserAuthContext, {
 					theFundFund: true,
 					theFoundationFoundation: false,
 					theFundersWhoFund: false,
@@ -557,7 +589,9 @@ describe('/funders', () => {
 			it('creates and returns exactly one funder collaborative member', async () => {
 				const db = getDatabase();
 				const adminUser = await loadTestUser(db);
-				await createTestFunders(db, {
+				const testUser = await loadTestUser(db);
+				const testUserAuthContext = getAuthContext(testUser);
+				await createTestFunders(db, testUserAuthContext, {
 					theFundFund: true,
 					theFoundationFoundation: false,
 					theFundersWhoFund: false,
@@ -579,7 +613,9 @@ describe('/funders', () => {
 
 			it('returns 400 when the funder is not collaborative', async () => {
 				const db = getDatabase();
-				await createTestFunders(db, {
+				const testUser = await loadTestUser(db);
+				const testUserAuthContext = getAuthContext(testUser);
+				await createTestFunders(db, testUserAuthContext, {
 					theFundFund: false,
 					theFoundationFoundation: false,
 					theFundersWhoFund: false,
@@ -630,8 +666,9 @@ describe('/funders', () => {
 				const db = getDatabase();
 				const adminUser = await loadTestUser(db);
 				const adminUserAuthContext = getAuthContext(adminUser);
-
-				await createTestFunders(db, {
+				const testUser = await loadTestUser(db);
+				const testUserAuthContext = getAuthContext(testUser);
+				await createTestFunders(db, testUserAuthContext, {
 					theFundFund: true,
 					theFoundationFoundation: false,
 					theFundersWhoFund: false,
@@ -682,7 +719,9 @@ describe('/funders', () => {
 	describe('POST /:shortCode/invitations/sent/:invitedFunderShortCode', () => {
 		it('requires authentication', async () => {
 			const db = getDatabase();
-			await createTestFunders(db, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunders(db, testUserAuthContext, {
 				theFundFund: true,
 				theFoundationFoundation: false,
 				theFundersWhoFund: false,
@@ -710,12 +749,14 @@ describe('/funders', () => {
 
 		it('requires MANAGE permission on the funder', async () => {
 			const db = getDatabase();
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				isCollaborative: true,
 			});
-			await createTestFunder(db, null, {
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFoundationFoundation',
 				name: 'The Foundation Foundation',
 			});
@@ -737,10 +778,10 @@ describe('/funders', () => {
 		it('creates an invitation to a non-collaborative funder from a collaborative funder, and returns it', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-
-			await createTestFunders(db, {
+			await createTestFunders(db, testUserAuthContext, {
 				theFundFund: false,
 				theFoundationFoundation: true,
 				theFundersWhoFund: false,
@@ -773,7 +814,9 @@ describe('/funders', () => {
 		});
 		it('returns a 400 error when the source funder is not collaborative', async () => {
 			const db = getDatabase();
-			await createTestFunders(db, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunders(db, testUserAuthContext, {
 				theFundFund: false,
 				theFoundationFoundation: false,
 				theFundersWhoFund: false,
@@ -795,7 +838,9 @@ describe('/funders', () => {
 		});
 		it('returns a 400 bad request error when the invited funder is collaborative', async () => {
 			const db = getDatabase();
-			await createTestFunders(db, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunders(db, testUserAuthContext, {
 				theFundFund: true,
 				theFoundationFoundation: true,
 				theFundersWhoFund: false,
@@ -831,7 +876,9 @@ describe('/funders', () => {
 
 		it('requires MANAGE permission on the funder', async () => {
 			const db = getDatabase();
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				isCollaborative: true,
@@ -852,11 +899,11 @@ describe('/funders', () => {
 
 		it('returns all (and only) invitations sent by the funder when the user has MANAGE permission on the funder', async () => {
 			const db = getDatabase();
-			const testUser = await loadTestUser(db);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-
-			await createTestFunders(db, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunders(db, testUserAuthContext, {
 				theFundFund: true,
 				theFoundationFoundation: true,
 				theFundersWhoFund: false,
@@ -930,7 +977,9 @@ describe('/funders', () => {
 
 		it('requires MANAGE permission on the funder', async () => {
 			const db = getDatabase();
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				isCollaborative: true,
@@ -952,10 +1001,11 @@ describe('/funders', () => {
 		it('returns all (and only) invitations received by the funder when the user has MANAGE permission on the funder', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			await createTestFunders(db, {
+			await createTestFunders(db, testUserAuthContext, {
 				theFundFund: false,
 				theFoundationFoundation: true,
 				theFundersWhoFund: false,
@@ -1045,7 +1095,9 @@ describe('/funders', () => {
 
 		it('requires MANAGE permission on the invited funder', async () => {
 			const db = getDatabase();
-			await createTestFunder(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
 				shortCode: 'theFundFund',
 				name: 'The Fund Fund',
 				isCollaborative: true,
@@ -1061,10 +1113,11 @@ describe('/funders', () => {
 		it('successfully updates the invitation status to accepted, and creates a funder collaborative member', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			await createTestFunders(db, {
+			await createTestFunders(db, testUserAuthContext, {
 				theFundFund: false,
 				theFoundationFoundation: true,
 				theFundersWhoFund: false,
@@ -1124,10 +1177,11 @@ describe('/funders', () => {
 		it('successfully updates the invitation status to rejected, and does not create a funder collaborative member', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 
-			await createTestFunders(db, {
+			await createTestFunders(db, testUserAuthContext, {
 				theFundFund: false,
 				theFoundationFoundation: true,
 				theFundersWhoFund: false,
@@ -1184,10 +1238,11 @@ describe('/funders', () => {
 	it('throws a 400 error if the invitation status is updated after it has been accepted', async () => {
 		const db = getDatabase();
 		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
 		const systemUser = await loadSystemUser(db, null);
 		const systemUserAuthContext = getAuthContext(systemUser);
 
-		await createTestFunders(db, {
+		await createTestFunders(db, testUserAuthContext, {
 			theFundFund: false,
 			theFoundationFoundation: true,
 			theFundersWhoFund: false,
@@ -1235,10 +1290,11 @@ describe('/funders', () => {
 	it('throws a 400 error if the invitation status is updated after it has rejected', async () => {
 		const db = getDatabase();
 		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
 		const systemUser = await loadSystemUser(db, null);
 		const systemUserAuthContext = getAuthContext(systemUser);
 
-		await createTestFunders(db, {
+		await createTestFunders(db, testUserAuthContext, {
 			theFundFund: false,
 			theFoundationFoundation: true,
 			theFundersWhoFund: false,
@@ -1286,10 +1342,11 @@ describe('/funders', () => {
 	it('throws a 400 error if the invitation status is updated to an invalid value', async () => {
 		const db = getDatabase();
 		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
 		const systemUser = await loadSystemUser(db, null);
 		const systemUserAuthContext = getAuthContext(systemUser);
 
-		await createTestFunders(db, {
+		await createTestFunders(db, testUserAuthContext, {
 			theFundFund: false,
 			theFoundationFoundation: true,
 			theFundersWhoFund: false,
@@ -1338,10 +1395,11 @@ describe('/funders', () => {
 	it('throws a 400 error if the invitation status is set to null', async () => {
 		const db = getDatabase();
 		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
 		const systemUser = await loadSystemUser(db, null);
 		const systemUserAuthContext = getAuthContext(systemUser);
 
-		await createTestFunders(db, {
+		await createTestFunders(db, testUserAuthContext, {
 			theFundFund: false,
 			theFoundationFoundation: true,
 			theFundersWhoFund: false,

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -42,13 +42,24 @@ describe('/opportunities', () => {
 
 		it('returns all opportunities present in the database for an admin user', async () => {
 			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+
 			const systemOpportunity = await loadSystemOpportunity(db, null);
-			const opportunity1 = await createTestOpportunity(db, null, {
-				title: 'Tremendous opportunity 👌',
-			});
-			const opportunity2 = await createTestOpportunity(db, null, {
-				title: 'Terrific opportunity 👐',
-			});
+			const opportunity1 = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					title: 'Tremendous opportunity 👌',
+				},
+			);
+			const opportunity2 = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					title: 'Terrific opportunity 👐',
+				},
+			);
 			const response = await request(app)
 				.get('/opportunities')
 				.set(authHeaderWithAdminRole)
@@ -64,9 +75,10 @@ describe('/opportunities', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const visibleFunder = await loadSystemFunder(db, null);
 			const systemOpportunity = await loadSystemOpportunity(db, null);
-			const anotherFunder = await createTestFunder(db, null);
+			const anotherFunder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -75,11 +87,15 @@ describe('/opportunities', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const visibleOpportunity = await createTestOpportunity(db, null, {
-				title: 'Tremendous opportunity 👌',
-				funderShortCode: visibleFunder.shortCode,
-			});
-			await createTestOpportunity(db, null, {
+			const visibleOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					title: 'Tremendous opportunity 👌',
+					funderShortCode: visibleFunder.shortCode,
+				},
+			);
+			await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: anotherFunder.shortCode,
 			});
 			const response = await request(app)
@@ -100,9 +116,15 @@ describe('/opportunities', () => {
 
 		it('returns exactly one opportunity selected by id', async () => {
 			const db = getDatabase();
-			await createTestOpportunity(db, null);
-			const secondOpportunity = await createTestOpportunity(db, null);
-			await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+
+			await createTestOpportunity(db, testUserAuthContext);
+			const secondOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+			);
+			await createTestOpportunity(db, testUserAuthContext);
 
 			const response = await request(app)
 				.get(`/opportunities/${secondOpportunity.id}`)
@@ -116,7 +138,8 @@ describe('/opportunities', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
-			const visibleFunder = await createTestFunder(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -125,7 +148,7 @@ describe('/opportunities', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: visibleFunder.shortCode,
 			});
 			const response = await request(app)
@@ -159,7 +182,9 @@ describe('/opportunities', () => {
 
 		it('returns 404 when id is not found', async () => {
 			const db = getDatabase();
-			await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestOpportunity(db, testUserAuthContext);
 			await request(app)
 				.get('/opportunities/9001')
 				.set(authHeaderWithAdminRole)
@@ -171,7 +196,8 @@ describe('/opportunities', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-			const opportunity = await createTestOpportunity(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			// Also create a userGroup permission grant with an EXPIRED association
 			// to verify that expired associations don't grant access
@@ -232,6 +258,7 @@ describe('/opportunities', () => {
 				id: 2,
 				title: '🎆',
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(2);
 		});

--- a/src/__tests__/organizations.int.test.ts
+++ b/src/__tests__/organizations.int.test.ts
@@ -23,7 +23,11 @@ import {
 	PermissionGrantVerb,
 	stringToKeycloakId,
 } from '../types';
-import { getAuthContext, getTestAuthContext } from '../test/utils';
+import {
+	getAuthContext,
+	getTestAuthContext,
+	loadTestUser,
+} from '../test/utils';
 const agent = request.agent(app);
 
 describe('/organizations', () => {
@@ -36,34 +40,44 @@ describe('/organizations', () => {
 
 		it('returns changemaker, data provider, and funder selected by keycloak org id for admins', async () => {
 			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const keycloakOrganizationId = stringToKeycloakId(
 				'bde830f0-d590-467a-8431-cdf9d6af1b87',
 			);
 
 			// Unlinked entities (should not be returned)
-			await createTestChangemaker(db, null);
-			await createTestDataProvider(db, null);
-			await createTestFunder(db, null);
+			await createTestChangemaker(db, testUserAuthContext);
+			await createTestDataProvider(db, testUserAuthContext);
+			await createTestFunder(db, testUserAuthContext);
 
 			// Expected entities (linked to target keycloakOrganizationId)
-			const expectedChangemaker = await createTestChangemaker(db, null, {
-				keycloakOrganizationId,
-			});
-			const expectedDataProvider = await createTestDataProvider(db, null, {
-				keycloakOrganizationId,
-			});
-			const expectedFunder = await createTestFunder(db, null, {
+			const expectedChangemaker = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					keycloakOrganizationId,
+				},
+			);
+			const expectedDataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+				{
+					keycloakOrganizationId,
+				},
+			);
+			const expectedFunder = await createTestFunder(db, testUserAuthContext, {
 				keycloakOrganizationId,
 			});
 
 			// Decoy entities (linked to different keycloakOrganizationIds)
-			await createTestChangemaker(db, null, {
+			await createTestChangemaker(db, testUserAuthContext, {
 				keycloakOrganizationId: 'fa32e21e-e471-4d28-b101-7788c611aa04',
 			});
-			await createTestDataProvider(db, null, {
+			await createTestDataProvider(db, testUserAuthContext, {
 				keycloakOrganizationId: '865cb652-a1d2-418a-8c89-015c0d6e4676',
 			});
-			await createTestFunder(db, null, {
+			await createTestFunder(db, testUserAuthContext, {
 				keycloakOrganizationId: '75b4198f-dd88-4a6c-8259-fe4d725af125',
 			});
 
@@ -77,6 +91,7 @@ describe('/organizations', () => {
 					taxId: expectedChangemaker.taxId,
 					name: expectedChangemaker.name,
 					createdAt: expectedChangemaker.createdAt,
+					createdBy: testUser.keycloakUserId,
 					id: expectedChangemaker.id,
 					keycloakOrganizationId: expectedChangemaker.keycloakOrganizationId,
 				},
@@ -91,11 +106,11 @@ describe('/organizations', () => {
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const keycloakOrganizationId = 'b5465297-d63a-4371-8054-f94d95f1aace';
 
-			await createTestFunder(db, null, {
+			await createTestFunder(db, systemUserAuthContext, {
 				name: 'Unlinked funder one.',
 				shortCode: 'unlinkedfunderone',
 			});
-			const expectedFunder = await createTestFunder(db, null, {
+			const expectedFunder = await createTestFunder(db, systemUserAuthContext, {
 				name: 'Funderdome',
 				shortCode: 'funderdome',
 				keycloakOrganizationId,
@@ -112,7 +127,7 @@ describe('/organizations', () => {
 			});
 			const keycloakOrganizationIdLackingPerm =
 				'75b4198f-dd88-4a6c-8259-fe4d725af125';
-			await createTestFunder(db, null, {
+			await createTestFunder(db, systemUserAuthContext, {
 				name: 'Decoy funder, unexpected because I lack view access to this org',
 				shortCode: 'decoyfunderunexpected',
 				keycloakOrganizationId: keycloakOrganizationIdLackingPerm,
@@ -137,19 +152,23 @@ describe('/organizations', () => {
 
 		it('returns only the data provider on which my org has view permission', async () => {
 			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const keycloakOrganizationId = stringToKeycloakId(mockOrgId);
 
-			await createTestDataProvider(db, null, {
+			await createTestDataProvider(db, systemUserAuthContext, {
 				name: 'Unlinked Data Provider one.',
 				shortCode: 'unlinkeddataproviderone',
 			});
-			const expectedDataProvider = await createTestDataProvider(db, null, {
-				name: 'Dapper Data Provider',
-				shortCode: 'dapperdataprovider',
-				keycloakOrganizationId,
-			});
-			const systemUser = await loadSystemUser(db, null);
-			const systemUserAuthContext = getAuthContext(systemUser, true);
+			const expectedDataProvider = await createTestDataProvider(
+				db,
+				systemUserAuthContext,
+				{
+					name: 'Dapper Data Provider',
+					shortCode: 'dapperdataprovider',
+					keycloakOrganizationId,
+				},
+			);
 			// Grant my organization of which I'm a member view access to this data provider
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER_GROUP,
@@ -161,7 +180,7 @@ describe('/organizations', () => {
 			});
 			const keycloakOrganizationIdLackingPerm =
 				'24fea6aa-f1c5-4594-8bdc-b1789d4d0840';
-			await createTestDataProvider(db, null, {
+			await createTestDataProvider(db, systemUserAuthContext, {
 				name: 'Decoy Data Provider, unexpected because I lack view access to this org',
 				shortCode: 'decoydataproviderunexpected',
 				keycloakOrganizationId: keycloakOrganizationIdLackingPerm,

--- a/src/__tests__/permissionGrants.int.test.ts
+++ b/src/__tests__/permissionGrants.int.test.ts
@@ -88,7 +88,7 @@ describe('/permissionGrants', () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
 			await createTestPermissionGrant(db, authContext);
-			const funder = await createTestFunder(db, null);
+			const funder = await createTestFunder(db, authContext);
 			await createTestPermissionGrant(db, authContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
@@ -185,7 +185,8 @@ describe('/permissionGrants', () => {
 
 		it('requires administrator role', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
 			await agent
 				.post('/permissionGrants')
 				.type('application/json')
@@ -204,7 +205,8 @@ describe('/permissionGrants', () => {
 
 		it('creates and returns a permission grant for a user', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
 			const before = await loadTableMetrics(db, 'permission_grants');
 			const result = await agent
 				.post('/permissionGrants')
@@ -238,7 +240,8 @@ describe('/permissionGrants', () => {
 		it('creates and returns a permission grant for a user group', async () => {
 			const db = getDatabase();
 			const userGroupKeycloakId = '47d406ad-5e50-42d4-88f1-f87947a3e314';
-			const funder = await createTestFunder(db, null);
+			const authContext = await getTestAuthContext(db);
+			const funder = await createTestFunder(db, authContext);
 			const before = await loadTableMetrics(db, 'permission_grants');
 			const result = await agent
 				.post('/permissionGrants')
@@ -273,7 +276,8 @@ describe('/permissionGrants', () => {
 			const db = getDatabase();
 			const arbitraryUserKeycloakUserId =
 				'b4e46c13-0abc-4a7e-9d72-a1b2c3d4e5f6';
-			const changemaker = await createTestChangemaker(db, null);
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
 			const result = await agent
 				.post('/permissionGrants')
 				.type('application/json')
@@ -524,7 +528,8 @@ describe('/permissionGrants', () => {
 
 		it('returns 400 bad request when scope contains entity type not allowed for context', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
 			const result = await agent
 				.post('/permissionGrants')
 				.type('application/json')
@@ -546,7 +551,8 @@ describe('/permissionGrants', () => {
 
 		it('returns 400 bad request when scope contains mix of allowed and disallowed types', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
 			const result = await agent
 				.post('/permissionGrants')
 				.type('application/json')
@@ -630,7 +636,8 @@ describe('/permissionGrants', () => {
 
 		it('creates and returns a permission grant with conditions', async () => {
 			const db = getDatabase();
-			const funder = await createOrUpdateFunder(db, null, {
+			const authContext = await getTestAuthContext(db);
+			const funder = await createOrUpdateFunder(db, authContext, {
 				shortCode: 'condFunder',
 				name: 'Conditions Test Funder',
 				keycloakOrganizationId: null,
@@ -679,7 +686,8 @@ describe('/permissionGrants', () => {
 
 		it('creates a permission grant with null conditions', async () => {
 			const db = getDatabase();
-			const funder = await createOrUpdateFunder(db, null, {
+			const authContext = await getTestAuthContext(db);
+			const funder = await createOrUpdateFunder(db, authContext, {
 				shortCode: 'nullCondFunder',
 				name: 'Null Conditions Funder',
 				keycloakOrganizationId: null,
@@ -707,7 +715,8 @@ describe('/permissionGrants', () => {
 
 		it('creates a permission grant with in operator condition', async () => {
 			const db = getDatabase();
-			const funder = await createOrUpdateFunder(db, null, {
+			const authContext = await getTestAuthContext(db);
+			const funder = await createOrUpdateFunder(db, authContext, {
 				shortCode: 'eqCondFunder',
 				name: 'In Condition Funder',
 				keycloakOrganizationId: null,
@@ -747,7 +756,8 @@ describe('/permissionGrants', () => {
 
 		it('returns 400 when conditions has invalid property name', async () => {
 			const db = getDatabase();
-			const funder = await createOrUpdateFunder(db, null, {
+			const authContext = await getTestAuthContext(db);
+			const funder = await createOrUpdateFunder(db, authContext, {
 				shortCode: 'badFieldFunder',
 				name: 'Bad Field Funder',
 				keycloakOrganizationId: null,
@@ -781,7 +791,8 @@ describe('/permissionGrants', () => {
 
 		it('returns 400 when conditions has invalid operator', async () => {
 			const db = getDatabase();
-			const funder = await createOrUpdateFunder(db, null, {
+			const authContext = await getTestAuthContext(db);
+			const funder = await createOrUpdateFunder(db, authContext, {
 				shortCode: 'badOpFunder',
 				name: 'Bad Op Funder',
 				keycloakOrganizationId: null,
@@ -815,7 +826,8 @@ describe('/permissionGrants', () => {
 
 		it('returns 400 when condition key is not in scope', async () => {
 			const db = getDatabase();
-			const funder = await createOrUpdateFunder(db, null, {
+			const authContext = await getTestAuthContext(db);
+			const funder = await createOrUpdateFunder(db, authContext, {
 				shortCode: 'noScopeFunder',
 				name: 'No Scope Funder',
 				keycloakOrganizationId: null,
@@ -871,7 +883,7 @@ describe('/permissionGrants', () => {
 		it('updates and returns the permission grant', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const changemaker = await createTestChangemaker(db, null);
+			const changemaker = await createTestChangemaker(db, authContext);
 			const permissionGrant = await createTestPermissionGrant(db, authContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
@@ -911,7 +923,7 @@ describe('/permissionGrants', () => {
 		it('updates the context entity of a permission grant', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const changemaker = await createTestChangemaker(db, null);
+			const changemaker = await createTestChangemaker(db, authContext);
 			const permissionGrant = await createTestPermissionGrant(db, authContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
@@ -920,7 +932,7 @@ describe('/permissionGrants', () => {
 				scope: [PermissionGrantEntityType.CHANGEMAKER],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const funder = await createTestFunder(db, null);
+			const funder = await createTestFunder(db, authContext);
 
 			const response = await agent
 				.put(`/permissionGrants/${permissionGrant.id}`)
@@ -950,7 +962,7 @@ describe('/permissionGrants', () => {
 		it('updates the grantee of a permission grant', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const changemaker = await createTestChangemaker(db, null);
+			const changemaker = await createTestChangemaker(db, authContext);
 			const permissionGrant = await createTestPermissionGrant(db, authContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
@@ -989,7 +1001,7 @@ describe('/permissionGrants', () => {
 		it('updates conditions on a permission grant', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const funder = await createTestFunder(db, null);
+			const funder = await createTestFunder(db, authContext);
 			const permissionGrant = await createTestPermissionGrant(db, authContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
@@ -1035,7 +1047,7 @@ describe('/permissionGrants', () => {
 		it('does not create a new row when updating', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const changemaker = await createTestChangemaker(db, null);
+			const changemaker = await createTestChangemaker(db, authContext);
 			const permissionGrant = await createTestPermissionGrant(db, authContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
@@ -1106,7 +1118,7 @@ describe('/permissionGrants', () => {
 		it('returns 400 bad request when scope is not valid for context entity type', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const changemaker = await createTestChangemaker(db, null);
+			const changemaker = await createTestChangemaker(db, authContext);
 			const permissionGrant = await createTestPermissionGrant(db, authContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
@@ -1136,7 +1148,8 @@ describe('/permissionGrants', () => {
 
 		it('returns 404 when id is not found', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
 			await agent
 				.put('/permissionGrants/9001')
 				.type('application/json')
@@ -1200,8 +1213,8 @@ describe('/permissionGrants', () => {
 		it('cascades deletion when the referenced entity is deleted', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const changemaker = await createTestChangemaker(db, null);
-			const source = await createSource(db, null, {
+			const changemaker = await createTestChangemaker(db, authContext);
+			const source = await createSource(db, authContext, {
 				label: 'Cascade Test Source',
 				changemakerId: changemaker.id,
 			});

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -78,7 +78,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -111,7 +111,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const visibleFunder = await createTestFunder(db, null);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -123,7 +123,7 @@ describe('/proposalVersions', () => {
 				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: visibleFunder.shortCode,
 			});
 			const proposal = await createProposal(db, testUserAuthContext, {
@@ -158,9 +158,13 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const visibleChangemaker = await createTestChangemaker(db, null, {
-				name: 'Visible Changemaker',
-			});
+			const visibleChangemaker = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Visible Changemaker',
+				},
+			);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -172,7 +176,7 @@ describe('/proposalVersions', () => {
 				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -235,7 +239,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -270,7 +274,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -309,7 +313,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const testFunder = await createTestFunder(db, null);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -322,7 +326,7 @@ describe('/proposalVersions', () => {
 				],
 				verbs: [PermissionGrantVerb.VIEW, PermissionGrantVerb.EDIT],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
 			const proposal = await createProposal(db, testUserAuthContext, {
@@ -360,7 +364,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const testFunder = await createTestFunder(db, null);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -384,7 +388,7 @@ describe('/proposalVersions', () => {
 				],
 				verbs: [PermissionGrantVerb.EDIT],
 			});
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
 			const proposal = await createProposal(db, testUserAuthContext, {
@@ -415,7 +419,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -460,7 +464,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -547,7 +551,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -680,7 +684,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -717,7 +721,7 @@ describe('/proposalVersions', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -744,7 +748,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -786,8 +790,8 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity1 = await createTestOpportunity(db, null);
-			const opportunity2 = await createTestOpportunity(db, null);
+			const opportunity1 = await createTestOpportunity(db, testUserAuthContext);
+			const opportunity2 = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity1.id,
@@ -835,7 +839,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -886,7 +890,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -987,7 +991,7 @@ describe('/proposalVersions', () => {
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
 
-			const opportunity = await createOpportunity(db, null, {
+			const opportunity = await createOpportunity(db, testUserAuthContext, {
 				title: 'Conditional Test Opportunity',
 				funderShortCode: systemFunder.shortCode,
 			});
@@ -1114,7 +1118,7 @@ describe('/proposalVersions', () => {
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
 
-			const opportunity = await createOpportunity(db, null, {
+			const opportunity = await createOpportunity(db, testUserAuthContext, {
 				title: 'No Conditions Test Opportunity',
 				funderShortCode: systemFunder.shortCode,
 			});
@@ -1219,7 +1223,7 @@ describe('/proposalVersions', () => {
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
 
-			const opportunity = await createOpportunity(db, null, {
+			const opportunity = await createOpportunity(db, testUserAuthContext, {
 				title: 'Exclusion Test Opportunity',
 				funderShortCode: systemFunder.shortCode,
 			});
@@ -1323,7 +1327,7 @@ describe('/proposalVersions', () => {
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
 
-			const opportunity = await createOpportunity(db, null, {
+			const opportunity = await createOpportunity(db, testUserAuthContext, {
 				title: 'Equals Test Opportunity',
 				funderShortCode: systemFunder.shortCode,
 			});
@@ -1426,8 +1430,8 @@ describe('/proposalVersions', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
 
-			const grantedFunder = await createTestFunder(db, null);
-			const otherFunder = await createTestFunder(db, null);
+			const grantedFunder = await createTestFunder(db, testUserAuthContext);
+			const otherFunder = await createTestFunder(db, testUserAuthContext);
 
 			await createOrUpdateBaseField(db, null, {
 				label: 'Budget Amount',
@@ -1441,10 +1445,14 @@ describe('/proposalVersions', () => {
 			});
 
 			// Set up opportunity + proposal + field values for the OTHER funder
-			const otherOpportunity = await createOpportunity(db, null, {
-				title: 'Other Funder Opportunity',
-				funderShortCode: otherFunder.shortCode,
-			});
+			const otherOpportunity = await createOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					title: 'Other Funder Opportunity',
+					funderShortCode: otherFunder.shortCode,
+				},
+			);
 			const otherProposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'other-funder-proposal-1',
 				opportunityId: otherOpportunity.id,
@@ -1514,8 +1522,8 @@ describe('/proposalVersions', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
 
-			const grantedFunder = await createTestFunder(db, null);
-			const otherFunder = await createTestFunder(db, null);
+			const grantedFunder = await createTestFunder(db, testUserAuthContext);
+			const otherFunder = await createTestFunder(db, testUserAuthContext);
 
 			await createOrUpdateBaseField(db, null, {
 				label: 'Budget Amount',
@@ -1539,10 +1547,14 @@ describe('/proposalVersions', () => {
 			});
 
 			// Set up data for the GRANTED funder
-			const grantedOpportunity = await createOpportunity(db, null, {
-				title: 'Granted Funder Opportunity',
-				funderShortCode: grantedFunder.shortCode,
-			});
+			const grantedOpportunity = await createOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					title: 'Granted Funder Opportunity',
+					funderShortCode: grantedFunder.shortCode,
+				},
+			);
 			const grantedProposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'granted-funder-proposal-1',
 				opportunityId: grantedOpportunity.id,
@@ -1594,10 +1606,14 @@ describe('/proposalVersions', () => {
 			});
 
 			// Set up data for the OTHER funder
-			const otherOpportunity = await createOpportunity(db, null, {
-				title: 'Other Funder Opportunity',
-				funderShortCode: otherFunder.shortCode,
-			});
+			const otherOpportunity = await createOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					title: 'Other Funder Opportunity',
+					funderShortCode: otherFunder.shortCode,
+				},
+			);
 			const otherProposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'other-funder-proposal-1',
 				opportunityId: otherOpportunity.id,

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -90,13 +90,17 @@ describe('/proposals', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const anotherFunder = await loadSystemFunder(db, null);
-			const visibleFunder = await createTestFunder(db, null, {
+			const visibleFunder = await createTestFunder(db, testUserAuthContext, {
 				name: 'Visible Funder',
 				shortCode: 'visibleFunder',
 			});
-			const visibleChangemaker = await createTestChangemaker(db, null, {
-				name: 'Visible Changemaker',
-			});
+			const visibleChangemaker = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+				{
+					name: 'Visible Changemaker',
+				},
+			);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -119,12 +123,20 @@ describe('/proposals', () => {
 				],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			const visibleOpportunity = await createTestOpportunity(db, null, {
-				funderShortCode: visibleFunder.shortCode,
-			});
-			const anotherOpportunity = await createTestOpportunity(db, null, {
-				funderShortCode: anotherFunder.shortCode,
-			});
+			const visibleOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: visibleFunder.shortCode,
+				},
+			);
+			const anotherOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: anotherFunder.shortCode,
+				},
+			);
 			await createTestBaseFields(db);
 			const funderVisibleProposal = await createProposal(
 				db,
@@ -175,7 +187,7 @@ describe('/proposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			await createTestBaseFields(db);
 			const proposal = await createProposal(db, testUserAuthContext, {
@@ -186,7 +198,7 @@ describe('/proposals', () => {
 				externalId: 'proposal-2',
 				opportunityId: opportunity.id,
 			});
-			const changemaker = await createTestChangemaker(db, null, {
+			const changemaker = await createTestChangemaker(db, testUserAuthContext, {
 				name: 'Canadian Company',
 			});
 			await createChangemakerProposal(db, null, {
@@ -215,6 +227,7 @@ describe('/proposals', () => {
 								name: changemaker.name,
 								keycloakOrganizationId: null,
 								createdAt: expectTimestamp(),
+								createdBy: testUser.keycloakUserId,
 							},
 						],
 					},
@@ -226,13 +239,20 @@ describe('/proposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const testFunder = await createTestFunder(db, null);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
 			await createTestBaseFields(db);
 
-			const systemOpportunity = await createTestOpportunity(db, null);
-			const testFunderOpportunity = await createTestOpportunity(db, null, {
-				funderShortCode: testFunder.shortCode,
-			});
+			const systemOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+			);
+			const testFunderOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: testFunder.shortCode,
+				},
+			);
 
 			await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
@@ -301,7 +321,7 @@ describe('/proposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			const systemSource = await loadSystemSource(db, null);
 			await createTestBaseFields(db);
@@ -423,7 +443,7 @@ describe('/proposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const systemSource = await loadSystemSource(db, null);
 			const forbiddenField = await createOrUpdateBaseField(db, null, {
 				label: 'Forbidden Field',
@@ -493,7 +513,7 @@ describe('/proposals', () => {
 				keycloakUserName: 'Dave',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			await createTestBaseFields(db);
 			await createProposal(db, testUserAuthContext, {
@@ -544,7 +564,7 @@ describe('/proposals', () => {
 				keycloakUserName: 'Erin',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			await createTestBaseFields(db);
 			await createProposal(db, testUserAuthContext, {
@@ -587,7 +607,7 @@ describe('/proposals', () => {
 				keycloakUserName: 'Fulton',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			await createTestBaseFields(db);
 			await createProposal(db, testUserAuthContext, {
@@ -626,7 +646,7 @@ describe('/proposals', () => {
 			await db.query("set default_text_search_config = 'simple';");
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const systemSource = await loadSystemSource(db, null);
 			await createTestBaseFields(db);
 			await createProposal(db, testUserAuthContext, {
@@ -747,7 +767,7 @@ describe('/proposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			await Array.from(Array(20)).reduce(async (p, _, i) => {
 				await p;
@@ -858,12 +878,13 @@ describe('/proposals', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const anotherUser = await createOrUpdateUser(db, null, {
 				keycloakUserId: '123e4567-e89b-12d3-a456-426614174000',
 				keycloakUserName: 'Georgina',
 			});
 			const anotherUserAuthContext = getAuthContext(anotherUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, anotherUserAuthContext, {
 				externalId: `proposal-1`,
 				opportunityId: opportunity.id,
@@ -925,7 +946,7 @@ describe('/proposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			await createProposal(db, testUserAuthContext, {
 				externalId: `proposal-1`,
@@ -956,7 +977,7 @@ describe('/proposals', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createTestBaseFields(db);
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
@@ -1209,7 +1230,7 @@ describe('/proposals', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
 			await createTestBaseFields(db);
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
 				name: null,
@@ -1460,7 +1481,7 @@ describe('/proposals', () => {
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const testFunder = await createTestFunder(db, null, {
+			const testFunder = await createTestFunder(db, testUserAuthContext, {
 				name: 'Test Funder',
 				shortCode: 'testFunder',
 			});
@@ -1477,7 +1498,7 @@ describe('/proposals', () => {
 				verbs: [PermissionGrantVerb.VIEW],
 			});
 
-			const opportunity = await createTestOpportunity(db, null, {
+			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
 			const applicationForm = await createApplicationForm(db, null, {
@@ -1546,7 +1567,7 @@ describe('/proposals', () => {
 				sensitivityClassification:
 					BaseFieldSensitivityClassification.RESTRICTED,
 			});
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			await createApplicationForm(db, null, {
 				opportunityId: opportunity.id,
 				name: null,
@@ -1679,9 +1700,10 @@ describe('/proposals', () => {
 
 		it('creates exactly one proposal when the user is an administrator', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
-			const before = await loadTableMetrics(db, 'proposals');
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			const before = await loadTableMetrics(db, 'proposals');
 			const result = await request(app)
 				.post('/proposals')
 				.type('application/json')
@@ -1708,6 +1730,7 @@ describe('/proposals', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemFunder = await loadSystemFunder(db, null);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
@@ -1717,7 +1740,7 @@ describe('/proposals', () => {
 				scope: [PermissionGrantEntityType.FUNDER],
 				verbs: [PermissionGrantVerb.EDIT],
 			});
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const before = await loadTableMetrics(db, 'proposals');
 			const result = await request(app)
 				.post('/proposals')
@@ -1741,7 +1764,9 @@ describe('/proposals', () => {
 
 		it('returns 422 if the user does not have permission', async () => {
 			const db = getDatabase();
-			const opportunity = await createTestOpportunity(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const before = await loadTableMetrics(db, 'proposals');
 			await request(app)
 				.post('/proposals')
@@ -1761,7 +1786,8 @@ describe('/proposals', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-			const opportunity = await createTestOpportunity(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -53,9 +53,11 @@ describe('/sources', () => {
 
 		it('returns all sources present in the database', async () => {
 			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const changemaker = await createTestChangemaker(db, null);
-			const source = await createSource(db, null, {
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			const source = await createSource(db, testUserAuthContext, {
 				label: 'Example Inc.',
 				changemakerId: changemaker.id,
 			});
@@ -74,8 +76,10 @@ describe('/sources', () => {
 
 		it('returns exactly one source selected by id', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
-			const source = await createSource(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			const source = await createSource(db, testUserAuthContext, {
 				label: 'Example Inc.',
 				changemakerId: changemaker.id,
 			});
@@ -108,8 +112,10 @@ describe('/sources', () => {
 
 		it('returns 404 when id is not found', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
-			await createSource(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			await createSource(db, testUserAuthContext, {
 				label: 'not to be returned',
 				changemakerId: changemaker.id,
 			});
@@ -124,7 +130,9 @@ describe('/sources', () => {
 
 		it('creates and returns exactly one changemaker source for an admin user', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			const before = await loadTableMetrics(db, 'sources');
 			const result = await agent
 				.post('/sources')
@@ -150,14 +158,17 @@ describe('/sources', () => {
 					createdAt: changemaker.createdAt,
 				},
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(2);
 		});
 
 		it('returns 409 conflict when label is not unique on changemaker foreign key', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
-			await createSource(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			await createSource(db, testUserAuthContext, {
 				label: 'Example Corp',
 				changemakerId: changemaker.id,
 			});
@@ -182,8 +193,13 @@ describe('/sources', () => {
 
 		it('returns 409 conflict when label is not unique on data provider foreign key', async () => {
 			const db = getDatabase();
-			const dataProvider = await createTestDataProvider(db, null);
-			await createSource(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const dataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
+			await createSource(db, testUserAuthContext, {
 				label: 'Example Corp',
 				dataProviderShortCode: dataProvider.shortCode,
 			});
@@ -208,8 +224,10 @@ describe('/sources', () => {
 
 		it('returns 409 conflict when label is not unique on funder foreign key', async () => {
 			const db = getDatabase();
-			const funder = await createTestFunder(db, null);
-			await createSource(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const funder = await createTestFunder(db, testUserAuthContext);
+			await createSource(db, testUserAuthContext, {
 				label: 'Example Corp',
 				funderShortCode: funder.shortCode,
 			});
@@ -237,7 +255,8 @@ describe('/sources', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
-			const changemaker = await createTestChangemaker(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -254,8 +273,8 @@ describe('/sources', () => {
 				.send({
 					label: 'Example Corp',
 					changemakerId: changemaker.id,
-				})
-				.expect(201);
+				});
+			expect(result.status).toEqual(201);
 			const after = await loadTableMetrics(db, 'sources');
 			// Source response includes a shallow changemaker (no fields/fiscalSponsors)
 			expect(result.body).toMatchObject({
@@ -270,6 +289,7 @@ describe('/sources', () => {
 					createdAt: changemaker.createdAt,
 				},
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(before.count + 1);
 		});
@@ -279,7 +299,8 @@ describe('/sources', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
-			const changemaker = await createTestChangemaker(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -336,7 +357,9 @@ describe('/sources', () => {
 
 		it('creates and returns exactly one funder source for an admin user', async () => {
 			const db = getDatabase();
-			const funder = await createTestFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const funder = await createTestFunder(db, testUserAuthContext);
 			const before = await loadTableMetrics(db, 'sources');
 			const result = await agent
 				.post('/sources')
@@ -355,6 +378,7 @@ describe('/sources', () => {
 				funderShortCode: funder.shortCode,
 				funder,
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(2);
 		});
@@ -364,7 +388,8 @@ describe('/sources', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
-			const funder = await createTestFunder(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const funder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -390,6 +415,7 @@ describe('/sources', () => {
 				funderShortCode: funder.shortCode,
 				funder,
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(before.count + 1);
 		});
@@ -399,7 +425,8 @@ describe('/sources', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
-			const funder = await createTestFunder(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const funder = await createTestFunder(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -456,7 +483,12 @@ describe('/sources', () => {
 
 		it('creates and returns exactly one data provider source for an admin user', async () => {
 			const db = getDatabase();
-			const dataProvider = await createTestDataProvider(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const dataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
 			const before = await loadTableMetrics(db, 'sources');
 			const result = await agent
 				.post('/sources')
@@ -475,6 +507,7 @@ describe('/sources', () => {
 				dataProviderShortCode: dataProvider.shortCode,
 				dataProvider,
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(2);
 		});
@@ -484,7 +517,11 @@ describe('/sources', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
-			const dataProvider = await createTestDataProvider(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const dataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -510,6 +547,7 @@ describe('/sources', () => {
 				dataProviderShortCode: dataProvider.shortCode,
 				dataProvider,
 				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(before.count + 1);
 		});
@@ -519,7 +557,11 @@ describe('/sources', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
-			const dataProvider = await createTestDataProvider(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const dataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -568,7 +610,9 @@ describe('/sources', () => {
 
 		it('returns 400 bad request when no label sent', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			const result = await agent
 				.post('/sources')
 				.type('application/json')
@@ -609,8 +653,10 @@ describe('/sources', () => {
 
 		it('deletes exactly one source that has no proposals associated with it', async () => {
 			const db = getDatabase();
-			const changemaker = await createTestChangemaker(db, null);
-			const localSource = await createSource(db, null, {
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			const localSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: 'Example Inc.',
 			});
@@ -630,14 +676,16 @@ describe('/sources', () => {
 
 		it('Returns 422 Unprocessable Content when it tries to delete a source that is associated with a proposal', async () => {
 			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const changemaker = await createTestChangemaker(db, null);
-			const localSource = await createSource(db, null, {
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			const localSource = await createSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 				label: 'Example Inc.',
 			});
-			const opportunity = await createTestOpportunity(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, systemUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,

--- a/src/database/initialization/__tests__/proposal_field_value_to_json.int.test.ts
+++ b/src/database/initialization/__tests__/proposal_field_value_to_json.int.test.ts
@@ -25,7 +25,7 @@ describe('/proposal_field_value_to_json', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 		const systemSource = await loadSystemSource(db, null);
-		const opportunity = await createTestOpportunity(db, null);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext);
 		const proposal = await createProposal(db, testUserAuthContext, {
 			externalId: 'proposal-1',
 			opportunityId: opportunity.id,
@@ -91,7 +91,7 @@ describe('/proposal_field_value_to_json', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 		const systemSource = await loadSystemSource(db, null);
-		const opportunity = await createTestOpportunity(db, null);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext);
 		const proposal = await createProposal(db, testUserAuthContext, {
 			externalId: 'proposal-with-file',
 			opportunityId: opportunity.id,
@@ -178,7 +178,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 		const otherUserAuthContext = getAuthContext(otherUser);
 		const systemSource = await loadSystemSource(db, null);
-		const opportunity = await createTestOpportunity(db, null);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext);
 		const proposal = await createProposal(db, testUserAuthContext, {
 			externalId: 'proposal-with-other-file',
 			opportunityId: opportunity.id,
@@ -260,7 +260,7 @@ describe('/proposal_field_value_to_json', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 		const systemSource = await loadSystemSource(db, null);
-		const opportunity = await createTestOpportunity(db, null);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext);
 		const proposal = await createProposal(db, testUserAuthContext, {
 			externalId: 'proposal-with-missing-file',
 			opportunityId: opportunity.id,
@@ -334,7 +334,7 @@ describe('/proposal_field_value_to_json', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 		const systemSource = await loadSystemSource(db, null);
-		const opportunity = await createTestOpportunity(db, null);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext);
 		const proposal = await createProposal(db, testUserAuthContext, {
 			externalId: 'proposal-with-invalid-file-id',
 			opportunityId: opportunity.id,
@@ -408,7 +408,7 @@ describe('/proposal_field_value_to_json', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 		const systemSource = await loadSystemSource(db, null);
-		const opportunity = await createTestOpportunity(db, null);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext);
 		const proposal = await createProposal(db, testUserAuthContext, {
 			externalId: 'proposal-with-string',
 			opportunityId: opportunity.id,

--- a/src/database/initialization/changemaker_to_json.sql
+++ b/src/database/initialization/changemaker_to_json.sql
@@ -139,7 +139,8 @@ BEGIN
 		'taxId', changemaker.tax_id,
 		'name', changemaker.name,
 		'keycloakOrganizationId', changemaker.keycloak_organization_id,
-		'createdAt', changemaker.created_at
+		'createdAt', changemaker.created_at,
+		'createdBy', changemaker.created_by
 	) INTO changemaker_json;
 
 	RETURN

--- a/src/database/initialization/data_provider_to_json.sql
+++ b/src/database/initialization/data_provider_to_json.sql
@@ -7,7 +7,8 @@ BEGIN
     'shortCode', data_provider.short_code,
     'name', data_provider.name,
     'keycloakOrganizationId', data_provider.keycloak_organization_id,
-    'createdAt', data_provider.created_at
+    'createdAt', data_provider.created_at,
+    'createdBy', data_provider.created_by
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/src/database/initialization/funder_to_json.sql
+++ b/src/database/initialization/funder_to_json.sql
@@ -8,6 +8,7 @@ BEGIN
     'name', funder.name,
     'keycloakOrganizationId', funder.keycloak_organization_id,
     'createdAt', funder.created_at,
+		'createdBy', funder.created_by,
     'isCollaborative', funder.is_collaborative
   );
 END;

--- a/src/database/initialization/opportunity_to_json.sql
+++ b/src/database/initialization/opportunity_to_json.sql
@@ -15,7 +15,8 @@ BEGIN
     'title', opportunity.title,
     'funderShortCode', opportunity.funder_short_code,
     'funder', funder_json,
-    'createdAt', to_json(opportunity.created_at)::jsonb
+    'createdAt', to_json(opportunity.created_at),
+    'createdBy', to_json(opportunity.created_by)
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/src/database/initialization/source_to_json.sql
+++ b/src/database/initialization/source_to_json.sql
@@ -47,7 +47,8 @@ BEGIN
     ('funder', funder_json),
     ('changemakerId', to_jsonb(source.changemaker_id)),
     ('changemaker', changemaker_json),
-    ('createdAt', to_jsonb(source.created_at))
+    ('createdAt', to_jsonb(source.created_at)),
+		('createdBy', to_jsonb(source.created_by))
   ) AS props(name, value)
   WHERE value IS NOT NULL;
 

--- a/src/database/migrations/0102-alter-funders-add-created_by.sql
+++ b/src/database/migrations/0102-alter-funders-add-created_by.sql
@@ -1,0 +1,8 @@
+ALTER TABLE funders
+ADD COLUMN created_by uuid NOT NULL
+DEFAULT system_keycloak_user_id()
+REFERENCES users (keycloak_user_id)
+ON DELETE CASCADE;
+
+ALTER TABLE funders
+ALTER COLUMN created_by DROP DEFAULT;

--- a/src/database/migrations/0103-alter-opportunities-add-created_by.sql
+++ b/src/database/migrations/0103-alter-opportunities-add-created_by.sql
@@ -1,0 +1,8 @@
+ALTER TABLE opportunities
+ADD COLUMN created_by uuid NOT NULL
+DEFAULT system_keycloak_user_id()
+REFERENCES users (keycloak_user_id)
+ON DELETE CASCADE;
+
+ALTER TABLE opportunities
+ALTER COLUMN created_by DROP DEFAULT;

--- a/src/database/migrations/0104-alter-changemakers-add-created_by.sql
+++ b/src/database/migrations/0104-alter-changemakers-add-created_by.sql
@@ -1,0 +1,8 @@
+ALTER TABLE changemakers
+ADD COLUMN created_by uuid NOT NULL
+DEFAULT system_keycloak_user_id()
+REFERENCES users (keycloak_user_id)
+ON DELETE CASCADE;
+
+ALTER TABLE changemakers
+ALTER COLUMN created_by DROP DEFAULT;

--- a/src/database/migrations/0105-alter-sources-add-created_by.sql
+++ b/src/database/migrations/0105-alter-sources-add-created_by.sql
@@ -1,0 +1,8 @@
+ALTER TABLE sources
+ADD COLUMN created_by uuid NOT NULL
+DEFAULT system_keycloak_user_id()
+REFERENCES users (keycloak_user_id)
+ON DELETE CASCADE;
+
+ALTER TABLE sources
+ALTER COLUMN created_by DROP DEFAULT;

--- a/src/database/migrations/0106-alter-data_providers-add-created_by.sql
+++ b/src/database/migrations/0106-alter-data_providers-add-created_by.sql
@@ -1,0 +1,8 @@
+ALTER TABLE data_providers
+ADD COLUMN created_by uuid NOT NULL
+DEFAULT system_keycloak_user_id()
+REFERENCES users (keycloak_user_id)
+ON DELETE CASCADE;
+
+ALTER TABLE data_providers
+ALTER COLUMN created_by DROP DEFAULT;

--- a/src/database/operations/changemakers/__test__/updateChangemakers.int.test.ts
+++ b/src/database/operations/changemakers/__test__/updateChangemakers.int.test.ts
@@ -1,11 +1,14 @@
 import { createChangemaker, updateChangemaker } from '..';
 import { stringToKeycloakId } from '../../../../types';
 import { getDatabase } from '../../../db';
+import { getAuthContext, loadTestUser } from '../../../../test/utils';
 
 describe('updateChangemaker', () => {
 	it('Successfully sets a keycloakOrganizationId where previously null', async () => {
 		const db = getDatabase();
-		const changemaker = await createChangemaker(db, null, {
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const changemaker = await createChangemaker(db, testUserAuthContext, {
 			taxId: '4833091201209397622311990956044204588593',
 			name: 'Changemaker 4833091201209397622311990956044204588593',
 			keycloakOrganizationId: null,
@@ -27,7 +30,9 @@ describe('updateChangemaker', () => {
 
 	it('Successfully sets a keycloakOrganizationId where previously non-null', async () => {
 		const db = getDatabase();
-		const changemaker = await createChangemaker(db, null, {
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const changemaker = await createChangemaker(db, testUserAuthContext, {
 			taxId: '1099594605318784561881495063299923285326',
 			name: 'Changemaker 1099594605318784561881495063299923285326',
 			keycloakOrganizationId: '7733cef4-8a08-4089-a699-9be1e5536733',

--- a/src/database/queries/changemakers/insertOne.sql
+++ b/src/database/queries/changemakers/insertOne.sql
@@ -1,11 +1,13 @@
 INSERT INTO changemakers (
 	tax_id,
 	name,
-	keycloak_organization_id
+	keycloak_organization_id,
+	created_by
 ) VALUES (
 	:taxId,
 	:name,
-	:keycloakOrganizationId
+	:keycloakOrganizationId,
+	:authContextKeycloakUserId
 )
 RETURNING changemaker_to_json(
 	changemakers,

--- a/src/database/queries/changemakers/insertOrSelectOne.sql
+++ b/src/database/queries/changemakers/insertOrSelectOne.sql
@@ -1,11 +1,13 @@
 INSERT INTO changemakers (
 	tax_id,
 	name,
-	keycloak_organization_id
+	keycloak_organization_id,
+	created_by
 ) VALUES (
 	:taxId,
 	:name,
-	:keycloakOrganizationId
+	:keycloakOrganizationId,
+	:authContextKeycloakUserId
 )
 ON CONFLICT (tax_id, name)
 -- The no-op update is required to make RETURNING work on conflicts.

--- a/src/database/queries/dataProviders/insertOrUpdateOne.sql
+++ b/src/database/queries/dataProviders/insertOrUpdateOne.sql
@@ -1,11 +1,13 @@
 INSERT INTO data_providers (
 	short_code,
 	name,
-	keycloak_organization_id
+	keycloak_organization_id,
+	created_by
 ) VALUES (
 	:shortCode,
 	:name,
-	:keycloakOrganizationId
+	:keycloakOrganizationId,
+	:authContextKeycloakUserId
 )
 ON CONFLICT (short_code)
 DO UPDATE

--- a/src/database/queries/funders/insertOrUpdateOne.sql
+++ b/src/database/queries/funders/insertOrUpdateOne.sql
@@ -2,12 +2,14 @@ INSERT INTO funders (
 	short_code,
 	name,
 	keycloak_organization_id,
-	is_collaborative
+	is_collaborative,
+	created_by
 ) VALUES (
 	:shortCode,
 	:name,
 	:keycloakOrganizationId,
-	:isCollaborative
+	:isCollaborative,
+	:authContextKeycloakUserId
 )
 ON CONFLICT (short_code)
 DO UPDATE

--- a/src/database/queries/opportunities/insertOne.sql
+++ b/src/database/queries/opportunities/insertOne.sql
@@ -1,8 +1,10 @@
 INSERT INTO opportunities (
 	title,
-	funder_short_code
+	funder_short_code,
+	created_by
 ) VALUES (
 	:title,
-	:funderShortCode
+	:funderShortCode,
+	:authContextKeycloakUserId
 )
 RETURNING opportunity_to_json(opportunities) AS object;

--- a/src/database/queries/sources/insertOne.sql
+++ b/src/database/queries/sources/insertOne.sql
@@ -2,13 +2,15 @@ INSERT INTO sources (
 	label,
 	data_provider_short_code,
 	funder_short_code,
-	changemaker_id
+	changemaker_id,
+	created_by
 )
 VALUES (
 	:label,
 	:dataProviderShortCode,
 	:funderShortCode,
-	:changemakerId
+	:changemakerId,
+	:authContextKeycloakUserId
 )
 RETURNING source_to_json(
 	sources,

--- a/src/handlers/changemakersHandlers.ts
+++ b/src/handlers/changemakersHandlers.ts
@@ -31,13 +31,16 @@ import type { Request, Response } from 'express';
 
 const postChangemaker = async (req: Request, res: Response): Promise<void> => {
 	const db = getDatabase();
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
 	if (!isWritableChangemaker(req.body)) {
 		throw new InputValidationError(
 			'Invalid request body.',
 			isWritableChangemaker.errors ?? [],
 		);
 	}
-	const changemaker = await createChangemaker(db, null, req.body);
+	const changemaker = await createChangemaker(db, req, req.body);
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')
@@ -101,7 +104,7 @@ const patchChangemaker = async (req: Request, res: Response): Promise<void> => {
 	try {
 		const changemaker = await updateChangemaker(
 			db,
-			null,
+			req,
 			req.body,
 			changemakerId,
 		);

--- a/src/handlers/dataProvidersHandlers.ts
+++ b/src/handlers/dataProvidersHandlers.ts
@@ -26,7 +26,6 @@ const getDataProviders = async (req: Request, res: Response): Promise<void> => {
 		limit,
 		offset,
 	);
-
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.OK)
 		.contentType('application/json')
@@ -70,7 +69,7 @@ const putDataProvider = async (req: Request, res: Response): Promise<void> => {
 		);
 	}
 	const { name, keycloakOrganizationId } = body;
-	const dataProvider = await createOrUpdateDataProvider(db, null, {
+	const dataProvider = await createOrUpdateDataProvider(db, req, {
 		shortCode,
 		name,
 		keycloakOrganizationId,

--- a/src/handlers/fundersHandlers.ts
+++ b/src/handlers/fundersHandlers.ts
@@ -25,7 +25,6 @@ const getFunders = async (req: Request, res: Response): Promise<void> => {
 	const { offset, limit } = getLimitValues(paginationParameters);
 	const { search } = extractSearchParameters(req);
 	const funderBundle = await loadFunderBundle(db, req, search, limit, offset);
-
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.OK)
 		.contentType('application/json')
@@ -70,7 +69,7 @@ const putFunder = async (req: Request, res: Response): Promise<void> => {
 	}
 
 	const { name, keycloakOrganizationId, isCollaborative } = body;
-	const funder = await createOrUpdateFunder(db, null, {
+	const funder = await createOrUpdateFunder(db, req, {
 		shortCode,
 		name,
 		keycloakOrganizationId,

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -73,7 +73,7 @@ const postOpportunity = async (req: Request, res: Response): Promise<void> => {
 	) {
 		throw new UnauthorizedError();
 	}
-	const opportunity = await createOpportunity(db, null, req.body);
+	const opportunity = await createOpportunity(db, req, req.body);
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')

--- a/src/handlers/sourcesHandlers.ts
+++ b/src/handlers/sourcesHandlers.ts
@@ -77,7 +77,7 @@ const postSource = async (req: Request, res: Response): Promise<void> => {
 	// Normally we try to avoid passing the body directly vs extracting the values and passing them.
 	// Because because writableSource is a union type it is hard to extract the values directly without
 	// losing type context that the union provided.
-	const source = await createSource(db, null, req.body);
+	const source = await createSource(db, req, req.body);
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')
@@ -92,7 +92,6 @@ const getSources = async (req: Request, res: Response): Promise<void> => {
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
 	const bundle = await loadSourceBundle(db, req, limit, offset);
-
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.OK)
 		.contentType('application/json')

--- a/src/middleware/__tests__/requireChangemakerPermission.int.test.ts
+++ b/src/middleware/__tests__/requireChangemakerPermission.int.test.ts
@@ -77,7 +77,8 @@ describe('requireChangemakerPermission', () => {
 		void (async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
-			const changemaker = await createChangemaker(db, null, {
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createChangemaker(db, testUserAuthContext, {
 				taxId: '11-1111111',
 				name: 'Test Changemaker',
 				keycloakOrganizationId: null,
@@ -111,7 +112,8 @@ describe('requireChangemakerPermission', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-			const changemaker = await createChangemaker(db, null, {
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createChangemaker(db, testUserAuthContext, {
 				taxId: '22-2222222',
 				name: 'Permitted Changemaker',
 				keycloakOrganizationId: null,
@@ -150,7 +152,8 @@ describe('requireChangemakerPermission', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-			const changemaker = await createChangemaker(db, null, {
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createChangemaker(db, testUserAuthContext, {
 				taxId: '33-3333333',
 				name: 'View Only Changemaker',
 				keycloakOrganizationId: null,

--- a/src/middleware/__tests__/requireDataProviderPermission.int.test.ts
+++ b/src/middleware/__tests__/requireDataProviderPermission.int.test.ts
@@ -77,7 +77,11 @@ describe('requireDataProviderPermission', () => {
 		void (async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
-			const dataProvider = await createTestDataProvider(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const dataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
 
 			const req = getMockRequest() as AuthenticatedRequest;
 			const res = getMockResponse();
@@ -107,7 +111,11 @@ describe('requireDataProviderPermission', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-			const dataProvider = await createTestDataProvider(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const dataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
 
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
@@ -142,7 +150,11 @@ describe('requireDataProviderPermission', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-			const dataProvider = await createTestDataProvider(db, null);
+			const testUserAuthContext = getAuthContext(testUser);
+			const dataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
 
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,

--- a/src/middleware/__tests__/requireFunderPermission.int.test.ts
+++ b/src/middleware/__tests__/requireFunderPermission.int.test.ts
@@ -65,7 +65,8 @@ describe('requireFunderPermission', () => {
 		void (async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
-			await createOrUpdateFunder(db, null, {
+			const testUserAuthContext = getAuthContext(testUser);
+			await createOrUpdateFunder(db, testUserAuthContext, {
 				shortCode: 'test_funder_no_perm',
 				name: 'Test Funder No Permission',
 				keycloakOrganizationId: null,
@@ -100,7 +101,8 @@ describe('requireFunderPermission', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-			const funder = await createOrUpdateFunder(db, null, {
+			const testUserAuthContext = getAuthContext(testUser);
+			const funder = await createOrUpdateFunder(db, testUserAuthContext, {
 				shortCode: 'test_funder_with_perm',
 				name: 'Permitted Funder',
 				keycloakOrganizationId: null,
@@ -140,7 +142,8 @@ describe('requireFunderPermission', () => {
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
-			const funder = await createOrUpdateFunder(db, null, {
+			const testUserAuthContext = getAuthContext(testUser);
+			const funder = await createOrUpdateFunder(db, testUserAuthContext, {
 				shortCode: 'test_funder_view_only',
 				name: 'View Only Funder',
 				keycloakOrganizationId: null,

--- a/src/openapi/components/schemas/Changemaker.json
+++ b/src/openapi/components/schemas/Changemaker.json
@@ -20,6 +20,7 @@
 							"taxId": "US123456789",
 							"fields": [],
 							"createdAt": "2025-02-07T13:16:16.191509-06:00",
+							"createdBy": "adace57c-25c2-40b1-9228-c48939f39f98",
 							"fiscalSponsors": [],
 							"keycloakOrganizationId": "f16a71f8-e67b-43ab-a258-31cd8a99a97a"
 						}

--- a/src/openapi/components/schemas/DataProvider.json
+++ b/src/openapi/components/schemas/DataProvider.json
@@ -16,7 +16,19 @@
 			"type": "string",
 			"format": "date-time",
 			"readOnly": true
+		},
+		"createdBy": {
+			"description": "The keycloak user id of the PDC user that created this data provider",
+			"type": "string",
+			"format": "uuid",
+			"readOnly": true
 		}
 	},
-	"required": ["shortCode", "name", "keycloakOrganizationId", "createdAt"]
+	"required": [
+		"shortCode",
+		"name",
+		"keycloakOrganizationId",
+		"createdAt",
+		"createdBy"
+	]
 }

--- a/src/openapi/components/schemas/Funder.json
+++ b/src/openapi/components/schemas/Funder.json
@@ -17,10 +17,16 @@
 			"format": "date-time",
 			"readOnly": true
 		},
+		"createdBy": {
+			"description": "The keycloak user id of the PDC user that created this funder",
+			"type": "string",
+			"format": "uuid",
+			"readOnly": true
+		},
 		"isCollaborative": {
 			"type": "boolean",
 			"default": false
 		}
 	},
-	"required": ["shortCode", "name", "createdAt", "isCollaborative"]
+	"required": ["shortCode", "name", "createdAt", "createdBy", "isCollaborative"]
 }

--- a/src/openapi/components/schemas/Opportunity.json
+++ b/src/openapi/components/schemas/Opportunity.json
@@ -22,7 +22,13 @@
 			"type": "string",
 			"format": "date-time",
 			"readOnly": true
+		},
+		"createdBy": {
+			"description": "The keycloak user id of the PDC user that created this opportunity",
+			"type": "string",
+			"format": "uuid",
+			"readOnly": true
 		}
 	},
-	"required": ["id", "title", "createdAt"]
+	"required": ["id", "title", "createdAt", "createdBy"]
 }

--- a/src/openapi/components/schemas/ShallowChangemaker.json
+++ b/src/openapi/components/schemas/ShallowChangemaker.json
@@ -23,7 +23,13 @@
 			"type": "string",
 			"format": "date-time",
 			"readOnly": true
+		},
+		"createdBy": {
+			"description": "The keycloak user id of the PDC user that created this changemaker",
+			"type": "string",
+			"format": "uuid",
+			"readOnly": true
 		}
 	},
-	"required": ["id", "taxId", "name", "createdAt"]
+	"required": ["id", "taxId", "name", "createdAt", "createdBy"]
 }

--- a/src/openapi/components/schemas/Source.json
+++ b/src/openapi/components/schemas/Source.json
@@ -17,9 +17,15 @@
 					"type": "string",
 					"format": "date-time",
 					"readOnly": true
+				},
+				"createdBy": {
+					"description": "The keycloak user id of the PDC user that created this source",
+					"type": "string",
+					"format": "uuid",
+					"readOnly": true
 				}
 			},
-			"required": ["id", "label", "relatedEntityId", "createdAt"]
+			"required": ["id", "label", "relatedEntityId", "createdAt", "createdBy"]
 		},
 		{
 			"oneOf": [

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -54,14 +54,14 @@ const createTestApplicationForm = async (
 	shortCodes: string[],
 ): Promise<{ applicationFormId: number; opportunity: Opportunity }> => {
 	const opportunity = await createTestOpportunity(db, authContext);
-	const applicationForm = await createApplicationForm(db, authContext, {
+	const applicationForm = await createApplicationForm(db, null, {
 		opportunityId: opportunity.id,
 		name: null,
 	});
 	await Promise.all(
 		shortCodes.map(
 			async (shortCode, index) =>
-				await createApplicationFormField(db, authContext, {
+				await createApplicationFormField(db, null, {
 					applicationFormId: applicationForm.id,
 					baseFieldShortCode: shortCode,
 					position: index,
@@ -818,12 +818,13 @@ describe('processBulkUploadTask', () => {
 			entries: [
 				{
 					createdAt: expectTimestamp(),
+					createdBy: systemUser.keycloakUserId,
 					taxId: '51-2144346',
 					id: 1,
 					name: 'Foo LLC.',
 					keycloakOrganizationId: null,
-					fiscalSponsors: [],
 					fields: [],
+					fiscalSponsors: [],
 				},
 			],
 			total: 1,

--- a/src/test/factories/createTestOpportunity.ts
+++ b/src/test/factories/createTestOpportunity.ts
@@ -15,7 +15,7 @@ const createTestOpportunity = async (
 ): Promise<Opportunity> => {
 	const funderShortCode =
 		overrideValues?.funderShortCode ??
-		(await createTestFunder(db, null)).shortCode;
+		(await createTestFunder(db, authContext)).shortCode;
 	const defaultValues: WritableOpportunity = {
 		title: `Test Opportunity ${uuidv4()}`,
 		funderShortCode,

--- a/src/test/factories/createTestPermissionGrant.ts
+++ b/src/test/factories/createTestPermissionGrant.ts
@@ -17,8 +17,9 @@ let systemChangemakerPromise: Promise<Changemaker> | null = null;
 
 const getOrCreateSystemChangemaker = async (
 	db: TinyPg,
+	authContext: AuthContext,
 ): Promise<Changemaker> => {
-	systemChangemakerPromise ??= createChangemaker(db, null, {
+	systemChangemakerPromise ??= createChangemaker(db, authContext, {
 		taxId: '99-9999999',
 		name: 'System Test Changemaker',
 		keycloakOrganizationId: null,
@@ -32,13 +33,13 @@ const resetTestPermissionGrantFactory = (): void => {
 
 const createTestPermissionGrant = async (
 	db: TinyPg,
-	authContext: AuthContext | null,
+	authContext: AuthContext,
 	overrideValues?: WritablePermissionGrant,
 ): Promise<PermissionGrant> => {
 	if (overrideValues !== undefined) {
 		return await createPermissionGrant(db, authContext, overrideValues);
 	}
-	const changemaker = await getOrCreateSystemChangemaker(db);
+	const changemaker = await getOrCreateSystemChangemaker(db, authContext);
 	const defaultValues: WritablePermissionGrant = {
 		granteeType: PermissionGrantGranteeType.USER,
 		granteeUserKeycloakUserId: getTestUserKeycloakUserId(),

--- a/src/types/Changemaker.ts
+++ b/src/types/Changemaker.ts
@@ -15,6 +15,7 @@ interface ShallowChangemaker {
 	// https://github.com/ajv-validator/ajv/issues/2163.
 	keycloakOrganizationId: KeycloakId | null | undefined;
 	readonly createdAt: string;
+	readonly createdBy: KeycloakId;
 }
 
 interface Changemaker extends ShallowChangemaker {

--- a/src/types/DataProvider.ts
+++ b/src/types/DataProvider.ts
@@ -13,6 +13,7 @@ interface DataProvider {
 	// https://github.com/ajv-validator/ajv/issues/2163.
 	keycloakOrganizationId: KeycloakId | null | undefined;
 	readonly createdAt: string;
+	readonly createdBy: KeycloakId;
 }
 
 type WritableDataProvider = Writable<DataProvider>;

--- a/src/types/Funder.ts
+++ b/src/types/Funder.ts
@@ -14,6 +14,7 @@ interface Funder {
 	keycloakOrganizationId: KeycloakId | null | undefined;
 	isCollaborative: boolean;
 	readonly createdAt: string;
+	readonly createdBy: KeycloakId;
 }
 
 type WritableFunder = Writable<Funder>;

--- a/src/types/Opportunity.ts
+++ b/src/types/Opportunity.ts
@@ -4,6 +4,7 @@ import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
 import type { ShortCode } from './ShortCode';
 import type { Funder } from './Funder';
+import type { KeycloakId } from './KeycloakId';
 
 interface Opportunity {
 	readonly id: number;
@@ -11,6 +12,7 @@ interface Opportunity {
 	funderShortCode: ShortCode;
 	readonly funder: Funder;
 	readonly createdAt: string;
+	readonly createdBy: KeycloakId;
 }
 
 type WritableOpportunity = Writable<Opportunity>;

--- a/src/types/Source.ts
+++ b/src/types/Source.ts
@@ -4,11 +4,13 @@ import type { Changemaker } from './Changemaker';
 import type { DataProvider } from './DataProvider';
 import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
+import type { KeycloakId } from './KeycloakId';
 
 interface SourceBase {
 	readonly id: number;
 	label: string;
 	readonly createdAt: string;
+	readonly createdBy: KeycloakId;
 }
 
 interface DataProviderSource extends SourceBase {


### PR DESCRIPTION
This PR adds a new `createdBy` attribute to `Opportunity,` `Funder,` `Changemaker,` `DataProvider,` and `Source.` This doesn't affect required fields from end users since this is populated based on auth context, but will add to the returned object.

Resolves #1860 