### PR TITLE
Ignore major `@eslint/*` dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@eslint/*'
+        update-types: ['version-update:semver-major']
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
This PR expands the `eslint` major dep ignore to include other official eslint packages (which tend to be co-released / require the now-ignored packages).