### PR TITLE
Update `permissionGrants` endpoints to honor `MANAGE` permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `POST /applicationForms` now requires `edit | applicationForm` scope on the target opportunity instead of `edit | opportunity`.
 - `PATCH /applicationFormFields/:applicationFormFieldId` now requires `edit | applicationForm` scope on the parent application form instead of `edit | opportunity`.
 - Existing permission grants with `opportunity` scope on funder or opportunity contexts have been migrated to also include `applicationForm` scope. This preserves prior access for grantees who relied on `opportunity`-scoped grants for application form access.
+- `/permissionGrants` endpoints (list, read, create, update, delete) no longer require administrator role. Non-admin users holding the `manage` verb on a grant's context entity may now list, read, create, update, and delete those grants. `GET /permissionGrants` filters results for non-admins to grants whose context entity they can manage. Updating a grant requires manage on both the existing and proposed context entity.
 
 ## 0.36.0 2026-05-12
 

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -230,9 +230,15 @@ checks. This role grants full administrative access to the PDC service.
 
 ### Permission Grant Management
 
-All CRUD operations on permission grants require the `pdc-admin` role.
-Non-administrators cannot directly create, view, or delete permission grants
-through the API.
+CRUD operations on permission grants require either the `pdc-admin` role or the
+`manage` verb on the grant's context entity. Administrators may act on any
+grant. Non-administrators holding `manage` on a given context entity may list,
+read, create, update, and delete grants whose `contextEntityType` and
+corresponding key identify that entity. `GET /permissionGrants` filters results
+for non-administrators so they see only grants whose context entity they can
+manage. `PUT /permissionGrants/:id` additionally requires `manage` on the
+proposed context entity when the caller re-points a grant at a different
+entity.
 
 ## Implemented Permissions
 

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -795,7 +795,6 @@ describe('/applicationForms', () => {
 		it('grants the creator a manage permission on the new form and each field', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
-			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const opportunity = await createTestOpportunity(db, testUserAuthContext);
@@ -822,7 +821,7 @@ describe('/applicationForms', () => {
 				.expect(201);
 			const grants = await loadPermissionGrantBundle(
 				db,
-				systemUserAuthContext,
+				getAuthContext(systemUser, true),
 				NO_LIMIT,
 				NO_OFFSET,
 			);

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -565,7 +565,7 @@ describe('/tasks/bulkUploads', () => {
 				.expect(201);
 			const grants = await loadPermissionGrantBundle(
 				db,
-				systemUserAuthContext,
+				getAuthContext(systemUser, true),
 				NO_LIMIT,
 				NO_OFFSET,
 			);

--- a/src/__tests__/changemakerFieldValues.int.test.ts
+++ b/src/__tests__/changemakerFieldValues.int.test.ts
@@ -88,7 +88,6 @@ describe('POST /changemakerFieldValues', () => {
 	it('grants the creator a manage permission on the new changemaker field value', async () => {
 		const db = getDatabase();
 		const systemUser = await loadSystemUser(db, null);
-		const systemUserAuthContext = getAuthContext(systemUser);
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser, true);
 		const changemaker = await createTestChangemaker(db, testUserAuthContext);
@@ -119,7 +118,7 @@ describe('POST /changemakerFieldValues', () => {
 			.expect(201);
 		const grants = await loadPermissionGrantBundle(
 			db,
-			systemUserAuthContext,
+			getAuthContext(systemUser, true),
 			NO_LIMIT,
 			NO_OFFSET,
 		);

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -1117,7 +1117,6 @@ describe('/changemakers', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const systemUser = await loadSystemUser(db, null);
-			const systemUserAuthContext = getAuthContext(systemUser);
 			await request(app)
 				.post('/changemakers')
 				.type('application/json')
@@ -1130,7 +1129,7 @@ describe('/changemakers', () => {
 				.expect(201);
 			const grants = await loadPermissionGrantBundle(
 				db,
-				systemUserAuthContext,
+				getAuthContext(systemUser, true),
 				NO_LIMIT,
 				NO_OFFSET,
 			);

--- a/src/__tests__/dataProviders.int.test.ts
+++ b/src/__tests__/dataProviders.int.test.ts
@@ -194,7 +194,6 @@ describe('/dataProviders', () => {
 		it('grants the creator a manage permission on the new data provider', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
-			const systemUserAuthContext = getAuthContext(systemUser);
 			await agent
 				.put('/dataProviders/self_grant_dp')
 				.type('application/json')
@@ -203,7 +202,7 @@ describe('/dataProviders', () => {
 				.expect(201);
 			const grants = await loadPermissionGrantBundle(
 				db,
-				systemUserAuthContext,
+				getAuthContext(systemUser, true),
 				NO_LIMIT,
 				NO_OFFSET,
 			);

--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -483,7 +483,6 @@ describe('/funders', () => {
 		it('grants the creator a manage permission on the new funder', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
-			const systemUserAuthContext = getAuthContext(systemUser);
 			await agent
 				.put('/funders/self_grant_funder')
 				.type('application/json')
@@ -492,7 +491,7 @@ describe('/funders', () => {
 				.expect(201);
 			const grants = await loadPermissionGrantBundle(
 				db,
-				systemUserAuthContext,
+				getAuthContext(systemUser, true),
 				NO_LIMIT,
 				NO_OFFSET,
 			);

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -299,7 +299,7 @@ describe('/opportunities', () => {
 				.expect(201);
 			const grants = await loadPermissionGrantBundle(
 				db,
-				systemUserAuthContext,
+				getAuthContext(systemUser, true),
 				NO_LIMIT,
 				NO_OFFSET,
 			);

--- a/src/__tests__/permissionGrants.int.test.ts
+++ b/src/__tests__/permissionGrants.int.test.ts
@@ -53,8 +53,75 @@ describe('/permissionGrants', () => {
 			await agent.get('/permissionGrants').expect(401);
 		});
 
-		it('requires administrator role', async () => {
-			await agent.get('/permissionGrants').set(authHeader).expect(401);
+		it('returns an empty list for a non-admin without any manage permissions', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			await createTestPermissionGrant(db, authContext);
+
+			const response = await agent
+				.get('/permissionGrants')
+				.set(authHeader)
+				.expect(200);
+			expect(response.body).toEqual({
+				entries: [],
+				total: 0,
+			});
+		});
+
+		it('returns only grants whose context entity the non-admin can manage', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const manageableChangemaker = await createTestChangemaker(
+				db,
+				authContext,
+			);
+			const unmanageableChangemaker = await createTestChangemaker(
+				db,
+				authContext,
+			);
+			await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: manageableChangemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.MANAGE],
+			});
+			const visibleGrant = await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: manageableChangemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+			await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: unmanageableChangemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+
+			const response = await agent
+				.get('/permissionGrants')
+				.set(authHeader)
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				total: 2,
+				entries: [
+					expect.objectContaining({
+						id: visibleGrant.id,
+						changemakerId: manageableChangemaker.id,
+					}),
+					expect.objectContaining({
+						changemakerId: manageableChangemaker.id,
+						verbs: ['manage'],
+					}),
+				],
+			});
 		});
 
 		it('returns an empty list when no permission grants exist', async () => {
@@ -135,8 +202,47 @@ describe('/permissionGrants', () => {
 			await agent.get('/permissionGrants/1').expect(401);
 		});
 
-		it('requires administrator role', async () => {
-			await agent.get('/permissionGrants/1').set(authHeader).expect(401);
+		it('returns 404 to a non-admin without manage permission on the context entity', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const permissionGrant = await createTestPermissionGrant(db, authContext);
+			await agent
+				.get(`/permissionGrants/${permissionGrant.id}`)
+				.set(authHeader)
+				.expect(404);
+		});
+
+		it('allows non-admin with manage permission on the context entity', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
+			await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.MANAGE],
+			});
+			const targetGrant = await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+
+			const response = await agent
+				.get(`/permissionGrants/${targetGrant.id}`)
+				.set(authHeader)
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				id: targetGrant.id,
+				contextEntityType: 'changemaker',
+				changemakerId: changemaker.id,
+			});
 		});
 
 		it('returns exactly one permission grant by id', async () => {
@@ -200,7 +306,7 @@ describe('/permissionGrants', () => {
 			await agent.post('/permissionGrants').expect(401);
 		});
 
-		it('requires administrator role', async () => {
+		it('returns 401 to a non-admin who has no permission on the context entity', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
 			const changemaker = await createTestChangemaker(db, authContext);
@@ -211,13 +317,89 @@ describe('/permissionGrants', () => {
 				.send({
 					granteeType: 'user',
 					granteeUserKeycloakUserId: testUserKeycloakUserId,
-					granteeKeycloakOrganizationId: null,
 					contextEntityType: 'changemaker',
 					changemakerId: changemaker.id,
 					scope: ['changemaker'],
 					verbs: ['view'],
 				})
 				.expect(401);
+		});
+
+		it('returns 401 to a non-admin with view but not manage permission on the context entity', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
+			await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+			await agent
+				.post('/permissionGrants')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUserKeycloakUserId,
+					contextEntityType: 'changemaker',
+					changemakerId: changemaker.id,
+					scope: ['changemaker'],
+					verbs: ['view'],
+				})
+				.expect(401);
+		});
+
+		it('returns 401 to a non-admin when the context entity does not exist', async () => {
+			await agent
+				.post('/permissionGrants')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUserKeycloakUserId,
+					contextEntityType: 'changemaker',
+					changemakerId: 9001,
+					scope: ['changemaker'],
+					verbs: ['view'],
+				})
+				.expect(401);
+		});
+
+		it('allows non-admin with manage permission to create a grant', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
+			await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.MANAGE],
+			});
+
+			const result = await agent
+				.post('/permissionGrants')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUserKeycloakUserId,
+					contextEntityType: 'changemaker',
+					changemakerId: changemaker.id,
+					scope: ['changemaker'],
+					verbs: ['view'],
+				})
+				.expect(201);
+
+			expect(result.body).toMatchObject({
+				contextEntityType: 'changemaker',
+				changemakerId: changemaker.id,
+				verbs: ['view'],
+			});
 		});
 
 		it('creates and returns a permission grant for a user', async () => {
@@ -878,20 +1060,115 @@ describe('/permissionGrants', () => {
 			await agent.put('/permissionGrants/1').expect(401);
 		});
 
-		it('requires administrator role', async () => {
+		it('returns 404 to a non-admin without manage permission on the existing context entity', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
+			const permissionGrant = await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
 			await agent
-				.put('/permissionGrants/1')
+				.put(`/permissionGrants/${permissionGrant.id}`)
 				.type('application/json')
 				.set(authHeader)
 				.send({
 					granteeType: 'user',
 					granteeUserKeycloakUserId: testUserKeycloakUserId,
 					contextEntityType: 'changemaker',
-					changemakerId: 1,
+					changemakerId: changemaker.id,
+					scope: ['changemaker'],
+					verbs: ['view'],
+				})
+				.expect(404);
+		});
+
+		it('rejects non-admin who can manage the existing entity but not the proposed entity', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const manageableChangemaker = await createTestChangemaker(
+				db,
+				authContext,
+			);
+			const unmanageableChangemaker = await createTestChangemaker(
+				db,
+				authContext,
+			);
+			await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: manageableChangemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.MANAGE],
+			});
+			const permissionGrant = await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: manageableChangemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+
+			await agent
+				.put(`/permissionGrants/${permissionGrant.id}`)
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUserKeycloakUserId,
+					contextEntityType: 'changemaker',
+					changemakerId: unmanageableChangemaker.id,
 					scope: ['changemaker'],
 					verbs: ['view'],
 				})
 				.expect(401);
+		});
+
+		it('allows non-admin with manage permission to update a grant', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
+			await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.MANAGE],
+			});
+			const permissionGrant = await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+
+			const response = await agent
+				.put(`/permissionGrants/${permissionGrant.id}`)
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUserKeycloakUserId,
+					contextEntityType: 'changemaker',
+					changemakerId: changemaker.id,
+					scope: ['changemaker'],
+					verbs: ['view', 'edit'],
+				})
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				id: permissionGrant.id,
+				verbs: ['view', 'edit'],
+			});
 		});
 
 		it('updates and returns the permission grant', async () => {
@@ -1207,8 +1484,45 @@ describe('/permissionGrants', () => {
 			await agent.delete('/permissionGrants/1').expect(401);
 		});
 
-		it('requires administrator role', async () => {
-			await agent.delete('/permissionGrants/1').set(authHeader).expect(401);
+		it('returns 404 to a non-admin without manage permission on the context entity', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const permissionGrant = await createTestPermissionGrant(db, authContext);
+			await agent
+				.delete(`/permissionGrants/${permissionGrant.id}`)
+				.set(authHeader)
+				.expect(404);
+		});
+
+		it('allows non-admin with manage permission to delete a grant', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
+			await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.MANAGE],
+			});
+			const permissionGrant = await createTestPermissionGrant(db, authContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.CHANGEMAKER],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+			const before = await loadTableMetrics(db, 'permission_grants');
+
+			await agent
+				.delete(`/permissionGrants/${permissionGrant.id}`)
+				.set(authHeader)
+				.expect(204);
+
+			const after = await loadTableMetrics(db, 'permission_grants');
+			expect(after.count).toEqual(before.count - 1);
 		});
 
 		it('deletes exactly one permission grant', async () => {

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -293,7 +293,6 @@ describe('/proposalVersions', () => {
 		it('grants the creator a manage permission on the new proposal version and field values', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
-			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
@@ -336,7 +335,7 @@ describe('/proposalVersions', () => {
 				.expect(201);
 			const grants = await loadPermissionGrantBundle(
 				db,
-				systemUserAuthContext,
+				getAuthContext(systemUser, true),
 				NO_LIMIT,
 				NO_OFFSET,
 			);

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -1560,7 +1560,6 @@ describe('/proposals', () => {
 		it('grants the creator a manage permission on the new proposal', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
-			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const opportunity = await createTestOpportunity(db, testUserAuthContext);
@@ -1575,7 +1574,7 @@ describe('/proposals', () => {
 				.expect(201);
 			const grants = await loadPermissionGrantBundle(
 				db,
-				systemUserAuthContext,
+				getAuthContext(systemUser, true),
 				NO_LIMIT,
 				NO_OFFSET,
 			);

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -380,7 +380,6 @@ describe('/sources', () => {
 		it('grants the creator a manage permission on the new source', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
-			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const changemaker = await createTestChangemaker(db, testUserAuthContext);
@@ -395,7 +394,7 @@ describe('/sources', () => {
 				.expect(201);
 			const grants = await loadPermissionGrantBundle(
 				db,
-				systemUserAuthContext,
+				getAuthContext(systemUser, true),
 				NO_LIMIT,
 				NO_OFFSET,
 			);

--- a/src/database/initialization/can_manage_permission_grant.sql
+++ b/src/database/initialization/can_manage_permission_grant.sql
@@ -1,0 +1,96 @@
+SELECT drop_function('can_manage_permission_grant');
+
+CREATE FUNCTION can_manage_permission_grant(
+	user_keycloak_user_id uuid,
+	user_is_admin boolean,
+	permission_grant permission_grants
+) RETURNS boolean AS $$
+BEGIN
+	IF user_is_admin THEN
+		RETURN TRUE;
+	END IF;
+
+	CASE permission_grant.context_entity_type
+		WHEN 'funder' THEN
+			RETURN has_funder_permission(
+				user_keycloak_user_id,
+				user_is_admin,
+				permission_grant.funder_short_code,
+				'manage',
+				'funder'
+			);
+		WHEN 'changemaker' THEN
+			RETURN has_changemaker_permission(
+				user_keycloak_user_id,
+				user_is_admin,
+				permission_grant.changemaker_id,
+				'manage',
+				'changemaker'
+			);
+		WHEN 'dataProvider' THEN
+			RETURN has_data_provider_permission(
+				user_keycloak_user_id,
+				user_is_admin,
+				permission_grant.data_provider_short_code,
+				'manage',
+				'dataProvider'
+			);
+		WHEN 'opportunity' THEN
+			RETURN has_opportunity_permission(
+				user_keycloak_user_id,
+				user_is_admin,
+				permission_grant.opportunity_id,
+				'manage',
+				'opportunity'
+			);
+		WHEN 'proposal' THEN
+			RETURN has_proposal_permission(
+				user_keycloak_user_id,
+				user_is_admin,
+				permission_grant.proposal_id,
+				'manage',
+				'proposal'
+			);
+		WHEN 'applicationForm' THEN
+			RETURN has_application_form_permission(
+				user_keycloak_user_id,
+				user_is_admin,
+				permission_grant.application_form_id,
+				'manage',
+				'applicationForm'
+			);
+		WHEN 'proposalFieldValue' THEN
+			RETURN has_proposal_field_value_permission(
+				user_keycloak_user_id,
+				user_is_admin,
+				permission_grant.proposal_field_value_id,
+				'manage',
+				'proposalFieldValue'
+			);
+		WHEN 'source' THEN
+			RETURN has_source_permission(
+				user_keycloak_user_id,
+				user_is_admin,
+				permission_grant.source_id,
+				'manage',
+				'source'
+			);
+		WHEN 'changemakerFieldValue' THEN
+			RETURN has_changemaker_field_value_permission(
+				user_keycloak_user_id,
+				user_is_admin,
+				permission_grant.changemaker_field_value_id,
+				'manage',
+				'changemakerFieldValue'
+			);
+		WHEN 'applicationFormField', 'proposalVersion', 'bulkUpload' THEN
+			-- Permission checks are not enforced for these context entity types;
+			-- only administrators may manage such grants.
+			RETURN FALSE;
+		ELSE
+			RAISE EXCEPTION
+				'Cannot manage permission grant with unsupported context entity type "%"',
+				permission_grant.context_entity_type;
+	END CASE;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/operations/authorization/__tests__/canManagePermissionGrantByContext.unit.test.ts
+++ b/src/database/operations/authorization/__tests__/canManagePermissionGrantByContext.unit.test.ts
@@ -1,0 +1,210 @@
+import { canManagePermissionGrantByContext } from '../canManagePermissionGrantByContext';
+import {
+	PermissionGrantEntityType,
+	stringToKeycloakId,
+} from '../../../../types';
+import type { AuthIdentityAndRole } from '../../../../types';
+
+const authContext: AuthIdentityAndRole = {
+	user: {
+		keycloakUserId: stringToKeycloakId('11111111-1111-1111-1111-111111111111'),
+	},
+	role: { isAdministrator: false },
+};
+
+const adminAuthContext: AuthIdentityAndRole = {
+	user: {
+		keycloakUserId: stringToKeycloakId('22222222-2222-2222-2222-222222222222'),
+	},
+	role: { isAdministrator: true },
+};
+
+const mockDbReturning = (result: boolean): { sql: jest.Mock } => ({
+	sql: jest.fn().mockResolvedValue({
+		rows: [{ result }],
+	}),
+});
+
+describe('canManagePermissionGrantByContext', () => {
+	const cases: Array<{
+		label: string;
+		grant: Parameters<typeof canManagePermissionGrantByContext>[2];
+		expectedKey: Record<string, unknown>;
+	}> = [
+		{
+			label: 'funder',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: 'exFunder',
+			},
+			expectedKey: { funderShortCode: 'exFunder' },
+		},
+		{
+			label: 'changemaker',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: 42,
+			},
+			expectedKey: { changemakerId: 42 },
+		},
+		{
+			label: 'dataProvider',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
+				dataProviderShortCode: 'exDataProvider',
+			},
+			expectedKey: { dataProviderShortCode: 'exDataProvider' },
+		},
+		{
+			label: 'opportunity',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.OPPORTUNITY,
+				opportunityId: 17,
+			},
+			expectedKey: { opportunityId: 17 },
+		},
+		{
+			label: 'proposal',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.PROPOSAL,
+				proposalId: 23,
+			},
+			expectedKey: { proposalId: 23 },
+		},
+		{
+			label: 'applicationForm',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.APPLICATION_FORM,
+				applicationFormId: 3,
+			},
+			expectedKey: { applicationFormId: 3 },
+		},
+		{
+			label: 'proposalFieldValue',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
+				proposalFieldValueId: 11,
+			},
+			expectedKey: { proposalFieldValueId: 11 },
+		},
+		{
+			label: 'source',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: 99,
+			},
+			expectedKey: { sourceId: 99 },
+		},
+		{
+			label: 'changemakerFieldValue',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER_FIELD_VALUE,
+				changemakerFieldValueId: 13,
+			},
+			expectedKey: { changemakerFieldValueId: 13 },
+		},
+		{
+			label: 'applicationFormField',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.APPLICATION_FORM_FIELD,
+				applicationFormFieldId: 5,
+			},
+			expectedKey: { applicationFormFieldId: 5 },
+		},
+		{
+			label: 'proposalVersion',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.PROPOSAL_VERSION,
+				proposalVersionId: 8,
+			},
+			expectedKey: { proposalVersionId: 8 },
+		},
+		{
+			label: 'bulkUpload',
+			grant: {
+				contextEntityType: PermissionGrantEntityType.BULK_UPLOAD,
+				bulkUploadTaskId: 7,
+			},
+			expectedKey: { bulkUploadTaskId: 7 },
+		},
+	];
+
+	const ALL_UNSET_ID_KEYS = {
+		funderShortCode: undefined,
+		changemakerId: undefined,
+		dataProviderShortCode: undefined,
+		opportunityId: undefined,
+		proposalId: undefined,
+		proposalVersionId: undefined,
+		applicationFormId: undefined,
+		applicationFormFieldId: undefined,
+		proposalFieldValueId: undefined,
+		sourceId: undefined,
+		bulkUploadTaskId: undefined,
+		changemakerFieldValueId: undefined,
+	};
+
+	it.each(cases)(
+		'$label: invokes the SQL wrapper with the grant context type and only the matching id field populated',
+		async ({ grant, expectedKey }) => {
+			const db = mockDbReturning(true);
+
+			const result = await canManagePermissionGrantByContext(
+				db,
+				authContext,
+				grant,
+			);
+
+			expect(result).toBe(true);
+			expect(db.sql).toHaveBeenCalledTimes(1);
+			expect(db.sql).toHaveBeenCalledWith(
+				'authorization.canManagePermissionGrantByContext',
+				expect.objectContaining({
+					authContextKeycloakUserId: authContext.user.keycloakUserId,
+					authContextIsAdministrator: false,
+					contextEntityType: grant.contextEntityType,
+					...ALL_UNSET_ID_KEYS,
+					...expectedKey,
+				}),
+			);
+		},
+	);
+
+	it('forwards admin role to the SQL wrapper', async () => {
+		const db = mockDbReturning(true);
+
+		await canManagePermissionGrantByContext(db, adminAuthContext, {
+			contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+			changemakerId: 1,
+		});
+
+		expect(db.sql).toHaveBeenCalledWith(
+			'authorization.canManagePermissionGrantByContext',
+			expect.objectContaining({
+				authContextIsAdministrator: true,
+			}),
+		);
+	});
+
+	it('returns false when the underlying query reports no permission', async () => {
+		const db = mockDbReturning(false);
+
+		const result = await canManagePermissionGrantByContext(db, authContext, {
+			contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+			changemakerId: 1,
+		});
+
+		expect(result).toBe(false);
+	});
+
+	it('returns false when the query returns no rows', async () => {
+		const db = { sql: jest.fn().mockResolvedValue({ rows: [] }) };
+
+		const result = await canManagePermissionGrantByContext(db, authContext, {
+			contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+			changemakerId: 1,
+		});
+
+		expect(result).toBe(false);
+	});
+});

--- a/src/database/operations/authorization/canManagePermissionGrantByContext.ts
+++ b/src/database/operations/authorization/canManagePermissionGrantByContext.ts
@@ -1,0 +1,24 @@
+import { generateExistsOperation } from '../generators';
+import type { PermissionGrantContextEntity } from '../../../types';
+
+const canManagePermissionGrantByContext =
+	generateExistsOperation<PermissionGrantContextEntity>(
+		'authorization.canManagePermissionGrantByContext',
+		[
+			'contextEntityType',
+			'funderShortCode',
+			'changemakerId',
+			'dataProviderShortCode',
+			'opportunityId',
+			'proposalId',
+			'proposalVersionId',
+			'applicationFormId',
+			'applicationFormFieldId',
+			'proposalFieldValueId',
+			'sourceId',
+			'bulkUploadTaskId',
+			'changemakerFieldValueId',
+		],
+	);
+
+export { canManagePermissionGrantByContext };

--- a/src/database/operations/authorization/canManagePermissionGrantById.ts
+++ b/src/database/operations/authorization/canManagePermissionGrantById.ts
@@ -1,0 +1,8 @@
+import { generateExistsOperation } from '../generators';
+import type { Id } from '../../../types';
+
+const canManagePermissionGrantById = generateExistsOperation<{
+	permissionGrantId: Id;
+}>('authorization.canManagePermissionGrantById', ['permissionGrantId']);
+
+export { canManagePermissionGrantById };

--- a/src/database/operations/authorization/index.ts
+++ b/src/database/operations/authorization/index.ts
@@ -1,3 +1,5 @@
+export { canManagePermissionGrantByContext } from './canManagePermissionGrantByContext';
+export { canManagePermissionGrantById } from './canManagePermissionGrantById';
 export { hasApplicationFormPermission } from './hasApplicationFormPermission';
 export { hasChangemakerFieldValuePermission } from './hasChangemakerFieldValuePermission';
 export { hasChangemakerPermission } from './hasChangemakerPermission';

--- a/src/database/operations/generators/generateExistsOperation.ts
+++ b/src/database/operations/generators/generateExistsOperation.ts
@@ -1,0 +1,64 @@
+import {
+	getIsAdministratorFromAuthContext,
+	getKeycloakUserIdFromAuthContext,
+} from '../../../types';
+import type { AuthIdentityAndRole } from '../../../types';
+import type { TinyPg } from 'tinypg';
+
+interface ExistsResult {
+	result: boolean;
+}
+
+// This may seem silly but it is necessary to get all keys of all
+// possible types in the event the type is a Union (e.g. A | B | C)
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+
+/**
+ * Generates an operation that executes a SQL query expected to return a single
+ * boolean column aliased as "result" and resolves to that value (or false if
+ * no row was returned).
+ *
+ * The auth context is supplied to the query automatically as
+ * `authContextKeycloakUserId` and `authContextIsAdministrator`. Each name in
+ * `inputAttributes` becomes a named query parameter; the corresponding value
+ * is read from the caller-supplied `input` object, and any attribute the
+ * input does not provide is bound as NULL.
+ *
+ * @param queryName - The name of the SQL query to execute.
+ * @param inputAttributes - Attribute names on the input object that should
+ *   become named query parameters.
+ *
+ * @returns A function that, given a database handle, an auth context, and the
+ *   input object, resolves to the boolean result of the query.
+ */
+const generateExistsOperation =
+	<I extends Record<string, unknown>>(
+		queryName: string,
+		inputAttributes: ReadonlyArray<KeysOfUnion<I>>,
+	): ((
+		db: Pick<TinyPg, 'sql'>,
+		authContext: AuthIdentityAndRole | null,
+		input: I,
+	) => Promise<boolean>) =>
+	async (db, authContext, input): Promise<boolean> => {
+		const inputAttributeQueryParameters = inputAttributes.reduce<
+			Record<string, unknown>
+		>((acc, attribute) => {
+			const { [attribute]: value } = input as Record<KeysOfUnion<I>, unknown>;
+			return {
+				...acc,
+				[attribute]: value,
+			};
+		}, {});
+		const {
+			rows: [row],
+		} = await db.sql<ExistsResult>(queryName, {
+			authContextKeycloakUserId: getKeycloakUserIdFromAuthContext(authContext),
+			authContextIsAdministrator:
+				getIsAdministratorFromAuthContext(authContext),
+			...inputAttributeQueryParameters,
+		});
+		return row?.result ?? false;
+	};
+
+export { generateExistsOperation };

--- a/src/database/operations/generators/index.ts
+++ b/src/database/operations/generators/index.ts
@@ -1,4 +1,5 @@
 export * from './generateCreateItemOperation';
+export * from './generateExistsOperation';
 export * from './generateHasPermissionOperation';
 export * from './generateLoadBundleOperation';
 export * from './generateLoadItemOperation';

--- a/src/database/queries/authorization/canManagePermissionGrantByContext.sql
+++ b/src/database/queries/authorization/canManagePermissionGrantByContext.sql
@@ -1,0 +1,19 @@
+SELECT can_manage_permission_grant(
+	:authContextKeycloakUserId,
+	:authContextIsAdministrator,
+	jsonb_populate_record(NULL::permission_grants, jsonb_build_object(
+		'context_entity_type', :contextEntityType::text,
+		'funder_short_code', :funderShortCode::text,
+		'changemaker_id', :changemakerId::integer,
+		'data_provider_short_code', :dataProviderShortCode::text,
+		'opportunity_id', :opportunityId::integer,
+		'proposal_id', :proposalId::integer,
+		'proposal_version_id', :proposalVersionId::integer,
+		'application_form_id', :applicationFormId::integer,
+		'application_form_field_id', :applicationFormFieldId::integer,
+		'proposal_field_value_id', :proposalFieldValueId::integer,
+		'source_id', :sourceId::integer,
+		'bulk_upload_task_id', :bulkUploadTaskId::integer,
+		'changemaker_field_value_id', :changemakerFieldValueId::integer
+	))
+) AS result;

--- a/src/database/queries/authorization/canManagePermissionGrantById.sql
+++ b/src/database/queries/authorization/canManagePermissionGrantById.sql
@@ -1,0 +1,11 @@
+SELECT exists(
+	SELECT 1
+	FROM permission_grants
+	WHERE
+		id = :permissionGrantId
+		AND can_manage_permission_grant(
+			:authContextKeycloakUserId,
+			:authContextIsAdministrator,
+			permission_grants.*::permission_grants
+		)
+) AS result;

--- a/src/database/queries/permissionGrants/selectById.sql
+++ b/src/database/queries/permissionGrants/selectById.sql
@@ -1,3 +1,9 @@
 SELECT permission_grant_to_json(permission_grants.*) AS object
 FROM permission_grants
-WHERE id = :permissionGrantId;
+WHERE
+	id = :permissionGrantId
+	AND can_manage_permission_grant(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		permission_grants.*::permission_grants
+	);

--- a/src/database/queries/permissionGrants/selectWithPagination.sql
+++ b/src/database/queries/permissionGrants/selectWithPagination.sql
@@ -2,6 +2,11 @@ WITH
 	candidate_entries AS NOT MATERIALIZED (
 		SELECT permission_grants.*
 		FROM permission_grants
+		WHERE can_manage_permission_grant(
+			:authContextKeycloakUserId,
+			:authContextIsAdministrator,
+			permission_grants.*::permission_grants
+		)
 	),
 
 	entry_count AS (

--- a/src/handlers/permissionGrantsHandlers.ts
+++ b/src/handlers/permissionGrantsHandlers.ts
@@ -1,6 +1,8 @@
 import { isEmpty } from '../arrays';
 import { HTTP_STATUS } from '../constants';
 import {
+	canManagePermissionGrantByContext,
+	canManagePermissionGrantById,
 	createPermissionGrant,
 	getDatabase,
 	getLimitValues,
@@ -14,6 +16,7 @@ import {
 	InputValidationError,
 	NoDataReturnedError,
 	NotFoundError,
+	UnauthorizedError,
 } from '../errors';
 import { extractPaginationParameters } from '../queryParameters';
 import {
@@ -23,11 +26,14 @@ import {
 	isId,
 	isWritablePermissionGrant,
 	PermissionGrantEntityType,
+	type AuthIdentityAndRole,
+	type Id,
 	type PermissionGrantCondition,
 	type WritableUnkeyedPermissionGrant,
 } from '../types';
 import { coerceParams } from '../coercion';
 import type { Request, Response } from 'express';
+import type { TinyPg } from 'tinypg';
 
 const assertPermissionGrantContextEntityTypeIsSupported = (
 	permissionGrant: WritableUnkeyedPermissionGrant,
@@ -157,12 +163,38 @@ const postPermissionGrant = async (
 	assertPermissionGrantContextEntityTypeIsSupported(body);
 	assertPermissionGrantHasValidScope(body);
 	assertPermissionGrantHasValidConditions(body);
+
+	if (!(await canManagePermissionGrantByContext(db, req, body))) {
+		throw new UnauthorizedError(
+			'Authenticated user does not have permission to manage permission grants on the specified context entity.',
+		);
+	}
+
 	const permissionGrant = await createPermissionGrant(db, req, body);
 
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')
 		.send(permissionGrant);
+};
+
+const assertCanManagePermissionGrantById = async (
+	db: Pick<TinyPg, 'sql'>,
+	authContext: AuthIdentityAndRole,
+	permissionGrantId: Id,
+): Promise<void> => {
+	if (
+		!(await canManagePermissionGrantById(db, authContext, {
+			permissionGrantId,
+		}))
+	) {
+		throw new NotFoundError('The given permission grant was not found.', {
+			entityType: 'PermissionGrant',
+			entityPrimaryKey: {
+				permissionGrantId,
+			},
+		});
+	}
 };
 
 const getPermissionGrant = async (
@@ -180,6 +212,8 @@ const getPermissionGrant = async (
 			isId.errors ?? [],
 		);
 	}
+
+	await assertCanManagePermissionGrantById(db, req, permissionGrantId);
 
 	const permissionGrant = await loadPermissionGrant(db, req, permissionGrantId);
 
@@ -205,6 +239,8 @@ const putPermissionGrant = async (
 		);
 	}
 
+	await assertCanManagePermissionGrantById(db, req, permissionGrantId);
+
 	const body = req.body as unknown;
 	if (!isWritablePermissionGrant(body)) {
 		throw new InputValidationError(
@@ -216,6 +252,12 @@ const putPermissionGrant = async (
 	assertPermissionGrantContextEntityTypeIsSupported(body);
 	assertPermissionGrantHasValidScope(body);
 	assertPermissionGrantHasValidConditions(body);
+
+	if (!(await canManagePermissionGrantByContext(db, req, body))) {
+		throw new UnauthorizedError(
+			'Authenticated user does not have permission to manage permission grants on the specified context entity.',
+		);
+	}
 
 	try {
 		const permissionGrant = await updatePermissionGrant(
@@ -260,6 +302,8 @@ const deletePermissionGrant = async (
 			isId.errors ?? [],
 		);
 	}
+
+	await assertCanManagePermissionGrantById(db, req, permissionGrantId);
 
 	await removePermissionGrant(db, req, permissionGrantId);
 

--- a/src/openapi/paths/permissionGrant.json
+++ b/src/openapi/paths/permissionGrant.json
@@ -2,7 +2,7 @@
 	"get": {
 		"operationId": "getPermissionGrantById",
 		"summary": "Gets a specific permission grant.",
-		"description": "Returns a permission grant by ID. Requires administrator role.",
+		"description": "Returns a permission grant by ID. Requires the `manage` verb on the grant's context entity.",
 		"tags": ["PermissionGrants"],
 		"security": [
 			{
@@ -59,7 +59,7 @@
 	"put": {
 		"operationId": "updatePermissionGrantById",
 		"summary": "Updates a specific permission grant.",
-		"description": "Replaces all mutable fields of a permission grant by ID. Requires administrator role.",
+		"description": "Replaces all mutable fields of a permission grant by ID. Requires the `manage` verb on both the existing and proposed context entity.",
 		"tags": ["PermissionGrants"],
 		"security": [
 			{
@@ -129,7 +129,7 @@
 	"delete": {
 		"operationId": "deletePermissionGrantById",
 		"summary": "Deletes a specific permission grant.",
-		"description": "Deletes a permission grant by ID. Requires administrator role.",
+		"description": "Deletes a permission grant by ID. Requires the `manage` verb on the grant's context entity.",
 		"tags": ["PermissionGrants"],
 		"security": [
 			{

--- a/src/openapi/paths/permissionGrants.json
+++ b/src/openapi/paths/permissionGrants.json
@@ -2,7 +2,7 @@
 	"get": {
 		"operationId": "getPermissionGrants",
 		"summary": "Gets a list of permission grants.",
-		"description": "Returns all permission grants. Requires administrator role.",
+		"description": "Returns permission grants whose context entity the authenticated user holds the `manage` verb on.",
 		"tags": ["PermissionGrants"],
 		"security": [
 			{
@@ -43,7 +43,7 @@
 	"post": {
 		"operationId": "createPermissionGrant",
 		"summary": "Creates a new permission grant.",
-		"description": "Creates a permission grant for a user or user group. Requires administrator role.",
+		"description": "Creates a permission grant for a user or user group. Requires the `manage` verb on the grant's context entity.",
 		"tags": ["PermissionGrants"],
 		"security": [
 			{

--- a/src/routers/permissionGrantsRouter.ts
+++ b/src/routers/permissionGrantsRouter.ts
@@ -1,41 +1,36 @@
 import express from 'express';
 import { permissionGrantsHandlers } from '../handlers/permissionGrantsHandlers';
-import { requireAdministratorRole, requireAuthentication } from '../middleware';
+import { requireAuthentication } from '../middleware';
 
 const permissionGrantsRouter = express.Router();
 
 permissionGrantsRouter.get(
 	'/',
 	requireAuthentication,
-	requireAdministratorRole,
 	permissionGrantsHandlers.getPermissionGrants,
 );
 
 permissionGrantsRouter.post(
 	'/',
 	requireAuthentication,
-	requireAdministratorRole,
 	permissionGrantsHandlers.postPermissionGrant,
 );
 
 permissionGrantsRouter.get(
 	'/:permissionGrantId',
 	requireAuthentication,
-	requireAdministratorRole,
 	permissionGrantsHandlers.getPermissionGrant,
 );
 
 permissionGrantsRouter.put(
 	'/:permissionGrantId',
 	requireAuthentication,
-	requireAdministratorRole,
 	permissionGrantsHandlers.putPermissionGrant,
 );
 
 permissionGrantsRouter.delete(
 	'/:permissionGrantId',
 	requireAuthentication,
-	requireAdministratorRole,
 	permissionGrantsHandlers.deletePermissionGrant,
 );
 

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -887,7 +887,7 @@ describe('processBulkUploadTask', () => {
 
 		const grantBundle = await loadPermissionGrantBundle(
 			db,
-			systemUserAuthContext,
+			getAuthContext(systemUser, true),
 			NO_LIMIT,
 			NO_OFFSET,
 		);

--- a/src/types/PermissionGrant.ts
+++ b/src/types/PermissionGrant.ts
@@ -243,10 +243,12 @@ type PermissionGrantContextEntityKeyVariant<
 		}
 	: { contextEntityType: C };
 
+type PermissionGrantContextEntity = {
+	[C in PermissionGrantEntityType]: PermissionGrantContextEntityKeyVariant<C>;
+}[PermissionGrantEntityType];
+
 type PermissionGrant = UnkeyedPermissionGrant &
-	{
-		[C in PermissionGrantEntityType]: PermissionGrantContextEntityKeyVariant<C>;
-	}[PermissionGrantEntityType] &
+	PermissionGrantContextEntity &
 	{
 		[G in PermissionGrantGranteeType]: PermissionGrantGranteeKeyVariant<G>;
 	}[PermissionGrantGranteeType];
@@ -481,6 +483,7 @@ export {
 	PermissionGrantGranteeType,
 	type PermissionGrant,
 	type PermissionGrantCondition,
+	type PermissionGrantContextEntity,
 	type PermissionGrantEntityKeyValueType,
 	type PermissionGrantKeyedContextEntityType,
 	type WritablePermissionGrant,


### PR DESCRIPTION
This PR removes the `admin`-only authorization check on the various `/permissionGrants` endpoints.  Now non-admin users with `MANAGE` permissions can interact with grants for various entities.

Resolves #2316 