### PR TITLE
Auto-publish changelog to WordPress

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,7 +9,8 @@ on:
     inputs:
       force_publish:
         description: 'Force republish all posts'
-        default: 'true'
+        type: boolean
+        default: 'false'
 
 jobs:
   publish:
@@ -24,6 +25,7 @@ jobs:
         with:
           directory: 'docs'
           default_status: 'publish'
+          force_publish: ${{ inputs.force_publish }}
         env:
           WP_URL: ${{ secrets.WP_URL }}
           WP_USERNAME: ${{ secrets.WP_USERNAME }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - 'docs/**/*.md'
+      - 'CHANGELOG.md'
   workflow_dispatch:
     inputs:
       force_publish:
@@ -24,6 +25,7 @@ jobs:
         uses: OpenTechStrategies/wp-post-gfm@main
         with:
           directory: 'docs'
+          extra_files: 'CHANGELOG.md'
           default_status: 'publish'
           force_publish: ${{ inputs.force_publish }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add changelog to documents that auto-publish to WordPress.
 - `GET /funders` now supports the `isCollaborative` query parameter to filter funders by their collaborative status.
 
 ## 0.33.0 2026-04-14


### PR DESCRIPTION
This adds CHANGELOG.md to the files that will be auto-published to WordPress on commit.

Also includes a commit that fixes the set up of `force_publish` in the workflow.

Resolves #2350