### PR TITLE
Support extensions in phone number validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add extension support in phone number validation.
 - Add changelog to documents that auto-publish to WordPress.
 - `GET /funders` now supports the `isCollaborative` query parameter to filter funders by their collaborative status.
 

--- a/src/__tests__/fieldValidation.unit.test.ts
+++ b/src/__tests__/fieldValidation.unit.test.ts
@@ -58,19 +58,16 @@ describe('field value validation against BaseFieldDataType', () => {
 	});
 	test('validate a valid phone number as PHONE_NUMBER', () => {
 		expect(
-			fieldValueIsValid('18005555555', BaseFieldDataType.PHONE_NUMBER),
+			fieldValueIsValid('+18005555555', BaseFieldDataType.PHONE_NUMBER),
 		).toBe(true);
 		expect(
 			fieldValueIsValid('+1(800)-555-5555', BaseFieldDataType.PHONE_NUMBER),
 		).toBe(true);
 		expect(
-			fieldValueIsValid('800-555-5555', BaseFieldDataType.PHONE_NUMBER),
-		).toBe(true);
-		expect(
-			fieldValueIsValid('800-555-5555', BaseFieldDataType.PHONE_NUMBER),
+			fieldValueIsValid('+1800-555-5555', BaseFieldDataType.PHONE_NUMBER),
 		).toBe(true);
 	});
-	test('validate an invalid phone number as PHONE_NUMBER', () => {
+	test('validate non-phone number strings as PHONE_NUMBER', () => {
 		expect(
 			fieldValueIsValid(
 				'112345678901234567890',
@@ -83,6 +80,68 @@ describe('field value validation against BaseFieldDataType', () => {
 		expect(fieldValueIsValid('      ', BaseFieldDataType.PHONE_NUMBER)).toBe(
 			false,
 		);
+	});
+	test('validate otherwise valid phone number without +country code as PHONE_NUMBER', () => {
+		expect(
+			fieldValueIsValid('18005555555', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(false);
+		expect(
+			fieldValueIsValid('8005555555', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(false);
+	});
+	test('validate a valid phone number with no extension as PHONE_NUMBER', () => {
+		expect(
+			fieldValueIsValid('+18005555555', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(true);
+	});
+	test('validate a phone number with visual markers as PHONE_NUMBER', () => {
+		expect(
+			fieldValueIsValid('+1 (800) 555-5555', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(true);
+		expect(
+			fieldValueIsValid('+1800-555-5555', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(true);
+	});
+	test('validate a valid phone number with ;ext= extension as PHONE_NUMBER', () => {
+		expect(
+			fieldValueIsValid(
+				'+1 (800) 555-5555;ext=100',
+				BaseFieldDataType.PHONE_NUMBER,
+			),
+		).toBe(true);
+	});
+	test('validate a valid phone number with comma extension as PHONE_NUMBER', () => {
+		expect(
+			fieldValueIsValid(
+				'+1 (800) 555-5555,100',
+				BaseFieldDataType.PHONE_NUMBER,
+			),
+		).toBe(true);
+		expect(
+			fieldValueIsValid('+1800-555-5555,,2', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(true);
+	});
+	test('validate an invalid phone number with valid extension as PHONE_NUMBER', () => {
+		expect(
+			fieldValueIsValid('(800) 555-5555,,090', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(false);
+		expect(
+			fieldValueIsValid(
+				'1(800)555-55555;ext=5',
+				BaseFieldDataType.PHONE_NUMBER,
+			),
+		).toBe(false);
+	});
+	test('validate a valid phone number with invalid extension as PHONE_NUMBER', () => {
+		expect(
+			fieldValueIsValid('+18005555555;;5', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(false);
+		expect(
+			fieldValueIsValid('+18005555555x254', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(false);
+		expect(
+			fieldValueIsValid('+18005555555,', BaseFieldDataType.PHONE_NUMBER),
+		).toBe(false);
 	});
 	test('validate a valid boolean as BOOLEAN', () => {
 		expect(fieldValueIsValid('true', BaseFieldDataType.BOOLEAN)).toBe(true);

--- a/src/fieldValidation.ts
+++ b/src/fieldValidation.ts
@@ -34,12 +34,34 @@ const isString = ajv.compile({
 	type: 'string',
 });
 
+const splitPhoneNumberAndExtensionCandidates = (
+	value: string,
+): [baseNumber: string, extension: string | undefined] => {
+	const match = /^(?<baseNumber>.+?)(?:(?:,+|;ext=)(?<extension>.*))?$/v.exec(
+		value,
+	);
+	return [match?.groups?.baseNumber ?? '', match?.groups?.extension];
+};
+
+const isValidBasePhoneNumber = (candidate: string): boolean =>
+	candidate.trim() === candidate &&
+	validator.isMobilePhone(candidate, 'any', { strictMode: true });
+
+const isValidExtension = (candidate: string): boolean =>
+	/^\d+$/v.test(candidate);
+
 // The validator package has only one phone number validator function,
 // 'isMobilePhone.' but the PDC does not currently have any requirement
 // for a phone number to be a mobile number, nor does the function seem
 // to discriminate on landline numbers.
-const isPhoneNumberString = (value: string): boolean =>
-	validator.isMobilePhone(value);
+const isPhoneNumberString = (value: string): boolean => {
+	const [baseNumberCandidate, extensionCandidate] =
+		splitPhoneNumberAndExtensionCandidates(value);
+	return (
+		isValidBasePhoneNumber(baseNumberCandidate) &&
+		(extensionCandidate === undefined || isValidExtension(extensionCandidate))
+	);
+};
 
 const isCurrencyWithCodeString = (value: string): boolean => {
 	const [currency, code] = value.split(' ');


### PR DESCRIPTION
This adds support for extensions in phone numbers by validating the base number only, without the extension, by stripping off any sequence that begins with a letter from the end of a phone number (which can only contain punctuation, whitespace, and numbers). The stored base field value is unchanged. 

Overall validation documentation will be added in a separate PR to follow this one, to cover decisions made thus far. 

Resolves #2151 Support ext in phone numbers