### PR TITLE
Ignore major eslint versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'postgres-schema-migrations'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
Eslint has a large network of ecosystem dependencies, and it often takes months for those dependencies to update to support major changes to the core eslint package.

Rather than get stuck with all lint dependencies being frozen when eslint has a major bump, let's manually perform those changes once the ecosystem has caught up.