### PR TITLE
Use `Id` consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add changelog to documents that auto-publish to WordPress.
 - `GET /funders` now supports the `isCollaborative` query parameter to filter funders by their collaborative status.
 
+### Fixed
+
+- `baseFieldShortCode` path parameters in base field localization endpoints were incorrectly typed as `integer` instead of `shortCode`.
+
 ## 0.33.0 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add changelog to documents that auto-publish to WordPress.
 - `GET /funders` now supports the `isCollaborative` query parameter to filter funders by their collaborative status.
 
+### Changed
+
+- All ID fields in the OpenAPI specification now reference a shared `id` schema with constraints (minimum: 1, maximum: 2147483647) instead of using bare `integer` types.
+
 ### Fixed
 
 - `baseFieldShortCode` path parameters in base field localization endpoints were incorrectly typed as `integer` instead of `shortCode`.

--- a/src/database/operations/baseFieldsCopyTasks/updateBaseFieldsCopyTask.ts
+++ b/src/database/operations/baseFieldsCopyTasks/updateBaseFieldsCopyTask.ts
@@ -1,13 +1,14 @@
 import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
 	BaseFieldsCopyTask,
+	Id,
 	InternallyWritableBaseFieldsCopyTask,
 } from '../../../types';
 
 const updateBaseFieldsCopyTask = generateCreateOrUpdateItemOperation<
 	BaseFieldsCopyTask,
 	Partial<InternallyWritableBaseFieldsCopyTask>,
-	[baseFieldsCopyTaskId: number]
+	[baseFieldsCopyTaskId: Id]
 >('baseFieldsCopyTasks.updateById', ['status'], ['baseFieldsCopyTaskId']);
 
 export { updateBaseFieldsCopyTask };

--- a/src/database/operations/bulkUploadTasks/updateBulkUploadTask.ts
+++ b/src/database/operations/bulkUploadTasks/updateBulkUploadTask.ts
@@ -1,13 +1,14 @@
 import { generateCreateOrUpdateItemOperation } from '../generators';
 import type {
 	BulkUploadTask,
+	Id,
 	InternallyWritableBulkUploadTask,
 } from '../../../types';
 
 const updateBulkUploadTask = generateCreateOrUpdateItemOperation<
 	BulkUploadTask,
 	Partial<InternallyWritableBulkUploadTask>,
-	[bulkUploadTaskId: number]
+	[bulkUploadTaskId: Id]
 >('bulkUploadTasks.updateById', ['status'], ['bulkUploadTaskId']);
 
 export { updateBulkUploadTask };

--- a/src/database/operations/changemakerFieldValues/loadChangemakerFieldValueBundle.ts
+++ b/src/database/operations/changemakerFieldValues/loadChangemakerFieldValueBundle.ts
@@ -1,10 +1,10 @@
 import { generateLoadBundleOperation } from '../generators';
 import { decorateWithFileDownloadUrl } from '../../../decorators/changemakerFieldValue';
-import type { ChangemakerFieldValue } from '../../../types';
+import type { ChangemakerFieldValue, Id } from '../../../types';
 
 const loadChangemakerFieldValueBundle = generateLoadBundleOperation<
 	ChangemakerFieldValue,
-	[batchId: number | undefined, changemakerId: number | undefined]
+	[batchId: Id | undefined, changemakerId: Id | undefined]
 >(
 	'changemakerFieldValues.selectWithPagination',
 	['batchId', 'changemakerId'],

--- a/src/database/operations/changemakerProposals/loadChangemakerProposalBundle.ts
+++ b/src/database/operations/changemakerProposals/loadChangemakerProposalBundle.ts
@@ -1,10 +1,10 @@
 import { generateLoadBundleOperation } from '../generators';
 import { decorateWithFileDownloadUrls } from '../../../decorators/changemakerProposal';
-import type { ChangemakerProposal } from '../../../types';
+import type { ChangemakerProposal, Id } from '../../../types';
 
 const loadChangemakerProposalBundle = generateLoadBundleOperation<
 	ChangemakerProposal,
-	[changemakerId: number | undefined, proposalId: number | undefined]
+	[changemakerId: Id | undefined, proposalId: Id | undefined]
 >(
 	'changemakersProposals.selectWithPagination',
 	['changemakerId', 'proposalId'],

--- a/src/database/operations/changemakers/loadChangemakerBundle.ts
+++ b/src/database/operations/changemakers/loadChangemakerBundle.ts
@@ -1,10 +1,10 @@
 import { generateLoadBundleOperation } from '../generators';
 import { decorateWithFileDownloadUrls } from '../../../decorators/changemaker';
-import type { Changemaker } from '../../../types';
+import type { Changemaker, Id } from '../../../types';
 
 const loadChangemakerBundle = generateLoadBundleOperation<
 	Changemaker,
-	[proposalId: number | undefined, search: string | undefined]
+	[proposalId: Id | undefined, search: string | undefined]
 >(
 	'changemakers.selectWithPagination',
 	['proposalId', 'search'],

--- a/src/database/operations/files/loadFile.ts
+++ b/src/database/operations/files/loadFile.ts
@@ -1,8 +1,8 @@
 import { generateLoadItemOperation } from '../generators';
 import { decorateWithDownloadUrl } from '../../../decorators/file';
-import type { File } from '../../../types';
+import type { File, Id } from '../../../types';
 
-const loadFile = generateLoadItemOperation<File, [fileId: number]>(
+const loadFile = generateLoadItemOperation<File, [fileId: Id]>(
 	'files.selectById',
 	'File',
 	['fileId'],

--- a/src/database/operations/files/loadFileIfCreatedBy.ts
+++ b/src/database/operations/files/loadFileIfCreatedBy.ts
@@ -1,10 +1,10 @@
 import { generateLoadItemOperation } from '../generators';
 import { decorateWithDownloadUrl } from '../../../decorators/file';
-import type { File, KeycloakId } from '../../../types';
+import type { File, Id, KeycloakId } from '../../../types';
 
 const loadFileIfCreatedBy = generateLoadItemOperation<
 	File,
-	[fileId: number, createdBy: KeycloakId]
+	[fileId: Id, createdBy: KeycloakId]
 >('files.selectById', 'File', ['fileId', 'createdBy'], decorateWithDownloadUrl);
 
 export { loadFileIfCreatedBy };

--- a/src/database/operations/fiscalSponsorships/removeFiscalSponsorship.ts
+++ b/src/database/operations/fiscalSponsorships/removeFiscalSponsorship.ts
@@ -1,9 +1,9 @@
 import { generateRemoveItemOperation } from '../generators';
-import type { FiscalSponsorship } from '../../../types';
+import type { FiscalSponsorship, Id } from '../../../types';
 
 const removeFiscalSponsorship = generateRemoveItemOperation<
 	FiscalSponsorship,
-	[fiscalSponseeChangemakerId: number, fiscalSponsorChangemakerId: number]
+	[fiscalSponseeChangemakerId: Id, fiscalSponsorChangemakerId: Id]
 >('fiscalSponsorships.deleteOne', 'FiscalSponsorship', [
 	'fiscalSponseeChangemakerId',
 	'fiscalSponsorChangemakerId',

--- a/src/database/operations/proposals/loadProposalBundle.ts
+++ b/src/database/operations/proposals/loadProposalBundle.ts
@@ -1,12 +1,12 @@
 import { generateLoadBundleOperation } from '../generators';
 import { decorateWithFileDownloadUrls } from '../../../decorators/proposal';
-import type { Proposal, KeycloakId, ShortCode } from '../../../types';
+import type { Id, Proposal, KeycloakId, ShortCode } from '../../../types';
 
 const loadProposalBundle = generateLoadBundleOperation<
 	Proposal,
 	[
 		createdBy: KeycloakId | undefined,
-		changemakerId: number | undefined,
+		changemakerId: Id | undefined,
 		funderShortCode: ShortCode | undefined,
 		search: string | undefined,
 	]

--- a/src/errors/InputConflictError.ts
+++ b/src/errors/InputConflictError.ts
@@ -1,9 +1,11 @@
+import type { Id } from '../types';
+
 interface ConflictErrorDetails {
 	entityType: string;
-	entityId?: number;
+	entityId?: Id;
 	entityShortCode?: string;
 	contextEntityType?: string;
-	contextEntityId?: number;
+	contextEntityId?: Id;
 	contextEntityShortCode?: string;
 }
 

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,3 +1,5 @@
+import type { Id } from '../types';
+
 interface NotFoundErrorDetailsWithShortCode {
 	entityType: string;
 	entityShortCode: string;
@@ -5,12 +7,12 @@ interface NotFoundErrorDetailsWithShortCode {
 
 interface NotFoundErrorDetailsWithId {
 	entityType: string;
-	entityId: number;
+	entityId: Id;
 }
 
 interface NotFoundErrorDetailsWithComplexPrimaryKey {
 	entityType: string;
-	entityPrimaryKey: Record<string, number | string>;
+	entityPrimaryKey: Record<string, Id | string>;
 }
 
 interface NotFoundErrorDetailsWithLookupValues {

--- a/src/handlers/applicationFormFieldsHandlers.ts
+++ b/src/handlers/applicationFormFieldsHandlers.ts
@@ -21,13 +21,13 @@ import {
 } from '../errors';
 import { coerceParams } from '../coercion';
 import type { Request, Response } from 'express';
-import type { AuthContext } from '../types';
+import type { AuthContext, Id } from '../types';
 import type { TinyPg } from 'tinypg';
 
 const checkApplicationFormFieldPermission = async (
 	db: Pick<TinyPg, 'sql'>,
 	authContext: AuthContext,
-	applicationFormFieldId: number,
+	applicationFormFieldId: Id,
 	permission: PermissionGrantVerb,
 ): Promise<void> => {
 	const applicationFormField = await loadApplicationFormField(

--- a/src/handlers/bulkUploadTasksHandlers.ts
+++ b/src/handlers/bulkUploadTasksHandlers.ts
@@ -29,13 +29,13 @@ import {
 } from '../queryParameters';
 import { addProcessBulkUploadJob } from '../jobQueue';
 import type { Request, Response } from 'express';
-import type { AuthContext } from '../types';
+import type { AuthContext, Id } from '../types';
 import type { TinyPg } from 'tinypg';
 
 const validateApplicationFormCreatePermission = async (
 	db: Pick<TinyPg, 'sql'>,
 	authContext: AuthContext,
-	applicationFormId: number,
+	applicationFormId: Id,
 ): Promise<void> => {
 	try {
 		const applicationForm = await loadApplicationForm(
@@ -72,7 +72,7 @@ const validateApplicationFormCreatePermission = async (
 const validateFileOwnership = async (
 	db: Pick<TinyPg, 'sql'>,
 	authContext: AuthContext,
-	fileId: number,
+	fileId: Id,
 	errorMessage: string,
 ): Promise<void> => {
 	try {

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -30,14 +30,15 @@ import type { Request, Response } from 'express';
 import type {
 	WritableProposalFieldValueWithProposalVersionContext,
 	AuthContext,
+	Id,
 } from '../types';
 import type { TinyPg } from 'tinypg';
 
 const assertApplicationFormExistsForProposal = async (
 	db: Pick<TinyPg, 'sql'>,
 	authContext: AuthContext,
-	applicationFormId: number,
-	proposalId: number,
+	applicationFormId: Id,
+	proposalId: Id,
 ): Promise<void> => {
 	const applicationForm = await loadApplicationForm(
 		db,
@@ -83,7 +84,7 @@ const assertApplicationFormExistsForProposal = async (
 const assertProposalFieldValuesMapToApplicationForm = async (
 	db: Pick<TinyPg, 'sql'>,
 	authContext: AuthContext,
-	applicationFormId: number,
+	applicationFormId: Id,
 	proposalFieldValues: WritableProposalFieldValueWithProposalVersionContext[],
 ): Promise<void> => {
 	const applicationFormFieldQueries = proposalFieldValues.map(

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -65,6 +65,9 @@
 			"BulkUploadTaskLogDetails": {
 				"$ref": "./components/schemas/BulkUploadLogDetails.json"
 			},
+			"id": {
+				"$ref": "./components/schemas/id.json"
+			},
 			"keycloakOrganizationId": {
 				"$ref": "./components/schemas/keycloakOrganizationId.json"
 			},

--- a/src/openapi/components/parameters/changemakerFieldValueBatchParam.json
+++ b/src/openapi/components/parameters/changemakerFieldValueBatchParam.json
@@ -1,6 +1,6 @@
 {
 	"schema": {
-		"type": "integer"
+		"$ref": "../schemas/id.json"
 	},
 	"in": "query",
 	"name": "changemakerFieldValueBatch",

--- a/src/openapi/components/parameters/changemakerParam.json
+++ b/src/openapi/components/parameters/changemakerParam.json
@@ -1,6 +1,6 @@
 {
 	"schema": {
-		"type": "integer"
+		"$ref": "../schemas/id.json"
 	},
 	"in": "query",
 	"name": "changemaker",

--- a/src/openapi/components/parameters/proposalParam.json
+++ b/src/openapi/components/parameters/proposalParam.json
@@ -1,6 +1,6 @@
 {
 	"schema": {
-		"type": "integer"
+		"$ref": "../schemas/id.json"
 	},
 	"in": "query",
 	"name": "proposal",

--- a/src/openapi/components/schemas/ApplicationForm.json
+++ b/src/openapi/components/schemas/ApplicationForm.json
@@ -2,12 +2,12 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 3529
 		},
 		"opportunityId": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"example": 3203
 		},
 		"name": {

--- a/src/openapi/components/schemas/ApplicationFormField.json
+++ b/src/openapi/components/schemas/ApplicationFormField.json
@@ -2,12 +2,12 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 3613
 		},
 		"applicationFormId": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 3529
 		},

--- a/src/openapi/components/schemas/ApplicationFormFieldPermissionGrant.json
+++ b/src/openapi/components/schemas/ApplicationFormFieldPermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "applicationFormField"
 				},
 				"applicationFormFieldId": {
-					"type": "integer",
-					"description": "The ID of the application form field.",
+					"$ref": "./id.json",
 					"example": 500
 				},
 				"scope": {

--- a/src/openapi/components/schemas/ApplicationFormPermissionGrant.json
+++ b/src/openapi/components/schemas/ApplicationFormPermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "applicationForm"
 				},
 				"applicationFormId": {
-					"type": "integer",
-					"description": "The ID of the application form.",
+					"$ref": "./id.json",
 					"example": 400
 				},
 				"scope": {

--- a/src/openapi/components/schemas/BaseFieldsCopyTask.json
+++ b/src/openapi/components/schemas/BaseFieldsCopyTask.json
@@ -2,7 +2,7 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 3407
 		},

--- a/src/openapi/components/schemas/BulkUploadLog.json
+++ b/src/openapi/components/schemas/BulkUploadLog.json
@@ -2,7 +2,7 @@
 	"type": "object",
 	"properties": {
 		"bulkUploadTaskId": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true
 		},
 		"createdAt": {

--- a/src/openapi/components/schemas/BulkUploadPermissionGrant.json
+++ b/src/openapi/components/schemas/BulkUploadPermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "bulkUpload"
 				},
 				"bulkUploadTaskId": {
-					"type": "integer",
-					"description": "The ID of the bulk upload task.",
+					"$ref": "./id.json",
 					"example": 800
 				},
 				"scope": {

--- a/src/openapi/components/schemas/BulkUploadTask.json
+++ b/src/openapi/components/schemas/BulkUploadTask.json
@@ -2,12 +2,12 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 3407
 		},
 		"sourceId": {
-			"type": "integer"
+			"$ref": "./id.json"
 		},
 		"source": {
 			"$ref": "./Source.json",
@@ -21,7 +21,7 @@
 			"readOnly": true
 		},
 		"proposalsDataFileId": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"example": 123
 		},
 		"proposalsDataFile": {

--- a/src/openapi/components/schemas/ChangemakerFieldValue.json
+++ b/src/openapi/components/schemas/ChangemakerFieldValue.json
@@ -5,7 +5,7 @@
 			"type": "object",
 			"properties": {
 				"changemakerId": {
-					"type": "integer",
+					"allOf": [{ "$ref": "./id.json" }],
 					"example": 123
 				},
 				"baseFieldShortCode": {
@@ -17,7 +17,7 @@
 					"readOnly": true
 				},
 				"batchId": {
-					"type": "integer",
+					"allOf": [{ "$ref": "./id.json" }],
 					"example": 456
 				},
 				"batch": {

--- a/src/openapi/components/schemas/ChangemakerFieldValuePermissionGrant.json
+++ b/src/openapi/components/schemas/ChangemakerFieldValuePermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "changemakerFieldValue"
 				},
 				"changemakerFieldValueId": {
-					"type": "integer",
-					"description": "The ID of the changemaker field value.",
+					"$ref": "./id.json",
 					"example": 900
 				},
 				"scope": {

--- a/src/openapi/components/schemas/ChangemakerPermissionGrant.json
+++ b/src/openapi/components/schemas/ChangemakerPermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "changemaker"
 				},
 				"changemakerId": {
-					"type": "integer",
-					"description": "The ID of the changemaker.",
+					"$ref": "./id.json",
 					"example": 15
 				},
 				"scope": {

--- a/src/openapi/components/schemas/ChangemakerProposal.json
+++ b/src/openapi/components/schemas/ChangemakerProposal.json
@@ -2,18 +2,18 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true
 		},
 		"changemakerId": {
-			"type": "integer"
+			"$ref": "./id.json"
 		},
 		"changemaker": {
 			"$ref": "./Changemaker.json",
 			"readOnly": true
 		},
 		"proposalId": {
-			"type": "integer"
+			"$ref": "./id.json"
 		},
 		"proposal": {
 			"$ref": "./Proposal.json",

--- a/src/openapi/components/schemas/FieldValueBase.json
+++ b/src/openapi/components/schemas/FieldValueBase.json
@@ -3,7 +3,7 @@
 	"description": "Base properties shared by all field value types.",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true
 		},
 		"value": {

--- a/src/openapi/components/schemas/File.json
+++ b/src/openapi/components/schemas/File.json
@@ -2,7 +2,7 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 1
 		},

--- a/src/openapi/components/schemas/Opportunity.json
+++ b/src/openapi/components/schemas/Opportunity.json
@@ -2,7 +2,7 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 3203
 		},

--- a/src/openapi/components/schemas/OpportunityPermissionGrant.json
+++ b/src/openapi/components/schemas/OpportunityPermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "opportunity"
 				},
 				"opportunityId": {
-					"type": "integer",
-					"description": "The ID of the opportunity.",
+					"$ref": "./id.json",
 					"example": 100
 				},
 				"scope": {

--- a/src/openapi/components/schemas/PermissionGrantBase.json
+++ b/src/openapi/components/schemas/PermissionGrantBase.json
@@ -2,7 +2,7 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 42
 		},

--- a/src/openapi/components/schemas/Proposal.json
+++ b/src/openapi/components/schemas/Proposal.json
@@ -2,12 +2,12 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 3709
 		},
 		"opportunityId": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"example": 3203
 		},
 		"opportunity": {

--- a/src/openapi/components/schemas/ProposalFieldValue.json
+++ b/src/openapi/components/schemas/ProposalFieldValue.json
@@ -5,12 +5,12 @@
 			"type": "object",
 			"properties": {
 				"proposalVersionId": {
-					"type": "integer",
+					"allOf": [{ "$ref": "./id.json" }],
 					"readOnly": true,
 					"example": 3709
 				},
 				"applicationFormFieldId": {
-					"type": "integer",
+					"allOf": [{ "$ref": "./id.json" }],
 					"example": 3613
 				},
 				"applicationFormField": {

--- a/src/openapi/components/schemas/ProposalFieldValuePermissionGrant.json
+++ b/src/openapi/components/schemas/ProposalFieldValuePermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "proposalFieldValue"
 				},
 				"proposalFieldValueId": {
-					"type": "integer",
-					"description": "The ID of the proposal field value.",
+					"$ref": "./id.json",
 					"example": 600
 				},
 				"scope": {

--- a/src/openapi/components/schemas/ProposalPermissionGrant.json
+++ b/src/openapi/components/schemas/ProposalPermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "proposal"
 				},
 				"proposalId": {
-					"type": "integer",
-					"description": "The ID of the proposal.",
+					"$ref": "./id.json",
 					"example": 200
 				},
 				"scope": {

--- a/src/openapi/components/schemas/ProposalVersion.json
+++ b/src/openapi/components/schemas/ProposalVersion.json
@@ -2,23 +2,23 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"readOnly": true,
 			"example": 3821
 		},
 		"proposalId": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"example": 3709
 		},
 		"sourceId": {
-			"type": "integer"
+			"$ref": "./id.json"
 		},
 		"source": {
 			"$ref": "./Source.json",
 			"readOnly": true
 		},
 		"applicationFormId": {
-			"type": "integer",
+			"allOf": [{ "$ref": "./id.json" }],
 			"example": 3529
 		},
 		"version": {

--- a/src/openapi/components/schemas/ProposalVersionPermissionGrant.json
+++ b/src/openapi/components/schemas/ProposalVersionPermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "proposalVersion"
 				},
 				"proposalVersionId": {
-					"type": "integer",
-					"description": "The ID of the proposal version.",
+					"$ref": "./id.json",
 					"example": 300
 				},
 				"scope": {

--- a/src/openapi/components/schemas/Source.json
+++ b/src/openapi/components/schemas/Source.json
@@ -5,7 +5,7 @@
 			"description": "A labeled dataset from the changemaker, funder, or data provider that adds data to the PDC. The Source is intended to be the 'last hop' prior to entering the PDC, not the ultimate origin of the data.",
 			"properties": {
 				"id": {
-					"type": "integer",
+					"allOf": [{ "$ref": "./id.json" }],
 					"readOnly": true
 				},
 				"label": {

--- a/src/openapi/components/schemas/SourcePermissionGrant.json
+++ b/src/openapi/components/schemas/SourcePermissionGrant.json
@@ -9,8 +9,7 @@
 					"const": "source"
 				},
 				"sourceId": {
-					"type": "integer",
-					"description": "The ID of the source.",
+					"$ref": "./id.json",
 					"example": 700
 				},
 				"scope": {

--- a/src/openapi/paths/applicationForm.json
+++ b/src/openapi/paths/applicationForm.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/applicationFormField.json
+++ b/src/openapi/paths/applicationFormField.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/applicationFormProposalDataCsv.json
+++ b/src/openapi/paths/applicationFormProposalDataCsv.json
@@ -16,7 +16,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/baseFieldLocalization.json
+++ b/src/openapi/paths/baseFieldLocalization.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/shortCode.json"
 				}
 			},
 			{

--- a/src/openapi/paths/baseFieldLocalizations.json
+++ b/src/openapi/paths/baseFieldLocalizations.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/shortCode.json"
 				}
 			}
 		],

--- a/src/openapi/paths/changemaker.json
+++ b/src/openapi/paths/changemaker.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],
@@ -58,7 +58,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/changemakerFieldValue.json
+++ b/src/openapi/paths/changemakerFieldValue.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/changemakerFieldValueBatch.json
+++ b/src/openapi/paths/changemakerFieldValueBatch.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/changemakerFiscalSponsor.json
+++ b/src/openapi/paths/changemakerFiscalSponsor.json
@@ -6,7 +6,7 @@
 			"in": "path",
 			"required": true,
 			"schema": {
-				"type": "integer"
+				"$ref": "../components/schemas/id.json"
 			}
 		},
 		{
@@ -15,7 +15,7 @@
 			"in": "path",
 			"required": true,
 			"schema": {
-				"type": "integer"
+				"$ref": "../components/schemas/id.json"
 			}
 		}
 	],
@@ -37,11 +37,11 @@
 							"type": "object",
 							"properties": {
 								"fiscalSponseeChangemakerId": {
-									"type": "integer",
+									"allOf": [{ "$ref": "../components/schemas/id.json" }],
 									"example": "43"
 								},
 								"fiscalSponsorChangemakerId": {
-									"type": "integer",
+									"allOf": [{ "$ref": "../components/schemas/id.json" }],
 									"example": "42"
 								},
 								"createdAt": {

--- a/src/openapi/paths/opportunity.json
+++ b/src/openapi/paths/opportunity.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/permissionGrant.json
+++ b/src/openapi/paths/permissionGrant.json
@@ -16,7 +16,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],
@@ -73,7 +73,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],
@@ -143,7 +143,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/proposal.json
+++ b/src/openapi/paths/proposal.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/proposalVersion.json
+++ b/src/openapi/paths/proposalVersion.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/openapi/paths/source.json
+++ b/src/openapi/paths/source.json
@@ -15,7 +15,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],
@@ -51,7 +51,7 @@
 				"in": "path",
 				"required": true,
 				"schema": {
-					"type": "integer"
+					"$ref": "../components/schemas/id.json"
 				}
 			}
 		],

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -38,13 +38,14 @@ import {
 	expectTimestamp,
 } from '../../test/asymettricMatchers';
 import { createTestFile, createTestOpportunity } from '../../test/factories';
-import type { TinyPg } from 'tinypg';
 import type {
+	Id,
 	BulkUploadTask,
 	InternallyWritableBulkUploadTask,
 	AuthContext,
 	Opportunity,
 } from '../../types';
+import type { TinyPg } from 'tinypg';
 
 const s3Mock = mockClient(S3Client);
 
@@ -52,7 +53,7 @@ const createTestApplicationForm = async (
 	db: TinyPg,
 	authContext: AuthContext,
 	shortCodes: string[],
-): Promise<{ applicationFormId: number; opportunity: Opportunity }> => {
+): Promise<{ applicationFormId: Id; opportunity: Opportunity }> => {
 	const opportunity = await createTestOpportunity(db, authContext);
 	const applicationForm = await createApplicationForm(db, null, {
 		opportunityId: opportunity.id,
@@ -78,8 +79,8 @@ const createTestBulkUploadTask = async (
 	db: TinyPg,
 	authContext: AuthContext,
 	options: {
-		proposalsDataFileId: number;
-		applicationFormId: number;
+		proposalsDataFileId: Id;
+		applicationFormId: Id;
 		overrideValues?: Partial<InternallyWritableBulkUploadTask>;
 	},
 ): Promise<BulkUploadTask> => {

--- a/src/types/ApplicationForm.ts
+++ b/src/types/ApplicationForm.ts
@@ -1,5 +1,7 @@
 import { ajv } from '../ajv';
 import { writableApplicationFormFieldWithApplicationContextSchema } from './ApplicationFormField';
+import { idSchema } from './Id';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type {
 	ApplicationFormField,
@@ -8,8 +10,8 @@ import type {
 import type { Writable } from './Writable';
 
 interface ApplicationForm {
-	readonly id: number;
-	opportunityId: number;
+	readonly id: Id;
+	opportunityId: Id;
 	name: string | null;
 	readonly version: number;
 	readonly fields: ApplicationFormField[];
@@ -26,9 +28,7 @@ const writableApplicationFormWithFieldsSchema: JSONSchemaType<WritableApplicatio
 	{
 		type: 'object',
 		properties: {
-			opportunityId: {
-				type: 'number',
-			},
+			opportunityId: idSchema,
 			name: {
 				type: 'string',
 				/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion --

--- a/src/types/ApplicationFormField.ts
+++ b/src/types/ApplicationFormField.ts
@@ -1,4 +1,5 @@
 import { ajv } from '../ajv';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type { BaseField } from './BaseField';
 import type { Writable } from './Writable';
@@ -14,8 +15,8 @@ enum ApplicationFormFieldInputType {
 }
 
 interface ApplicationFormField {
-	readonly id: number;
-	applicationFormId: number;
+	readonly id: Id;
+	applicationFormId: Id;
 	baseFieldShortCode: ShortCode;
 	readonly baseField: BaseField;
 	position: number;

--- a/src/types/BaseFieldsCopyTask.ts
+++ b/src/types/BaseFieldsCopyTask.ts
@@ -1,11 +1,12 @@
 import { ajv } from '../ajv';
+import type { Id } from './Id';
 import type { TaskStatus } from './TaskStatus';
 import type { Writable } from './Writable';
 import type { JSONSchemaType } from 'ajv';
 import type { KeycloakId } from './KeycloakId';
 
 interface BaseFieldsCopyTask {
-	readonly id: number;
+	readonly id: Id;
 	readonly status: TaskStatus;
 	pdcApiUrl: string;
 	readonly statusUpdatedAt: string;

--- a/src/types/BulkUploadTask.ts
+++ b/src/types/BulkUploadTask.ts
@@ -12,7 +12,7 @@ import type { Id } from './Id';
 import type { User } from './User';
 
 interface BulkUploadTask {
-	readonly id: number;
+	readonly id: Id;
 	sourceId: Id;
 	readonly source: Source;
 	applicationFormId: Id;

--- a/src/types/Changemaker.ts
+++ b/src/types/Changemaker.ts
@@ -1,13 +1,14 @@
 import { ajv } from '../ajv';
 import { keycloakIdSchema } from './KeycloakId';
 import type { ChangemakerFieldValue } from './ChangemakerFieldValue';
+import type { Id } from './Id';
 import type { KeycloakId } from './KeycloakId';
 import type { Writable } from './Writable';
 import type { JSONSchemaType } from 'ajv';
 import type { ProposalFieldValue } from './ProposalFieldValue';
 
 interface ShallowChangemaker {
-	readonly id: number;
+	readonly id: Id;
 	taxId: string;
 	name: string;
 	// We do not really want "undefined" here, only null. See

--- a/src/types/ChangemakerFieldValue.ts
+++ b/src/types/ChangemakerFieldValue.ts
@@ -1,4 +1,6 @@
 import { ajv } from '../ajv';
+import { idSchema } from './Id';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type { BaseField } from './BaseField';
 import type { ChangemakerFieldValueBatch } from './ChangemakerFieldValueBatch';
@@ -6,9 +8,9 @@ import type { FieldValueBase } from './FieldValueBase';
 import type { Writable } from './Writable';
 
 interface ChangemakerFieldValue extends FieldValueBase {
-	changemakerId: number;
+	changemakerId: Id;
 	baseFieldShortCode: string;
-	batchId: number;
+	batchId: Id;
 	readonly baseField: BaseField;
 	readonly batch: ChangemakerFieldValueBatch;
 }
@@ -19,15 +21,11 @@ const writableChangemakerFieldValueSchema: JSONSchemaType<WritableChangemakerFie
 	{
 		type: 'object',
 		properties: {
-			changemakerId: {
-				type: 'integer',
-			},
+			changemakerId: idSchema,
 			baseFieldShortCode: {
 				type: 'string',
 			},
-			batchId: {
-				type: 'integer',
-			},
+			batchId: idSchema,
 			value: {
 				type: 'string',
 			},

--- a/src/types/ChangemakerFieldValueBatch.ts
+++ b/src/types/ChangemakerFieldValueBatch.ts
@@ -1,12 +1,14 @@
 import { ajv } from '../ajv';
+import { idSchema } from './Id';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type { KeycloakId } from './KeycloakId';
 import type { Source } from './Source';
 import type { Writable } from './Writable';
 
 interface ChangemakerFieldValueBatch {
-	readonly id: number;
-	sourceId: number;
+	readonly id: Id;
+	sourceId: Id;
 	notes: string | null;
 	readonly createdBy: KeycloakId;
 	readonly createdAt: string;
@@ -19,9 +21,7 @@ const writableChangemakerFieldValueBatchSchema: JSONSchemaType<WritableChangemak
 	{
 		type: 'object',
 		properties: {
-			sourceId: {
-				type: 'integer',
-			},
+			sourceId: idSchema,
 			notes: {
 				type: 'string',
 				/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion --

--- a/src/types/ChangemakerProposal.ts
+++ b/src/types/ChangemakerProposal.ts
@@ -1,13 +1,15 @@
 import { ajv } from '../ajv';
+import { idSchema } from './Id';
 import type { Changemaker } from './Changemaker';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type { Proposal } from './Proposal';
 import type { Writable } from './Writable';
 
 interface ChangemakerProposal {
-	readonly id: number;
-	changemakerId: number;
-	proposalId: number;
+	readonly id: Id;
+	changemakerId: Id;
+	proposalId: Id;
 	readonly changemaker: Changemaker;
 	readonly proposal: Proposal;
 	readonly createdAt: string;
@@ -19,12 +21,8 @@ const writableChangemakerProposalSchema: JSONSchemaType<WritableChangemakerPropo
 	{
 		type: 'object',
 		properties: {
-			changemakerId: {
-				type: 'number',
-			},
-			proposalId: {
-				type: 'number',
-			},
+			changemakerId: idSchema,
+			proposalId: idSchema,
 		},
 		required: ['changemakerId', 'proposalId'],
 	};

--- a/src/types/CopyBaseFieldsJobPayload.ts
+++ b/src/types/CopyBaseFieldsJobPayload.ts
@@ -1,17 +1,17 @@
 import { ajv } from '../ajv';
+import { idSchema } from './Id';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 
 interface CopyBaseFieldsJobPayload {
-	baseFieldsCopyTaskId: number;
+	baseFieldsCopyTaskId: Id;
 }
 
 const copyBaseFieldsJobPayloadSchema: JSONSchemaType<CopyBaseFieldsJobPayload> =
 	{
 		type: 'object',
 		properties: {
-			baseFieldsCopyTaskId: {
-				type: 'integer',
-			},
+			baseFieldsCopyTaskId: idSchema,
 		},
 		required: ['baseFieldsCopyTaskId'],
 	};

--- a/src/types/FieldValueBase.ts
+++ b/src/types/FieldValueBase.ts
@@ -1,7 +1,8 @@
 import type { File } from './File';
+import type { Id } from './Id';
 
 interface FieldValueBase {
-	readonly id: number;
+	readonly id: Id;
 	value: string;
 	readonly file: File | null;
 	goodAsOf: string | null;

--- a/src/types/Opportunity.ts
+++ b/src/types/Opportunity.ts
@@ -1,5 +1,6 @@
 import { ajv } from '../ajv';
 import { shortCodeSchema } from './ShortCode';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
 import type { ShortCode } from './ShortCode';
@@ -7,7 +8,7 @@ import type { Funder } from './Funder';
 import type { KeycloakId } from './KeycloakId';
 
 interface Opportunity {
-	readonly id: number;
+	readonly id: Id;
 	title: string;
 	funderShortCode: ShortCode;
 	readonly funder: Funder;

--- a/src/types/PermissionGrant.ts
+++ b/src/types/PermissionGrant.ts
@@ -8,6 +8,7 @@ import {
 } from './PermissionGrantGranteeType';
 import { permissionGrantVerbSchema } from './PermissionGrantVerb';
 import type { TypeGuardWithAjvErrors } from '../ajv';
+import type { Id } from './Id';
 import type { KeycloakId } from './KeycloakId';
 import type { PermissionGrantVerb } from './PermissionGrantVerb';
 import type { Writable } from './Writable';
@@ -34,7 +35,7 @@ enum PermissionGrantEntityKeyType {
 }
 
 interface PermissionGrantEntityKeyValueType {
-	[PermissionGrantEntityKeyType.ID]: number;
+	[PermissionGrantEntityKeyType.ID]: Id;
 	[PermissionGrantEntityKeyType.SHORT_CODE]: string;
 }
 
@@ -183,7 +184,7 @@ const scopeConditions = {
 >;
 
 interface UnkeyedPermissionGrant {
-	readonly id: number;
+	readonly id: Id;
 	verbs: PermissionGrantVerb[];
 	readonly createdBy: KeycloakId;
 	readonly createdAt: string;

--- a/src/types/ProcessBulkUploadJobPayload.ts
+++ b/src/types/ProcessBulkUploadJobPayload.ts
@@ -1,17 +1,17 @@
 import { ajv } from '../ajv';
+import { idSchema } from './Id';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 
 export interface ProcessBulkUploadJobPayload {
-	bulkUploadId: number;
+	bulkUploadId: Id;
 }
 
 export const processBulkUploadJobPayloadSchema: JSONSchemaType<ProcessBulkUploadJobPayload> =
 	{
 		type: 'object',
 		properties: {
-			bulkUploadId: {
-				type: 'integer',
-			},
+			bulkUploadId: idSchema,
 		},
 		required: ['bulkUploadId'],
 	};

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -1,4 +1,6 @@
 import { ajv } from '../ajv';
+import { idSchema } from './Id';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type { ShallowChangemaker } from './Changemaker';
 import type { ProposalVersion } from './ProposalVersion';
@@ -7,8 +9,8 @@ import type { KeycloakId } from './KeycloakId';
 import type { Opportunity } from './Opportunity';
 
 interface Proposal {
-	readonly id: number;
-	opportunityId: number;
+	readonly id: Id;
+	opportunityId: Id;
 	readonly opportunity: Opportunity;
 	externalId: string;
 	readonly versions: ProposalVersion[];
@@ -22,9 +24,7 @@ type WritableProposal = Writable<Proposal>;
 const writableProposalSchema: JSONSchemaType<WritableProposal> = {
 	type: 'object',
 	properties: {
-		opportunityId: {
-			type: 'integer',
-		},
+		opportunityId: idSchema,
 		externalId: {
 			type: 'string',
 			pattern: '.+',

--- a/src/types/ProposalFieldValue.ts
+++ b/src/types/ProposalFieldValue.ts
@@ -1,11 +1,13 @@
+import { idSchema } from './Id';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type { ApplicationFormField } from './ApplicationFormField';
 import type { FieldValueBase } from './FieldValueBase';
 import type { Writable } from './Writable';
 
 interface ProposalFieldValue extends FieldValueBase {
-	proposalVersionId: number;
-	applicationFormFieldId: number;
+	proposalVersionId: Id;
+	applicationFormFieldId: Id;
 	position: number;
 	readonly applicationFormField: ApplicationFormField;
 }
@@ -21,9 +23,7 @@ const writableProposalFieldValueWithProposalVersionContextSchema: JSONSchemaType
 	{
 		type: 'object',
 		properties: {
-			applicationFormFieldId: {
-				type: 'integer',
-			},
+			applicationFormFieldId: idSchema,
 			position: {
 				type: 'integer',
 			},

--- a/src/types/ProposalVersion.ts
+++ b/src/types/ProposalVersion.ts
@@ -1,5 +1,7 @@
 import { ajv } from '../ajv';
 import { writableProposalFieldValueWithProposalVersionContextSchema } from './ProposalFieldValue';
+import { idSchema } from './Id';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type {
 	ProposalFieldValue,
@@ -10,12 +12,12 @@ import type { Source } from './Source';
 import type { KeycloakId } from './KeycloakId';
 
 interface ProposalVersion {
-	readonly id: number;
-	proposalId: number;
-	sourceId: number;
+	readonly id: Id;
+	proposalId: Id;
+	sourceId: Id;
 	readonly source: Source;
 	readonly version: number;
-	applicationFormId: number;
+	applicationFormId: Id;
 	readonly fieldValues: ProposalFieldValue[];
 	readonly createdAt: string;
 	readonly createdBy: KeycloakId;
@@ -31,15 +33,9 @@ const writableProposalVersionWithFieldValuesSchema: JSONSchemaType<WritablePropo
 	{
 		type: 'object',
 		properties: {
-			proposalId: {
-				type: 'integer',
-			},
-			sourceId: {
-				type: 'integer',
-			},
-			applicationFormId: {
-				type: 'integer',
-			},
+			proposalId: idSchema,
+			sourceId: idSchema,
+			applicationFormId: idSchema,
 			fieldValues: {
 				type: 'array',
 				items: writableProposalFieldValueWithProposalVersionContextSchema,

--- a/src/types/Source.ts
+++ b/src/types/Source.ts
@@ -1,13 +1,15 @@
 import { ajv } from '../ajv';
+import { idSchema } from './Id';
 import type { Funder } from './Funder';
 import type { Changemaker } from './Changemaker';
 import type { DataProvider } from './DataProvider';
+import type { Id } from './Id';
 import type { JSONSchemaType } from 'ajv';
 import type { Writable } from './Writable';
 import type { KeycloakId } from './KeycloakId';
 
 interface SourceBase {
-	readonly id: number;
+	readonly id: Id;
 	label: string;
 	readonly createdAt: string;
 	readonly createdBy: KeycloakId;
@@ -24,7 +26,7 @@ interface FunderSource extends SourceBase {
 }
 
 interface ChangemakerSource extends SourceBase {
-	changemakerId: number;
+	changemakerId: Id;
 	readonly changemaker: Changemaker;
 }
 
@@ -63,7 +65,7 @@ const writableSourceSchema: JSONSchemaType<WritableSource> = {
 				{
 					type: 'object',
 					properties: {
-						changemakerId: { type: 'number' },
+						changemakerId: idSchema,
 					},
 					required: ['changemakerId'],
 				},


### PR DESCRIPTION
This PR improves our internal and documented types to use the `Id` schema / type consistently.  It also fixes a documentation error where base field localizations were saying short codes were numbers.

Resolves #2015 