### PR TITLE
Add `isCollaborative` filter to GET /funders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `GET /funders` now supports the `isCollaborative` query parameter to filter funders by their collaborative status.
+
 ## 0.33.0 2026-04-14
 
 ### Added

--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -185,6 +185,115 @@ describe('/funders', () => {
 			});
 		});
 
+		it('returns only collaborative funders when isCollaborative=true is provided', async () => {
+			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
+				shortCode: 'collabA',
+				name: 'Collaborative A',
+				isCollaborative: true,
+			});
+			await createTestFunder(db, testUserAuthContext, {
+				shortCode: 'collabB',
+				name: 'Collaborative B',
+				isCollaborative: true,
+			});
+			await createTestFunder(db, testUserAuthContext, {
+				shortCode: 'soloFund',
+				name: 'Solo Fund',
+				isCollaborative: false,
+			});
+
+			const response = await agent
+				.get('/funders?isCollaborative=true')
+				.set(authHeader)
+				.expect(200);
+			expect(response.body).toEqual({
+				total: 2,
+				entries: expectArrayContaining([
+					expectObjectContaining({
+						shortCode: 'collabA',
+						isCollaborative: true,
+					}),
+					expectObjectContaining({
+						shortCode: 'collabB',
+						isCollaborative: true,
+					}),
+				]),
+			});
+		});
+
+		it('returns only non-collaborative funders when isCollaborative=false is provided', async () => {
+			const db = getDatabase();
+			const systemFunder = await loadSystemFunder(db, null);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
+				shortCode: 'collabA',
+				name: 'Collaborative A',
+				isCollaborative: true,
+			});
+			await createTestFunder(db, testUserAuthContext, {
+				shortCode: 'soloFund',
+				name: 'Solo Fund',
+				isCollaborative: false,
+			});
+
+			const response = await agent
+				.get('/funders?isCollaborative=false')
+				.set(authHeader)
+				.expect(200);
+			expect(response.body).toEqual({
+				total: 2,
+				entries: expectArrayContaining([
+					expectObjectContaining({
+						shortCode: 'soloFund',
+						isCollaborative: false,
+					}),
+					expectObjectContaining({
+						shortCode: systemFunder.shortCode,
+						isCollaborative: false,
+					}),
+				]),
+			});
+		});
+
+		it('combines isCollaborative and search filters', async () => {
+			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
+				shortCode: 'greenCollab',
+				name: 'Green Collaborative',
+				isCollaborative: true,
+			});
+			await createTestFunder(db, testUserAuthContext, {
+				shortCode: 'greenFund',
+				name: 'Green Fund',
+				isCollaborative: false,
+			});
+			await createTestFunder(db, testUserAuthContext, {
+				shortCode: 'climateCollab',
+				name: 'Climate Collaborative',
+				isCollaborative: true,
+			});
+
+			const response = await agent
+				.get('/funders?isCollaborative=true&_content=green')
+				.set(authHeader)
+				.expect(200);
+			expect(response.body).toEqual({
+				total: 1,
+				entries: [
+					expectObjectContaining({
+						shortCode: 'greenCollab',
+						isCollaborative: true,
+					}),
+				],
+			});
+		});
+
 		it('returns a collaborative funder when search matches a member funder name', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);

--- a/src/database/operations/funders/loadFunderBundle.ts
+++ b/src/database/operations/funders/loadFunderBundle.ts
@@ -3,7 +3,7 @@ import type { Funder } from '../../../types';
 
 const loadFunderBundle = generateLoadBundleOperation<
 	Funder,
-	[search: string | undefined]
->('funders.selectWithPagination', ['search']);
+	[search: string | undefined, isCollaborative: boolean | undefined]
+>('funders.selectWithPagination', ['search', 'isCollaborative']);
 
 export { loadFunderBundle };

--- a/src/database/queries/funders/selectWithPagination.sql
+++ b/src/database/queries/funders/selectWithPagination.sql
@@ -17,17 +17,23 @@ WITH
 		FROM funders
 			CROSS JOIN search_query
 		WHERE
-			search_query.tsquery IS NULL
-			OR funders.name_search @@ search_query.tsquery
-			OR EXISTS (
-				SELECT 1
-				FROM funder_collaborative_members AS fcm
-					INNER JOIN funders AS member_f
-						ON fcm.member_funder_short_code = member_f.short_code
-				WHERE
-					fcm.funder_collaborative_short_code = funders.short_code
-					AND NOT is_expired(fcm.not_after)
-					AND member_f.name_search @@ search_query.tsquery
+			(
+				:isCollaborative::boolean IS NULL
+				OR funders.is_collaborative = :isCollaborative::boolean
+			)
+			AND (
+				search_query.tsquery IS NULL
+				OR funders.name_search @@ search_query.tsquery
+				OR EXISTS (
+					SELECT 1
+					FROM funder_collaborative_members AS fcm
+						INNER JOIN funders AS member_f
+							ON fcm.member_funder_short_code = member_f.short_code
+					WHERE
+						fcm.funder_collaborative_short_code = funders.short_code
+						AND NOT is_expired(fcm.not_after)
+						AND member_f.name_search @@ search_query.tsquery
+				)
 			)
 	),
 

--- a/src/handlers/fundersHandlers.ts
+++ b/src/handlers/fundersHandlers.ts
@@ -9,6 +9,7 @@ import {
 import { isAuthContext, isWritableFunder } from '../types';
 import { FailedMiddlewareError, InputValidationError } from '../errors';
 import {
+	extractIsCollaborativeParameters,
 	extractPaginationParameters,
 	extractSearchParameters,
 } from '../queryParameters';
@@ -24,7 +25,15 @@ const getFunders = async (req: Request, res: Response): Promise<void> => {
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
 	const { search } = extractSearchParameters(req);
-	const funderBundle = await loadFunderBundle(db, req, search, limit, offset);
+	const { isCollaborative } = extractIsCollaborativeParameters(req);
+	const funderBundle = await loadFunderBundle(
+		db,
+		req,
+		search,
+		isCollaborative,
+		limit,
+		offset,
+	);
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.OK)
 		.contentType('application/json')

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -39,6 +39,9 @@
 			},
 			"createdByParam": {
 				"$ref": "./components/parameters/createdByParam.json"
+			},
+			"isCollaborativeParam": {
+				"$ref": "./components/parameters/isCollaborativeParam.json"
 			}
 		},
 		"securitySchemes": {

--- a/src/openapi/components/parameters/isCollaborativeParam.json
+++ b/src/openapi/components/parameters/isCollaborativeParam.json
@@ -1,0 +1,9 @@
+{
+	"schema": {
+		"type": "boolean"
+	},
+	"in": "query",
+	"name": "isCollaborative",
+	"required": false,
+	"description": "When provided, limits results to funders whose `isCollaborative` flag matches the given value."
+}

--- a/src/openapi/paths/funders.json
+++ b/src/openapi/paths/funders.json
@@ -11,7 +11,8 @@
 		"parameters": [
 			{ "$ref": "../components/parameters/pageParam.json" },
 			{ "$ref": "../components/parameters/countParam.json" },
-			{ "$ref": "../components/parameters/searchParam.json" }
+			{ "$ref": "../components/parameters/searchParam.json" },
+			{ "$ref": "../components/parameters/isCollaborativeParam.json" }
 		],
 		"responses": {
 			"200": {

--- a/src/queryParameters/__tests__/extractIsCollaborativeParameters.unit.test.ts
+++ b/src/queryParameters/__tests__/extractIsCollaborativeParameters.unit.test.ts
@@ -1,0 +1,65 @@
+import { extractIsCollaborativeParameters } from '..';
+import { InputValidationError } from '../../errors';
+
+describe('extractIsCollaborativeParameters', () => {
+	it('should return undefined when no isCollaborative parameter is provided', () => {
+		const parameters = extractIsCollaborativeParameters({
+			query: {},
+		});
+		expect(parameters).toEqual({
+			isCollaborative: undefined,
+		});
+	});
+
+	it('should return true when isCollaborative=true is provided', () => {
+		const parameters = extractIsCollaborativeParameters({
+			query: {
+				isCollaborative: 'true',
+			},
+		});
+		expect(parameters).toEqual({
+			isCollaborative: true,
+		});
+	});
+
+	it('should return false when isCollaborative=false is provided', () => {
+		const parameters = extractIsCollaborativeParameters({
+			query: {
+				isCollaborative: 'false',
+			},
+		});
+		expect(parameters).toEqual({
+			isCollaborative: false,
+		});
+	});
+
+	it('should throw an error when a non-boolean string is provided', () => {
+		expect(() =>
+			extractIsCollaborativeParameters({
+				query: {
+					isCollaborative: 'banana',
+				},
+			}),
+		).toThrow(InputValidationError);
+	});
+
+	it('should throw an error when a numeric value is provided', () => {
+		expect(() =>
+			extractIsCollaborativeParameters({
+				query: {
+					isCollaborative: '1',
+				},
+			}),
+		).toThrow(InputValidationError);
+	});
+
+	it('should throw an error when an empty string is provided', () => {
+		expect(() =>
+			extractIsCollaborativeParameters({
+				query: {
+					isCollaborative: '',
+				},
+			}),
+		).toThrow(InputValidationError);
+	});
+});

--- a/src/queryParameters/extractIsCollaborativeParameters.ts
+++ b/src/queryParameters/extractIsCollaborativeParameters.ts
@@ -1,0 +1,42 @@
+import { ajv } from '../ajv';
+import { InputValidationError } from '../errors';
+import { coerceQuery } from '../coercion';
+import type { JSONSchemaType } from 'ajv';
+import type { Request } from 'express';
+
+interface IsCollaborativeParameters {
+	isCollaborative: boolean | undefined;
+}
+
+const isCollaborativeParametersQuerySchema: JSONSchemaType<IsCollaborativeParameters> =
+	{
+		type: 'object',
+		properties: {
+			isCollaborative: {
+				type: 'boolean',
+				nullable: true,
+			},
+		},
+		required: [],
+	};
+
+const isIsCollaborativeParametersQuery = ajv.compile(
+	isCollaborativeParametersQuerySchema,
+);
+
+const extractIsCollaborativeParameters = ({
+	query,
+}: Pick<Request, 'query'>): IsCollaborativeParameters => {
+	const coercedQuery = coerceQuery(query);
+	if (!isIsCollaborativeParametersQuery(coercedQuery)) {
+		throw new InputValidationError(
+			'Invalid isCollaborative parameter.',
+			isIsCollaborativeParametersQuery.errors ?? [],
+		);
+	}
+	return {
+		isCollaborative: coercedQuery.isCollaborative,
+	};
+};
+
+export { extractIsCollaborativeParameters };

--- a/src/queryParameters/index.ts
+++ b/src/queryParameters/index.ts
@@ -3,6 +3,7 @@ export * from './extractChangemakerFieldValueBatchParameters';
 export * from './extractChangemakerParameters';
 export * from './extractCreatedByParameters';
 export * from './extractFunderParameters';
+export * from './extractIsCollaborativeParameters';
 export * from './extractKeycloakUserIdParameters';
 export * from './extractPaginationParameters';
 export * from './extractProposalParameters';


### PR DESCRIPTION
This PR adds an `isCollaborative` flag to the funders endpoint.

Resolves #2311