### PR TITLE
Add permissions to `/sources` endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - All ID fields in the OpenAPI specification now reference a shared `id` schema with constraints (minimum: 1, maximum: 2147483647) instead of using bare `integer` types.
+- `GET /sources` and `GET /sources/:sourceId` now filter results by `view | source` permission; sources are no longer universally visible to authenticated users.
+- Source creation now requires `create | source` scope (previously required `edit | funder`, `edit | changemaker`, or `edit | dataProvider`). Existing permission grants with the parent entity's scope have been migrated to also include `source` scope, and new `create | source` grants have been created for users who previously had `edit` verb on the parent entity.
+- `POST /proposalVersions`, `POST /tasks/bulkUploads`, and `POST /changemakerFieldValueBatches` now require a `reference | source` grant on the supplied source. Grants can be made directly on the source or inherited from the source's funder, changemaker, or data provider. This is a breaking change: previous behavior allowed any authenticated user to supply any source, so existing users will need new `reference | source` grants before they can use these endpoints.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add extension support in phone number validation.
 - Add changelog to documents that auto-publish to WordPress.
 - `GET /funders` now supports the `isCollaborative` query parameter to filter funders by their collaborative status.
+- Added a new `reference` verb to the permission grant verb set. Reference is intended to gate whether a user may cite an entity as a pointer in data they are creating, separate from `view` (which only grants read access) and `create` (which grants the ability to author new instances of an entity type).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.34.0 2026-04-23
+
 ### Added
 
 - Add extension support in phone number validation.

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -242,8 +242,9 @@ context key).
 |        |                    | Create bulk upload tasks for the funder's opportunities           |
 | edit   | opportunity        | Create or update application forms and fields for the funder      |
 | edit   | funder             | Create or update changemaker-proposal associations                |
-|        |                    | Create sources associated with the funder                         |
 | edit   | proposal           | Create or update proposal versions for the funder's proposals     |
+| view   | source             | View the funder's sources                                         |
+| create | source             | Create sources associated with the funder                         |
 | manage | funder             | View, send, and respond to funder collaborative invitations       |
 |        |                    | View collaborative members for the funder                         |
 
@@ -252,16 +253,17 @@ context key).
 Permissions granted against a changemaker (using the changemaker's `id` as the
 context key).
 
-| Verb | Scope              | What It Enables                                                    |
-| ---- | ------------------ | ------------------------------------------------------------------ |
-| view | changemaker        | View changemaker field values for the changemaker                  |
-| view | proposal           | View proposals associated with the changemaker                     |
-|      |                    | View proposal versions associated with the changemaker             |
-|      |                    | View changemaker-proposal associations for the changemaker         |
-| view | proposalFieldValue | View proposal field values for the changemaker's proposals         |
-| edit | changemaker        | Create or update changemaker field values                          |
-|      |                    | Create sources associated with the changemaker                     |
-| edit | proposal           | Create or update proposal versions for the changemaker's proposals |
+| Verb   | Scope              | What It Enables                                                    |
+| ------ | ------------------ | ------------------------------------------------------------------ |
+| view   | changemaker        | View changemaker field values for the changemaker                  |
+| view   | proposal           | View proposals associated with the changemaker                     |
+|        |                    | View proposal versions associated with the changemaker             |
+|        |                    | View changemaker-proposal associations for the changemaker         |
+| view   | proposalFieldValue | View proposal field values for the changemaker's proposals         |
+| edit   | changemaker        | Create or update changemaker field values                          |
+| edit   | proposal           | Create or update proposal versions for the changemaker's proposals |
+| view   | source             | View the changemaker's sources                                     |
+| create | source             | Create sources associated with the changemaker                     |
 
 ### Opportunity Permissions
 
@@ -324,9 +326,28 @@ can still view proposals but will see empty `fieldValues` arrays.
 Permissions granted against a data provider (using the data provider's
 `shortCode` as the context key).
 
-| Verb | Scope         | What It Enables                                  |
-| ---- | ------------- | ------------------------------------------------ |
-| edit | data_provider | Create sources associated with the data provider |
+| Verb   | Scope  | What It Enables                                  |
+| ------ | ------ | ------------------------------------------------ |
+| view   | source | View the data provider's sources                 |
+| create | source | Create sources associated with the data provider |
+
+### Source Permissions
+
+Permissions granted directly against a source (using the source's `id` as the
+context key). Source permissions inherit from the source's parent entity, so a
+`view | source` or `reference | source` grant on the source's funder,
+changemaker, or data provider automatically applies to all of that parent's
+sources. Source-level grants provide more granular control for specific
+sources.
+
+| Verb      | Scope  | What It Enables                                                                    |
+| --------- | ------ | ---------------------------------------------------------------------------------- |
+| view      | source | View the specific source                                                           |
+| reference | source | Cite the source when creating proposal versions, bulk upload tasks, or CFV batches |
+
+The `reference | source` check is applied when a source is provided as an
+attribute of data being created — currently when posting to
+`/proposalVersions`, `/tasks/bulkUploads`, or `/changemakerFieldValueBatches`.
 
 ### Conditional Permissions
 
@@ -376,8 +397,8 @@ included in the scope.
 ### Other Contexts
 
 The permission system data model includes additional contexts (`proposalVersion`,
-`applicationForm`, `applicationFormField`, `proposalFieldValue`, `source`,
-`bulkUpload`, `changemakerFieldValue`) that can have permission grants created.
-However, these contexts do not currently have permission checks enforced in the
+`applicationForm`, `applicationFormField`, `proposalFieldValue`, `bulkUpload`,
+`changemakerFieldValue`) that can have permission grants created. However,
+these contexts do not currently have permission checks enforced in the
 codebase. Access to these entities is controlled through the parent entity
 permissions described above (funder, changemaker, opportunity, or proposal).

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -176,17 +176,23 @@ The PDC permission system uses four concepts:
 
 The permission system supports the following verbs:
 
-| Verb   | Description                                       |
-| ------ | ------------------------------------------------- |
-| view   | Read access to data                               |
-| create | Create new data                                   |
-| edit   | Modify existing data                              |
-| delete | Delete data                                       |
-| manage | Manage permission grants associated with the data |
+| Verb      | Description                                         |
+| --------- | --------------------------------------------------- |
+| view      | Read access to data                                 |
+| create    | Create new data                                     |
+| edit      | Modify existing data                                |
+| delete    | Delete data                                         |
+| manage    | Manage permission grants associated with the data   |
+| reference | Use an entity as a pointer in data you are creating |
 
 Note: The current implementation uses `edit` for both creation and modification
 operations in most contexts. This is a known semantic mismatch with the intended
 meaning of the verb.
+
+The `reference` verb is separate from `view` and `create` so that permission to
+see an entity does not automatically imply permission to cite it from elsewhere,
+and permission to create entities in one context does not automatically imply
+permission to tag that creation with arbitrary related entities.
 
 For example, "User X can view proposals of changemaker foo" breaks down as:
 

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -5,12 +5,14 @@ import {
 	createApplicationForm,
 	createBulkUploadTask,
 	createOrUpdateUser,
+	createSource,
 	loadSystemSource,
 	loadSystemUser,
 	loadTableMetrics,
 	createPermissionGrant,
 } from '../database';
 import {
+	createTestDataProvider,
 	createTestFile,
 	createTestFunder,
 	createTestOpportunity,
@@ -431,6 +433,14 @@ describe('/tasks/bulkUploads', () => {
 				scope: [PermissionGrantEntityType.PROPOSAL],
 				verbs: [PermissionGrantVerb.CREATE],
 			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: systemSource.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.REFERENCE],
+			});
 			const proposalsDataFile = await createTestFile(db, testUserAuthContext);
 
 			const opportunity = await createTestOpportunity(
@@ -510,6 +520,14 @@ describe('/tasks/bulkUploads', () => {
 				scope: [PermissionGrantEntityType.PROPOSAL],
 				verbs: [PermissionGrantVerb.CREATE],
 			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: systemSource.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.REFERENCE],
+			});
 			const proposalsDataFile = await createTestFile(db, testUserAuthContext);
 			const attachmentsArchiveFile = await createTestFile(
 				db,
@@ -566,6 +584,144 @@ describe('/tasks/bulkUploads', () => {
 				logs: [],
 			});
 			expect(after.count).toEqual(1);
+		});
+
+		it('returns 422 unprocessable entity when the user lacks reference permission on the source', async () => {
+			const db = getDatabase();
+			const systemSource = await loadSystemSource(db, null);
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: testFunder.shortCode,
+				scope: [PermissionGrantEntityType.OPPORTUNITY],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: testFunder.shortCode,
+				scope: [PermissionGrantEntityType.PROPOSAL],
+				verbs: [PermissionGrantVerb.CREATE],
+			});
+			const proposalsDataFile = await createTestFile(db, testUserAuthContext);
+
+			const opportunity = await createTestOpportunity(
+				db,
+				systemUserAuthContext,
+				{
+					funderShortCode: testFunder.shortCode,
+				},
+			);
+			const applicationForm = await createApplicationForm(
+				db,
+				systemUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
+
+			const testData: WritableBulkUploadTask = {
+				sourceId: systemSource.id,
+				applicationFormId: applicationForm.id,
+				proposalsDataFileId: proposalsDataFile.id,
+				attachmentsArchiveFileId: null,
+			};
+			const before = await loadTableMetrics(db, 'bulk_upload_tasks');
+			const result = await request(app)
+				.post('/tasks/bulkUploads/')
+				.type('application/json')
+				.set(authHeader)
+				.send(testData)
+				.expect(422);
+			const after = await loadTableMetrics(db, 'bulk_upload_tasks');
+
+			expect(before.count).toEqual(0);
+			expect(result.body).toEqual({
+				details: [{ name: 'UnprocessableEntityError' }],
+				message:
+					'You do not have permission to reference the specified source.',
+				name: 'UnprocessableEntityError',
+			});
+			expect(after.count).toEqual(0);
+		});
+
+		it('allows creation when reference permission on the source is inherited from the source data provider', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
+			const dataProvider = await createTestDataProvider(
+				db,
+				systemUserAuthContext,
+			);
+			const dataProviderSource = await createSource(db, systemUserAuthContext, {
+				label: 'Provider-owned Source',
+				dataProviderShortCode: dataProvider.shortCode,
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: testFunder.shortCode,
+				scope: [PermissionGrantEntityType.OPPORTUNITY],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: testFunder.shortCode,
+				scope: [PermissionGrantEntityType.PROPOSAL],
+				verbs: [PermissionGrantVerb.CREATE],
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
+				dataProviderShortCode: dataProvider.shortCode,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.REFERENCE],
+			});
+			const proposalsDataFile = await createTestFile(db, testUserAuthContext);
+
+			const opportunity = await createTestOpportunity(
+				db,
+				systemUserAuthContext,
+				{
+					funderShortCode: testFunder.shortCode,
+				},
+			);
+			const applicationForm = await createApplicationForm(
+				db,
+				systemUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
+
+			const testData: WritableBulkUploadTask = {
+				sourceId: dataProviderSource.id,
+				applicationFormId: applicationForm.id,
+				proposalsDataFileId: proposalsDataFile.id,
+				attachmentsArchiveFileId: null,
+			};
+			await request(app)
+				.post('/tasks/bulkUploads/')
+				.type('application/json')
+				.set(authHeader)
+				.send(testData)
+				.expect(201);
 		});
 
 		it('returns 422 unprocessable entity when the user does not have create proposal permission for the associated opportunity', async () => {
@@ -761,6 +917,14 @@ describe('/tasks/bulkUploads', () => {
 				scope: [PermissionGrantEntityType.PROPOSAL],
 				verbs: [PermissionGrantVerb.CREATE],
 			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: systemSource.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.REFERENCE],
+			});
 
 			const fileOwnedByAnotherUser = await createTestFile(
 				db,
@@ -836,6 +1000,14 @@ describe('/tasks/bulkUploads', () => {
 				funderShortCode: testFunder.shortCode,
 				scope: [PermissionGrantEntityType.PROPOSAL],
 				verbs: [PermissionGrantVerb.CREATE],
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: systemSource.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.REFERENCE],
 			});
 			const proposalsDataFile = await createTestFile(db, testUserAuthContext);
 			const attachmentsArchiveFileOwnedByAnotherUser = await createTestFile(

--- a/src/__tests__/changemakerFieldValueBatches.int.test.ts
+++ b/src/__tests__/changemakerFieldValueBatches.int.test.ts
@@ -4,7 +4,9 @@ import {
 	getDatabase,
 	createChangemakerFieldValueBatch,
 	createOrUpdateUser,
+	createPermissionGrant,
 	createSource,
+	loadSystemUser,
 } from '../database';
 import { expectNumber, expectTimestamp } from '../test/asymettricMatchers';
 import { createTestChangemaker } from '../test/factories';
@@ -13,10 +15,17 @@ import {
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
 } from '../test/mockJwt';
 import { getAuthContext, loadTestUser } from '../test/utils';
+import {
+	PermissionGrantEntityType,
+	PermissionGrantGranteeType,
+	PermissionGrantVerb,
+} from '../types';
 
 describe('POST /changemakerFieldValueBatches', () => {
 	it('Successfully creates a changemaker field value batch', async () => {
 		const db = getDatabase();
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 		const changemaker = await createTestChangemaker(db, testUserAuthContext);
@@ -24,6 +33,14 @@ describe('POST /changemakerFieldValueBatches', () => {
 		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
+		});
+		await createPermissionGrant(db, systemUserAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.SOURCE,
+			sourceId: source.id,
+			scope: [PermissionGrantEntityType.SOURCE],
+			verbs: [PermissionGrantVerb.REFERENCE],
 		});
 
 		const result = await request(app)
@@ -50,6 +67,8 @@ describe('POST /changemakerFieldValueBatches', () => {
 
 	it('Accepts null for notes', async () => {
 		const db = getDatabase();
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 		const changemaker = await createTestChangemaker(db, testUserAuthContext);
@@ -57,6 +76,14 @@ describe('POST /changemakerFieldValueBatches', () => {
 		const source = await createSource(db, testUserAuthContext, {
 			label: 'Test Source',
 			changemakerId: changemaker.id,
+		});
+		await createPermissionGrant(db, systemUserAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.SOURCE,
+			sourceId: source.id,
+			scope: [PermissionGrantEntityType.SOURCE],
+			verbs: [PermissionGrantVerb.REFERENCE],
 		});
 
 		const result = await request(app)
@@ -120,7 +147,69 @@ describe('POST /changemakerFieldValueBatches', () => {
 			.expect(401);
 	});
 
-	it('Returns 409 when source does not exist', async () => {
+	it('Returns 422 when the user lacks reference permission on the source', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
+
+		const source = await createSource(db, testUserAuthContext, {
+			label: 'Test Source',
+			changemakerId: changemaker.id,
+		});
+
+		const result = await request(app)
+			.post('/changemakerFieldValueBatches')
+			.type('application/json')
+			.set(authHeader)
+			.send({
+				sourceId: source.id,
+				notes: 'Test notes',
+			})
+			.expect(422);
+
+		expect(result.body).toMatchObject({
+			name: 'UnprocessableEntityError',
+		});
+	});
+
+	it('Allows creation when reference permission is inherited from the source changemaker', async () => {
+		const db = getDatabase();
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
+
+		const source = await createSource(db, testUserAuthContext, {
+			label: 'Test Source',
+			changemakerId: changemaker.id,
+		});
+		await createPermissionGrant(db, systemUserAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+			changemakerId: changemaker.id,
+			scope: [PermissionGrantEntityType.SOURCE],
+			verbs: [PermissionGrantVerb.REFERENCE],
+		});
+
+		const result = await request(app)
+			.post('/changemakerFieldValueBatches')
+			.type('application/json')
+			.set(authHeader)
+			.send({
+				sourceId: source.id,
+				notes: 'Test notes',
+			})
+			.expect(201);
+
+		expect(result.body).toMatchObject({
+			sourceId: source.id,
+		});
+	});
+
+	it('Returns 422 when source does not exist', async () => {
 		const result = await request(app)
 			.post('/changemakerFieldValueBatches')
 			.type('application/json')
@@ -129,11 +218,10 @@ describe('POST /changemakerFieldValueBatches', () => {
 				sourceId: 999999,
 				notes: 'Test notes',
 			})
-			.expect(409);
+			.expect(422);
 
 		expect(result.body).toMatchObject({
-			name: 'InputConflictError',
-			message: 'The source does not exist.',
+			name: 'UnprocessableEntityError',
 		});
 	});
 });

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -8,6 +8,7 @@ import {
 	createOrUpdateBaseField,
 	createProposal,
 	createProposalVersion,
+	createSource,
 	loadSystemFunder,
 	loadSystemSource,
 	loadTableMetrics,
@@ -326,6 +327,14 @@ describe('/proposalVersions', () => {
 				],
 				verbs: [PermissionGrantVerb.VIEW, PermissionGrantVerb.EDIT],
 			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: systemSource.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.REFERENCE],
+			});
 			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});
@@ -431,6 +440,14 @@ describe('/proposalVersions', () => {
 				],
 				verbs: [PermissionGrantVerb.VIEW, PermissionGrantVerb.EDIT],
 			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: systemSource.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.REFERENCE],
+			});
 			const proposal = await createProposal(db, testUserAuthContext, {
 				externalId: 'proposal-1',
 				opportunityId: opportunity.id,
@@ -457,6 +474,103 @@ describe('/proposalVersions', () => {
 				fieldValues: [],
 			});
 			expect(after.count).toEqual(before.count + 1);
+		});
+
+		it('returns 422 when the user lacks reference permission on the source', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const systemSource = await loadSystemSource(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.OPPORTUNITY,
+				opportunityId: opportunity.id,
+				scope: [
+					PermissionGrantEntityType.OPPORTUNITY,
+					PermissionGrantEntityType.PROPOSAL,
+				],
+				verbs: [PermissionGrantVerb.VIEW, PermissionGrantVerb.EDIT],
+			});
+			const proposal = await createProposal(db, testUserAuthContext, {
+				externalId: 'proposal-1',
+				opportunityId: opportunity.id,
+			});
+			const applicationForm = await createApplicationForm(db, null, {
+				opportunityId: opportunity.id,
+				name: null,
+			});
+			const result = await request(app)
+				.post('/proposalVersions')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					proposalId: proposal.id,
+					applicationFormId: applicationForm.id,
+					sourceId: systemSource.id,
+					fieldValues: [],
+				})
+				.expect(422);
+			expect(result.body).toMatchObject({
+				name: 'UnprocessableEntityError',
+				message:
+					'You do not have permission to reference the specified source.',
+			});
+		});
+
+		it('allows creation when reference permission on the source is inherited from the source funder', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const sourceFunder = await createTestFunder(db, systemUserAuthContext);
+			const funderSource = await createSource(db, systemUserAuthContext, {
+				label: 'Funder-owned Source',
+				funderShortCode: sourceFunder.shortCode,
+			});
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.OPPORTUNITY,
+				opportunityId: opportunity.id,
+				scope: [
+					PermissionGrantEntityType.OPPORTUNITY,
+					PermissionGrantEntityType.PROPOSAL,
+				],
+				verbs: [PermissionGrantVerb.VIEW, PermissionGrantVerb.EDIT],
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: sourceFunder.shortCode,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.REFERENCE],
+			});
+			const proposal = await createProposal(db, testUserAuthContext, {
+				externalId: 'proposal-1',
+				opportunityId: opportunity.id,
+			});
+			const applicationForm = await createApplicationForm(db, null, {
+				opportunityId: opportunity.id,
+				name: null,
+			});
+			await request(app)
+				.post('/proposalVersions')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					proposalId: proposal.id,
+					applicationFormId: applicationForm.id,
+					sourceId: funderSource.id,
+					fieldValues: [],
+				})
+				.expect(201);
 		});
 
 		it('creates exactly the number of provided field values', async () => {

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -39,19 +39,7 @@ describe('/sources', () => {
 			await agent.get('/sources').expect(401);
 		});
 
-		it('returns the system source when no data has been added', async () => {
-			const db = getDatabase();
-			const systemSource = await loadSystemSource(db, null);
-			await agent
-				.get('/sources')
-				.set(authHeader)
-				.expect(200, {
-					entries: [systemSource],
-					total: 1,
-				});
-		});
-
-		it('returns all sources present in the database', async () => {
+		it('returns all sources for an administrator', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
@@ -61,10 +49,167 @@ describe('/sources', () => {
 				label: 'Example Inc.',
 				changemakerId: changemaker.id,
 			});
-			const response = await agent.get('/sources').set(authHeader).expect(200);
+			const response = await agent
+				.get('/sources')
+				.set(adminUserAuthHeader)
+				.expect(200);
 			expect(response.body).toEqual({
 				entries: [source, systemSource],
 				total: 2,
+			});
+		});
+
+		it('returns no sources when the user has no view permission on any source', async () => {
+			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			await createSource(db, testUserAuthContext, {
+				label: 'Example Inc.',
+				changemakerId: changemaker.id,
+			});
+			await agent.get('/sources').set(authHeader).expect(200, {
+				entries: [],
+				total: 0,
+			});
+		});
+
+		it('returns only sources the user has view permission on via a direct grant', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			const visibleSource = await createSource(db, testUserAuthContext, {
+				label: 'Visible Inc.',
+				changemakerId: changemaker.id,
+			});
+			await createSource(db, testUserAuthContext, {
+				label: 'Hidden Inc.',
+				changemakerId: changemaker.id,
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: visibleSource.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+
+			const response = await agent.get('/sources').set(authHeader).expect(200);
+			expect(response.body).toEqual({
+				entries: [visibleSource],
+				total: 1,
+			});
+		});
+
+		it('returns sources the user has view permission on via an inherited changemaker grant', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleChangemaker = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+			);
+			const hiddenChangemaker = await createTestChangemaker(
+				db,
+				testUserAuthContext,
+			);
+			const visibleSource = await createSource(db, testUserAuthContext, {
+				label: 'Visible Inc.',
+				changemakerId: visibleChangemaker.id,
+			});
+			await createSource(db, testUserAuthContext, {
+				label: 'Hidden Inc.',
+				changemakerId: hiddenChangemaker.id,
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: visibleChangemaker.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+
+			const response = await agent.get('/sources').set(authHeader).expect(200);
+			expect(response.body).toEqual({
+				entries: [visibleSource],
+				total: 1,
+			});
+		});
+
+		it('returns sources the user has view permission on via an inherited funder grant', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleFunder = await createTestFunder(db, testUserAuthContext);
+			const hiddenFunder = await createTestFunder(db, testUserAuthContext);
+			const visibleSource = await createSource(db, testUserAuthContext, {
+				label: 'Visible Inc.',
+				funderShortCode: visibleFunder.shortCode,
+			});
+			await createSource(db, testUserAuthContext, {
+				label: 'Hidden Inc.',
+				funderShortCode: hiddenFunder.shortCode,
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: visibleFunder.shortCode,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+
+			const response = await agent.get('/sources').set(authHeader).expect(200);
+			expect(response.body).toEqual({
+				entries: [visibleSource],
+				total: 1,
+			});
+		});
+
+		it('returns sources the user has view permission on via an inherited data provider grant', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const visibleDataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
+			const hiddenDataProvider = await createTestDataProvider(
+				db,
+				testUserAuthContext,
+			);
+			const visibleSource = await createSource(db, testUserAuthContext, {
+				label: 'Visible Inc.',
+				dataProviderShortCode: visibleDataProvider.shortCode,
+			});
+			await createSource(db, testUserAuthContext, {
+				label: 'Hidden Inc.',
+				dataProviderShortCode: hiddenDataProvider.shortCode,
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
+				dataProviderShortCode: visibleDataProvider.shortCode,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+
+			const response = await agent.get('/sources').set(authHeader).expect(200);
+			expect(response.body).toEqual({
+				entries: [visibleSource],
+				total: 1,
 			});
 		});
 	});
@@ -74,7 +219,7 @@ describe('/sources', () => {
 			await agent.get('/sources/1').expect(401);
 		});
 
-		it('returns exactly one source selected by id', async () => {
+		it('returns the source to an administrator', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
@@ -82,6 +227,60 @@ describe('/sources', () => {
 			const source = await createSource(db, testUserAuthContext, {
 				label: 'Example Inc.',
 				changemakerId: changemaker.id,
+			});
+
+			const response = await agent
+				.get(`/sources/${source.id}`)
+				.set(adminUserAuthHeader)
+				.expect(200);
+			expect(response.body).toEqual(source);
+		});
+
+		it('returns the source to a user with a direct view grant', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			const source = await createSource(db, testUserAuthContext, {
+				label: 'Example Inc.',
+				changemakerId: changemaker.id,
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: source.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+
+			const response = await agent
+				.get(`/sources/${source.id}`)
+				.set(authHeader)
+				.expect(200);
+			expect(response.body).toEqual(source);
+		});
+
+		it('returns the source to a user with an inherited changemaker view grant', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			const source = await createSource(db, testUserAuthContext, {
+				label: 'Example Inc.',
+				changemakerId: changemaker.id,
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.VIEW],
 			});
 
 			const response = await agent
@@ -111,15 +310,19 @@ describe('/sources', () => {
 		});
 
 		it('returns 404 when id is not found', async () => {
+			await agent.get('/sources/9001').set(adminUserAuthHeader).expect(404);
+		});
+
+		it('returns 404 when the user does not have view permission on the source', async () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			await createSource(db, testUserAuthContext, {
-				label: 'not to be returned',
+			const source = await createSource(db, testUserAuthContext, {
+				label: 'Example Inc.',
 				changemakerId: changemaker.id,
 			});
-			await agent.get('/sources/9001').set(authHeader).expect(404);
+			await agent.get(`/sources/${source.id}`).set(authHeader).expect(404);
 		});
 	});
 
@@ -250,7 +453,7 @@ describe('/sources', () => {
 			});
 		});
 
-		it('creates and returns exactly one changemaker source for a user with edit permissions on that changemaker', async () => {
+		it('creates and returns exactly one changemaker source for a user with create source permissions on that changemaker', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
@@ -262,8 +465,8 @@ describe('/sources', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
 				changemakerId: changemaker.id,
-				scope: [PermissionGrantEntityType.CHANGEMAKER],
-				verbs: [PermissionGrantVerb.EDIT],
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.CREATE],
 			});
 			const before = await loadTableMetrics(db, 'sources');
 			const result = await agent
@@ -294,7 +497,7 @@ describe('/sources', () => {
 			expect(after.count).toEqual(before.count + 1);
 		});
 
-		it('returns 422 if the user does not have edit permission on the changemaker', async () => {
+		it('returns 422 if the user does not have create source permission on the changemaker', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
@@ -306,8 +509,8 @@ describe('/sources', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
 				changemakerId: changemaker.id,
-				scope: [PermissionGrantEntityType.CHANGEMAKER],
-				verbs: [PermissionGrantVerb.MANAGE],
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.MANAGE, PermissionGrantVerb.VIEW],
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
@@ -315,10 +518,10 @@ describe('/sources', () => {
 				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
 				changemakerId: changemaker.id,
 				scope: [PermissionGrantEntityType.CHANGEMAKER],
-				verbs: [PermissionGrantVerb.VIEW],
+				verbs: [PermissionGrantVerb.CREATE],
 			});
 
-			// Also create a userGroup permission grant with EDIT verb but an EXPIRED association
+			// Also create a userGroup permission grant with CREATE|source but an EXPIRED association
 			// to verify that expired associations don't grant access
 			const expiredOrgId = 'eeeeeeee-1111-2222-3333-444444444444';
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -326,8 +529,8 @@ describe('/sources', () => {
 				granteeKeycloakOrganizationId: stringToKeycloakId(expiredOrgId),
 				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
 				changemakerId: changemaker.id,
-				scope: [PermissionGrantEntityType.CHANGEMAKER],
-				verbs: [PermissionGrantVerb.EDIT],
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.CREATE],
 			});
 			await createEphemeralUserGroupAssociation(db, null, {
 				userKeycloakUserId: testUser.keycloakUserId,
@@ -349,7 +552,7 @@ describe('/sources', () => {
 			expect(result.body).toEqual({
 				details: [{ name: 'UnprocessableEntityError' }],
 				message:
-					'You do not have write permissions on a changemaker with the specified id.',
+					'You do not have permission to create a source for the specified changemaker.',
 				name: 'UnprocessableEntityError',
 			});
 			expect(after.count).toEqual(before.count);
@@ -383,7 +586,7 @@ describe('/sources', () => {
 			expect(after.count).toEqual(2);
 		});
 
-		it('creates and returns exactly one funder source for a user with edit permissions on that funder', async () => {
+		it('creates and returns exactly one funder source for a user with create source permissions on that funder', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
@@ -395,8 +598,8 @@ describe('/sources', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: funder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
-				verbs: [PermissionGrantVerb.EDIT],
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.CREATE],
 			});
 			const before = await loadTableMetrics(db, 'sources');
 			const result = await agent
@@ -420,7 +623,7 @@ describe('/sources', () => {
 			expect(after.count).toEqual(before.count + 1);
 		});
 
-		it('returns 422 if the user does not have edit permission on the funder', async () => {
+		it('returns 422 if the user does not have create source permission on the funder', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
@@ -432,8 +635,8 @@ describe('/sources', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: funder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
-				verbs: [PermissionGrantVerb.MANAGE],
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.MANAGE, PermissionGrantVerb.VIEW],
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
@@ -441,10 +644,10 @@ describe('/sources', () => {
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: funder.shortCode,
 				scope: [PermissionGrantEntityType.FUNDER],
-				verbs: [PermissionGrantVerb.VIEW],
+				verbs: [PermissionGrantVerb.CREATE],
 			});
 
-			// Also create a userGroup permission grant with EDIT verb but an EXPIRED association
+			// Also create a userGroup permission grant with CREATE|source but an EXPIRED association
 			// to verify that expired associations don't grant access
 			const expiredOrgId = 'ffffffff-1111-2222-3333-444444444444';
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -452,8 +655,8 @@ describe('/sources', () => {
 				granteeKeycloakOrganizationId: stringToKeycloakId(expiredOrgId),
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: funder.shortCode,
-				scope: [PermissionGrantEntityType.FUNDER],
-				verbs: [PermissionGrantVerb.EDIT],
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.CREATE],
 			});
 			await createEphemeralUserGroupAssociation(db, null, {
 				userKeycloakUserId: testUser.keycloakUserId,
@@ -475,7 +678,7 @@ describe('/sources', () => {
 			expect(result.body).toEqual({
 				details: [{ name: 'UnprocessableEntityError' }],
 				message:
-					'You do not have write permissions on a funder with the specified short code.',
+					'You do not have permission to create a source for the specified funder.',
 				name: 'UnprocessableEntityError',
 			});
 			expect(after.count).toEqual(before.count);
@@ -512,7 +715,7 @@ describe('/sources', () => {
 			expect(after.count).toEqual(2);
 		});
 
-		it('creates and returns exactly one data provider source for a user with edit permissions on the data provider', async () => {
+		it('creates and returns exactly one data provider source for a user with create source permissions on the data provider', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
@@ -527,8 +730,8 @@ describe('/sources', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
 				dataProviderShortCode: dataProvider.shortCode,
-				scope: [PermissionGrantEntityType.DATA_PROVIDER],
-				verbs: [PermissionGrantVerb.EDIT],
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.CREATE],
 			});
 			const before = await loadTableMetrics(db, 'sources');
 			const result = await agent
@@ -552,7 +755,7 @@ describe('/sources', () => {
 			expect(after.count).toEqual(before.count + 1);
 		});
 
-		it('returns 422 if the user does not have edit permission on the data provider', async () => {
+		it('returns 422 if the user does not have create source permission on the data provider', async () => {
 			const db = getDatabase();
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
@@ -567,11 +770,11 @@ describe('/sources', () => {
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
 				dataProviderShortCode: dataProvider.shortCode,
-				scope: [PermissionGrantEntityType.DATA_PROVIDER],
+				scope: [PermissionGrantEntityType.SOURCE],
 				verbs: [PermissionGrantVerb.MANAGE, PermissionGrantVerb.VIEW],
 			});
 
-			// Also create a userGroup permission grant with EDIT verb but an EXPIRED association
+			// Also create a userGroup permission grant with CREATE|source but an EXPIRED association
 			// to verify that expired associations don't grant access
 			const expiredOrgId = '11111111-aaaa-bbbb-cccc-dddddddddddd';
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -579,8 +782,8 @@ describe('/sources', () => {
 				granteeKeycloakOrganizationId: stringToKeycloakId(expiredOrgId),
 				contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
 				dataProviderShortCode: dataProvider.shortCode,
-				scope: [PermissionGrantEntityType.DATA_PROVIDER],
-				verbs: [PermissionGrantVerb.EDIT],
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.CREATE],
 			});
 			await createEphemeralUserGroupAssociation(db, null, {
 				userKeycloakUserId: testUser.keycloakUserId,
@@ -602,7 +805,7 @@ describe('/sources', () => {
 			expect(result.body).toEqual({
 				details: [{ name: 'UnprocessableEntityError' }],
 				message:
-					'You do not have write permissions on a data provider with the specified short code.',
+					'You do not have permission to create a source for the specified data provider.',
 				name: 'UnprocessableEntityError',
 			});
 			expect(after.count).toEqual(before.count);

--- a/src/database/initialization/has_source_permission.sql
+++ b/src/database/initialization/has_source_permission.sql
@@ -1,0 +1,71 @@
+CREATE OR REPLACE FUNCTION has_source_permission(
+	user_keycloak_user_id uuid,
+	user_is_admin boolean,
+	source_id int,
+	permission permission_grant_verb_t,
+	scope permission_grant_entity_type_t
+) RETURNS boolean AS $$
+DECLARE
+	has_permission boolean;
+BEGIN
+	-- If the user is an administrator, they have all permissions
+	IF user_is_admin THEN
+		RETURN TRUE;
+	END IF;
+
+	-- Check if the user has the specified permission on the specified source
+	-- via direct user grant, group membership, or inherited from parent entities.
+	-- Inherited grants are treated the same as direct source grants: the grant's
+	-- scope array must include the requested scope.
+	SELECT EXISTS (
+		SELECT 1
+		FROM sources s
+		INNER JOIN permission_grants pg ON (
+			-- Direct source grant
+			(
+				pg.context_entity_type = 'source'
+				AND pg.source_id = s.id
+			)
+			-- Inherited from funder
+			OR (
+				pg.context_entity_type = 'funder'
+				AND pg.funder_short_code = s.funder_short_code
+			)
+			-- Inherited from data provider
+			OR (
+				pg.context_entity_type = 'dataProvider'
+				AND pg.data_provider_short_code = s.data_provider_short_code
+			)
+			-- Inherited from changemaker
+			OR (
+				pg.context_entity_type = 'changemaker'
+				AND pg.changemaker_id = s.changemaker_id
+			)
+		)
+		WHERE s.id = has_source_permission.source_id
+			AND has_source_permission.permission = ANY(pg.verbs)
+			AND has_source_permission.scope = ANY(pg.scope)
+			AND (
+				(
+					pg.grantee_type = 'user'
+					AND pg.grantee_user_keycloak_user_id
+						= has_source_permission.user_keycloak_user_id
+				)
+				OR (
+					pg.grantee_type = 'userGroup'
+					AND EXISTS (
+						SELECT 1
+						FROM ephemeral_user_group_associations euga
+						WHERE euga.user_keycloak_user_id
+							= has_source_permission.user_keycloak_user_id
+							AND euga.user_group_keycloak_organization_id
+								= pg.grantee_keycloak_organization_id
+							AND NOT is_expired(euga.not_after)
+					)
+				)
+			)
+	) INTO has_permission;
+
+	RETURN has_permission;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/database/migrations/0107-add-reference-to-permission_grant_verb_t.sql
+++ b/src/database/migrations/0107-add-reference-to-permission_grant_verb_t.sql
@@ -1,0 +1,1 @@
+ALTER TYPE permission_grant_verb_t ADD VALUE IF NOT EXISTS 'reference';

--- a/src/database/migrations/0108-add-source-scope-to-existing-permissions.sql
+++ b/src/database/migrations/0108-add-source-scope-to-existing-permissions.sql
@@ -1,0 +1,187 @@
+-- Add 'source' scope to existing permission grants that have the
+-- scope of their own context entity type. Previously sources were
+-- viewable by any authenticated user; this change preserves the
+-- ability to view sources for users who already have some level of
+-- access to the source's parent entity.
+
+UPDATE permission_grants
+SET scope = array_append(scope, 'source'::permission_grant_entity_type_t)
+WHERE
+	context_entity_type = 'funder'
+	AND 'funder' = any(scope)
+	AND NOT ('source' = any(scope));
+
+UPDATE permission_grants
+SET scope = array_append(scope, 'source'::permission_grant_entity_type_t)
+WHERE
+	context_entity_type = 'dataProvider'
+	AND 'dataProvider' = any(scope)
+	AND NOT ('source' = any(scope));
+
+UPDATE permission_grants
+SET scope = array_append(scope, 'source'::permission_grant_entity_type_t)
+WHERE
+	context_entity_type = 'changemaker'
+	AND 'changemaker' = any(scope)
+	AND NOT ('source' = any(scope));
+
+-- Source creation now requires 'create' verb with 'source' scope
+-- instead of 'edit' verb with the parent entity's scope. Create new
+-- grants so users who previously could create sources retain that
+-- ability.
+
+INSERT INTO permission_grants (
+	grantee_type,
+	grantee_user_keycloak_user_id,
+	grantee_keycloak_organization_id,
+	context_entity_type,
+	funder_short_code,
+	scope,
+	verbs,
+	created_by
+)
+SELECT DISTINCT ON (
+	pg.grantee_type,
+	pg.grantee_user_keycloak_user_id,
+	pg.grantee_keycloak_organization_id,
+	pg.funder_short_code
+)
+	pg.grantee_type,
+	pg.grantee_user_keycloak_user_id,
+	pg.grantee_keycloak_organization_id,
+	pg.context_entity_type,
+	pg.funder_short_code,
+	ARRAY['source']::permission_grant_entity_type_t [],
+	ARRAY['create']::permission_grant_verb_t [],
+	pg.created_by
+FROM permission_grants AS pg
+WHERE
+	pg.context_entity_type = 'funder'
+	AND 'edit' = any(pg.verbs)
+	AND 'funder' = any(pg.scope)
+	AND NOT EXISTS (
+		SELECT 1
+		FROM permission_grants AS pg2
+		WHERE
+			pg2.context_entity_type = 'funder'
+			AND pg2.funder_short_code = pg.funder_short_code
+			AND pg2.grantee_type = pg.grantee_type
+			AND (
+				(
+					pg2.grantee_type = 'user'
+					AND pg2.grantee_user_keycloak_user_id
+					= pg.grantee_user_keycloak_user_id
+				)
+				OR (
+					pg2.grantee_type = 'userGroup'
+					AND pg2.grantee_keycloak_organization_id
+					= pg.grantee_keycloak_organization_id
+				)
+			)
+			AND 'create' = any(pg2.verbs)
+			AND 'source' = any(pg2.scope)
+	);
+
+INSERT INTO permission_grants (
+	grantee_type,
+	grantee_user_keycloak_user_id,
+	grantee_keycloak_organization_id,
+	context_entity_type,
+	data_provider_short_code,
+	scope,
+	verbs,
+	created_by
+)
+SELECT DISTINCT ON (
+	pg.grantee_type,
+	pg.grantee_user_keycloak_user_id,
+	pg.grantee_keycloak_organization_id,
+	pg.data_provider_short_code
+)
+	pg.grantee_type,
+	pg.grantee_user_keycloak_user_id,
+	pg.grantee_keycloak_organization_id,
+	pg.context_entity_type,
+	pg.data_provider_short_code,
+	ARRAY['source']::permission_grant_entity_type_t [],
+	ARRAY['create']::permission_grant_verb_t [],
+	pg.created_by
+FROM permission_grants AS pg
+WHERE
+	pg.context_entity_type = 'dataProvider'
+	AND 'edit' = any(pg.verbs)
+	AND 'dataProvider' = any(pg.scope)
+	AND NOT EXISTS (
+		SELECT 1
+		FROM permission_grants AS pg2
+		WHERE
+			pg2.context_entity_type = 'dataProvider'
+			AND pg2.data_provider_short_code = pg.data_provider_short_code
+			AND pg2.grantee_type = pg.grantee_type
+			AND (
+				(
+					pg2.grantee_type = 'user'
+					AND pg2.grantee_user_keycloak_user_id
+					= pg.grantee_user_keycloak_user_id
+				)
+				OR (
+					pg2.grantee_type = 'userGroup'
+					AND pg2.grantee_keycloak_organization_id
+					= pg.grantee_keycloak_organization_id
+				)
+			)
+			AND 'create' = any(pg2.verbs)
+			AND 'source' = any(pg2.scope)
+	);
+
+INSERT INTO permission_grants (
+	grantee_type,
+	grantee_user_keycloak_user_id,
+	grantee_keycloak_organization_id,
+	context_entity_type,
+	changemaker_id,
+	scope,
+	verbs,
+	created_by
+)
+SELECT DISTINCT ON (
+	pg.grantee_type,
+	pg.grantee_user_keycloak_user_id,
+	pg.grantee_keycloak_organization_id,
+	pg.changemaker_id
+)
+	pg.grantee_type,
+	pg.grantee_user_keycloak_user_id,
+	pg.grantee_keycloak_organization_id,
+	pg.context_entity_type,
+	pg.changemaker_id,
+	ARRAY['source']::permission_grant_entity_type_t [],
+	ARRAY['create']::permission_grant_verb_t [],
+	pg.created_by
+FROM permission_grants AS pg
+WHERE
+	pg.context_entity_type = 'changemaker'
+	AND 'edit' = any(pg.verbs)
+	AND 'changemaker' = any(pg.scope)
+	AND NOT EXISTS (
+		SELECT 1
+		FROM permission_grants AS pg2
+		WHERE
+			pg2.context_entity_type = 'changemaker'
+			AND pg2.changemaker_id = pg.changemaker_id
+			AND pg2.grantee_type = pg.grantee_type
+			AND (
+				(
+					pg2.grantee_type = 'user'
+					AND pg2.grantee_user_keycloak_user_id
+					= pg.grantee_user_keycloak_user_id
+				)
+				OR (
+					pg2.grantee_type = 'userGroup'
+					AND pg2.grantee_keycloak_organization_id
+					= pg.grantee_keycloak_organization_id
+				)
+			)
+			AND 'create' = any(pg2.verbs)
+			AND 'source' = any(pg2.scope)
+	);

--- a/src/database/operations/authorization/hasSourcePermission.ts
+++ b/src/database/operations/authorization/hasSourcePermission.ts
@@ -1,0 +1,8 @@
+import { generateHasPermissionOperation } from '../generators';
+
+const hasSourcePermission = generateHasPermissionOperation(
+	'authorization.hasSourcePermission',
+	'sourceId',
+);
+
+export { hasSourcePermission };

--- a/src/database/operations/authorization/index.ts
+++ b/src/database/operations/authorization/index.ts
@@ -5,3 +5,4 @@ export { hasFunderPermission } from './hasFunderPermission';
 export { hasOpportunityPermission } from './hasOpportunityPermission';
 export { hasProposalFieldValuePermission } from './hasProposalFieldValuePermission';
 export { hasProposalPermission } from './hasProposalPermission';
+export { hasSourcePermission } from './hasSourcePermission';

--- a/src/database/queries/authorization/hasSourcePermission.sql
+++ b/src/database/queries/authorization/hasSourcePermission.sql
@@ -1,0 +1,7 @@
+SELECT has_source_permission(
+	:userKeycloakUserId,
+	:isAdministrator,
+	:sourceId,
+	:permission::permission_grant_verb_t,
+	:scope::permission_grant_entity_type_t
+) AS "hasPermission";

--- a/src/database/queries/sources/selectById.sql
+++ b/src/database/queries/sources/selectById.sql
@@ -5,4 +5,12 @@ SELECT
 		:authContextIsAdministrator
 	) AS object
 FROM sources
-WHERE id = :sourceId;
+WHERE
+	id = :sourceId
+	AND has_source_permission(
+		:authContextKeycloakUserId,
+		:authContextIsAdministrator,
+		sources.id,
+		'view',
+		'source'
+	);

--- a/src/database/queries/sources/selectWithPagination.sql
+++ b/src/database/queries/sources/selectWithPagination.sql
@@ -2,6 +2,13 @@ WITH
 	candidate_entries AS NOT MATERIALIZED (
 		SELECT sources.*
 		FROM sources
+		WHERE has_source_permission(
+			:authContextKeycloakUserId,
+			:authContextIsAdministrator,
+			sources.id,
+			'view',
+			'source'
+		)
 	),
 
 	entry_count AS (

--- a/src/handlers/bulkUploadTasksHandlers.ts
+++ b/src/handlers/bulkUploadTasksHandlers.ts
@@ -4,6 +4,7 @@ import {
 	createBulkUploadTask,
 	getLimitValues,
 	hasOpportunityPermission,
+	hasSourcePermission,
 	loadApplicationForm,
 	loadBulkUploadTaskBundle,
 	loadFileIfCreatedBy,
@@ -18,7 +19,6 @@ import {
 } from '../types';
 import {
 	FailedMiddlewareError,
-	InputConflictError,
 	InputValidationError,
 	NotFoundError,
 	UnprocessableEntityError,
@@ -116,6 +116,18 @@ const postBulkUploadTask = async (
 
 	await validateApplicationFormCreatePermission(db, req, applicationFormId);
 
+	if (
+		!(await hasSourcePermission(db, req, {
+			sourceId,
+			permission: PermissionGrantVerb.REFERENCE,
+			scope: PermissionGrantEntityType.SOURCE,
+		}))
+	) {
+		throw new UnprocessableEntityError(
+			'You do not have permission to reference the specified source.',
+		);
+	}
+
 	await validateFileOwnership(
 		db,
 		req,
@@ -132,32 +144,20 @@ const postBulkUploadTask = async (
 		);
 	}
 
-	try {
-		const bulkUploadTask = await createBulkUploadTask(db, req, {
-			sourceId,
-			applicationFormId,
-			proposalsDataFileId,
-			attachmentsArchiveFileId,
-			status: TaskStatus.PENDING,
-		});
-		await addProcessBulkUploadJob({
-			bulkUploadId: bulkUploadTask.id,
-		});
-		res
-			.status(HTTP_STATUS.SUCCESSFUL.CREATED)
-			.contentType('application/json')
-			.send(bulkUploadTask);
-	} catch (error: unknown) {
-		if (error instanceof NotFoundError) {
-			if (error.details.entityType === 'Source') {
-				throw new InputConflictError(`The related entity does not exist`, {
-					entityType: 'Source',
-					entityId: sourceId,
-				});
-			}
-		}
-		throw error;
-	}
+	const bulkUploadTask = await createBulkUploadTask(db, req, {
+		sourceId,
+		applicationFormId,
+		proposalsDataFileId,
+		attachmentsArchiveFileId,
+		status: TaskStatus.PENDING,
+	});
+	await addProcessBulkUploadJob({
+		bulkUploadId: bulkUploadTask.id,
+	});
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
+		.contentType('application/json')
+		.send(bulkUploadTask);
 };
 
 const getBulkUploadTasks = async (

--- a/src/handlers/changemakerFieldValueBatchesHandlers.ts
+++ b/src/handlers/changemakerFieldValueBatchesHandlers.ts
@@ -3,20 +3,21 @@ import {
 	getDatabase,
 	createChangemakerFieldValueBatch,
 	getLimitValues,
+	hasSourcePermission,
 	loadChangemakerFieldValueBatch,
 	loadChangemakerFieldValueBatchBundle,
-	loadSource,
 } from '../database';
 import {
 	isAuthContext,
 	isId,
 	isWritableChangemakerFieldValueBatch,
+	PermissionGrantEntityType,
+	PermissionGrantVerb,
 } from '../types';
 import {
 	FailedMiddlewareError,
 	InputValidationError,
-	InputConflictError,
-	NotFoundError,
+	UnprocessableEntityError,
 } from '../errors';
 import { extractPaginationParameters } from '../queryParameters';
 import { coerceParams } from '../coercion';
@@ -41,16 +42,17 @@ const postChangemakerFieldValueBatch = async (
 
 	const { sourceId, notes } = body;
 
-	// Verify source exists
-	await loadSource(db, req, sourceId).catch((error: unknown) => {
-		if (error instanceof NotFoundError) {
-			throw new InputConflictError('The source does not exist.', {
-				entityType: 'Source',
-				entityId: sourceId,
-			});
-		}
-		throw error;
-	});
+	if (
+		!(await hasSourcePermission(db, req, {
+			sourceId,
+			permission: PermissionGrantVerb.REFERENCE,
+			scope: PermissionGrantEntityType.SOURCE,
+		}))
+	) {
+		throw new UnprocessableEntityError(
+			'You do not have permission to reference the specified source.',
+		);
+	}
 
 	const changemakerFieldValueBatch = await createChangemakerFieldValueBatch(
 		db,

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -4,6 +4,7 @@ import {
 	createProposalVersion,
 	getDatabase,
 	hasProposalPermission,
+	hasSourcePermission,
 	loadApplicationForm,
 	loadApplicationFormField,
 	loadProposal,
@@ -155,6 +156,17 @@ const postProposalVersion = async (
 				'You do not have write permissions on this proposal.',
 			);
 		}
+		if (
+			!(await hasSourcePermission(db, req, {
+				sourceId,
+				permission: PermissionGrantVerb.REFERENCE,
+				scope: PermissionGrantEntityType.SOURCE,
+			}))
+		) {
+			throw new UnprocessableEntityError(
+				'You do not have permission to reference the specified source.',
+			);
+		}
 		await assertApplicationFormExistsForProposal(
 			db,
 			req,
@@ -208,12 +220,6 @@ const postProposalVersion = async (
 			.send(finalProposalVersion);
 	} catch (error: unknown) {
 		if (error instanceof NotFoundError) {
-			if (error.details.entityType === 'Source') {
-				throw new InputConflictError(`The related entity does not exist`, {
-					entityType: 'Source',
-					entityId: sourceId,
-				});
-			}
 			if (error.details.entityType === 'Proposal') {
 				throw new InputConflictError(`The related entity does not exist`, {
 					entityType: 'Proposal',

--- a/src/handlers/sourcesHandlers.ts
+++ b/src/handlers/sourcesHandlers.ts
@@ -41,36 +41,36 @@ const postSource = async (req: Request, res: Response): Promise<void> => {
 		'funderShortCode' in req.body &&
 		!(await hasFunderPermission(db, req, {
 			funderShortCode: req.body.funderShortCode,
-			permission: PermissionGrantVerb.EDIT,
-			scope: PermissionGrantEntityType.FUNDER,
+			permission: PermissionGrantVerb.CREATE,
+			scope: PermissionGrantEntityType.SOURCE,
 		}))
 	) {
 		throw new UnprocessableEntityError(
-			'You do not have write permissions on a funder with the specified short code.',
+			'You do not have permission to create a source for the specified funder.',
 		);
 	}
 	if (
 		'dataProviderShortCode' in req.body &&
 		!(await hasDataProviderPermission(db, req, {
 			dataProviderShortCode: req.body.dataProviderShortCode,
-			permission: PermissionGrantVerb.EDIT,
-			scope: PermissionGrantEntityType.DATA_PROVIDER,
+			permission: PermissionGrantVerb.CREATE,
+			scope: PermissionGrantEntityType.SOURCE,
 		}))
 	) {
 		throw new UnprocessableEntityError(
-			'You do not have write permissions on a data provider with the specified short code.',
+			'You do not have permission to create a source for the specified data provider.',
 		);
 	}
 	if (
 		'changemakerId' in req.body &&
 		!(await hasChangemakerPermission(db, req, {
 			changemakerId: req.body.changemakerId,
-			permission: PermissionGrantVerb.EDIT,
-			scope: PermissionGrantEntityType.CHANGEMAKER,
+			permission: PermissionGrantVerb.CREATE,
+			scope: PermissionGrantEntityType.SOURCE,
 		}))
 	) {
 		throw new UnprocessableEntityError(
-			'You do not have write permissions on a changemaker with the specified id.',
+			'You do not have permission to create a source for the specified changemaker.',
 		);
 	}
 
@@ -99,12 +99,15 @@ const getSources = async (req: Request, res: Response): Promise<void> => {
 };
 
 const getSource = async (req: Request, res: Response): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
 	const db = getDatabase();
 	const { sourceId } = coerceParams(req.params);
 	if (!isId(sourceId)) {
 		throw new InputValidationError('Invalid request body.', isId.errors ?? []);
 	}
-	const source = await loadSource(db, null, sourceId);
+	const source = await loadSource(db, req, sourceId);
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.OK)
 		.contentType('application/json')

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.33.0",
+		"version": "0.34.0",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"

--- a/src/openapi/components/schemas/PermissionGrantVerb.json
+++ b/src/openapi/components/schemas/PermissionGrantVerb.json
@@ -1,4 +1,4 @@
 {
 	"type": "string",
-	"enum": ["view", "create", "edit", "delete", "manage"]
+	"enum": ["view", "create", "edit", "delete", "manage", "reference"]
 }

--- a/src/types/PermissionGrantVerb.ts
+++ b/src/types/PermissionGrantVerb.ts
@@ -7,6 +7,7 @@ enum PermissionGrantVerb {
 	EDIT = 'edit',
 	DELETE = 'delete',
 	MANAGE = 'manage',
+	REFERENCE = 'reference',
 }
 
 const permissionGrantVerbSchema: JSONSchemaType<PermissionGrantVerb> = {


### PR DESCRIPTION
This PR applies the permission grant system to the creation + viewing of `Source` entities.

Prior to this change all sources were visible to all authenticated users.  After this change, a user needs to be given explicit visibility of a given source to see it, and they need to be given explicit permission to reference a given source when creating new data in the system.

This PR also adds a new `reference` verb to cover that second case.  I explicitly do NOT grant any users `reference` rights since prior to this PR the state was overly permissive (for the most part we don't want users to be able to reference our existing sources today / that should be manually set in the cases we want that permission.)

Resolves #2361
Resolves #2364 