### PR TITLE
Treat `manage` permission as "all"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The `manage` permission verb now satisfies any verb check on the scope to which it is granted. A grantee with `manage` on a given scope no longer needs the other verbs listed alongside it to perform view, create, edit, delete, or reference operations at that scope. Scope matching is unchanged: `manage` does not grant access to scopes that are not explicitly included in the grant.
+
 ## 0.34.0 2026-04-23
 
 ### Added

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -182,12 +182,20 @@ The permission system supports the following verbs:
 | create    | Create new data                                     |
 | edit      | Modify existing data                                |
 | delete    | Delete data                                         |
-| manage    | Manage permission grants associated with the data   |
+| manage    | Full permissions, including permission management   |
 | reference | Use an entity as a pointer in data you are creating |
 
 Note: The current implementation uses `edit` for both creation and modification
 operations in most contexts. This is a known semantic mismatch with the intended
 meaning of the verb.
+
+A `manage` grant is treated as satisfying any verb check on the same scope.
+A grant of `manage | proposal` on a funder context, for example, lets the
+grantee view, create, edit, delete, and reference proposals for that funder
+without naming each verb separately. `manage` does not expand the scope set;
+a grantee holding `manage | proposal` does not gain access to `funder`-,
+`opportunity`-, or `source`-scoped data unless those scopes are also
+included in the grant.
 
 The `reference` verb is separate from `view` and `create` so that permission to
 see an entity does not automatically imply permission to cite it from elsewhere,

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -893,14 +893,6 @@ describe('/applicationForms', () => {
 				scope: [PermissionGrantEntityType.OPPORTUNITY],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
-			await createPermissionGrant(db, systemUserAuthContext, {
-				granteeType: PermissionGrantGranteeType.USER,
-				granteeUserKeycloakUserId: testUser.keycloakUserId,
-				contextEntityType: PermissionGrantEntityType.FUNDER,
-				funderShortCode: testFunder.shortCode,
-				scope: [PermissionGrantEntityType.OPPORTUNITY],
-				verbs: [PermissionGrantVerb.MANAGE],
-			});
 			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
 			});

--- a/src/__tests__/permissionGrantManageVerb.int.test.ts
+++ b/src/__tests__/permissionGrantManageVerb.int.test.ts
@@ -1,0 +1,564 @@
+import {
+	createApplicationForm,
+	createApplicationFormField,
+	createChangemakerFieldValue,
+	createChangemakerFieldValueBatch,
+	createPermissionGrant,
+	createProposal,
+	createProposalFieldValue,
+	createProposalVersion,
+	createSource,
+	getDatabase,
+	hasChangemakerFieldValuePermission,
+	hasChangemakerPermission,
+	hasDataProviderPermission,
+	hasFunderPermission,
+	hasOpportunityPermission,
+	hasProposalFieldValuePermission,
+	hasProposalPermission,
+	hasSourcePermission,
+	loadSystemSource,
+} from '../database';
+import {
+	createTestBaseField,
+	createTestChangemaker,
+	createTestDataProvider,
+	createTestFunder,
+	createTestOpportunity,
+} from '../test/factories';
+import { getAuthContext, loadTestUser } from '../test/utils';
+import {
+	BaseFieldCategory,
+	PermissionGrantEntityType,
+	PermissionGrantGranteeType,
+	PermissionGrantVerb,
+} from '../types';
+
+const NON_MANAGE_VERBS: PermissionGrantVerb[] = [
+	PermissionGrantVerb.VIEW,
+	PermissionGrantVerb.CREATE,
+	PermissionGrantVerb.EDIT,
+	PermissionGrantVerb.DELETE,
+	PermissionGrantVerb.REFERENCE,
+];
+
+const expectAllTrue = async (
+	checks: Array<Promise<boolean>>,
+): Promise<void> => {
+	const results = await Promise.all(checks);
+	results.forEach((result) => {
+		expect(result).toBe(true);
+	});
+};
+
+describe('`manage` verb semantics', () => {
+	it('satisfies any verb check on a funder grant whose scope matches', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const funder = await createTestFunder(db, testUserAuthContext);
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.FUNDER,
+			funderShortCode: funder.shortCode,
+			scope: [
+				PermissionGrantEntityType.FUNDER,
+				PermissionGrantEntityType.OPPORTUNITY,
+			],
+			verbs: [PermissionGrantVerb.MANAGE],
+		});
+
+		await expectAllTrue(
+			NON_MANAGE_VERBS.flatMap((verb) => [
+				hasFunderPermission(db, testUserAuthContext, {
+					funderShortCode: funder.shortCode,
+					permission: verb,
+					scope: PermissionGrantEntityType.FUNDER,
+				}),
+				hasFunderPermission(db, testUserAuthContext, {
+					funderShortCode: funder.shortCode,
+					permission: verb,
+					scope: PermissionGrantEntityType.OPPORTUNITY,
+				}),
+			]),
+		);
+		// A scope absent from the grant is not covered, even though the same
+		// grant confers manage on sibling scopes.
+		expect(
+			await hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.PROPOSAL,
+			}),
+		).toBe(false);
+	});
+
+	it('satisfies any verb check on a changemaker grant whose scope matches', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
+		const source = await createSource(db, testUserAuthContext, {
+			label: 'Source under changemaker',
+			changemakerId: changemaker.id,
+		});
+		const baseField = await createTestBaseField(db, null);
+		const batch = await createChangemakerFieldValueBatch(
+			db,
+			testUserAuthContext,
+			{ sourceId: source.id, notes: null },
+		);
+		const cfv = await createChangemakerFieldValue(db, testUserAuthContext, {
+			changemakerId: changemaker.id,
+			baseFieldShortCode: baseField.shortCode,
+			batchId: batch.id,
+			value: 'Some value',
+			isValid: true,
+			goodAsOf: null,
+		});
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+			changemakerId: changemaker.id,
+			scope: [
+				PermissionGrantEntityType.CHANGEMAKER,
+				PermissionGrantEntityType.CHANGEMAKER_FIELD_VALUE,
+			],
+			verbs: [PermissionGrantVerb.MANAGE],
+		});
+
+		await expectAllTrue(
+			NON_MANAGE_VERBS.flatMap((verb) => [
+				hasChangemakerPermission(db, testUserAuthContext, {
+					changemakerId: changemaker.id,
+					permission: verb,
+					scope: PermissionGrantEntityType.CHANGEMAKER,
+				}),
+				hasChangemakerFieldValuePermission(db, testUserAuthContext, {
+					changemakerFieldValueId: cfv.id,
+					permission: verb,
+					scope: PermissionGrantEntityType.CHANGEMAKER_FIELD_VALUE,
+				}),
+			]),
+		);
+	});
+
+	it('satisfies any verb check on an opportunity-inherited proposal grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext);
+		const proposal = await createProposal(db, testUserAuthContext, {
+			externalId: 'opp-manage-proposal',
+			opportunityId: opportunity.id,
+		});
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.OPPORTUNITY,
+			opportunityId: opportunity.id,
+			scope: [
+				PermissionGrantEntityType.OPPORTUNITY,
+				PermissionGrantEntityType.PROPOSAL,
+			],
+			verbs: [PermissionGrantVerb.MANAGE],
+		});
+
+		await expectAllTrue(
+			NON_MANAGE_VERBS.flatMap((verb) => [
+				hasOpportunityPermission(db, testUserAuthContext, {
+					opportunityId: opportunity.id,
+					permission: verb,
+					scope: PermissionGrantEntityType.OPPORTUNITY,
+				}),
+				hasProposalPermission(db, testUserAuthContext, {
+					proposalId: proposal.id,
+					permission: verb,
+					scope: PermissionGrantEntityType.PROPOSAL,
+				}),
+			]),
+		);
+	});
+
+	it('satisfies any verb check on a direct proposal grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext);
+		const proposal = await createProposal(db, testUserAuthContext, {
+			externalId: 'proposal-manage-proposal',
+			opportunityId: opportunity.id,
+		});
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.PROPOSAL,
+			proposalId: proposal.id,
+			scope: [PermissionGrantEntityType.PROPOSAL],
+			verbs: [PermissionGrantVerb.MANAGE],
+		});
+
+		await expectAllTrue(
+			NON_MANAGE_VERBS.map(
+				async (verb) =>
+					await hasProposalPermission(db, testUserAuthContext, {
+						proposalId: proposal.id,
+						permission: verb,
+						scope: PermissionGrantEntityType.PROPOSAL,
+					}),
+			),
+		);
+	});
+
+	it('satisfies any verb check on a dataProvider-inherited source grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const dataProvider = await createTestDataProvider(db, testUserAuthContext);
+		const source = await createSource(db, testUserAuthContext, {
+			label: 'DP-owned Source',
+			dataProviderShortCode: dataProvider.shortCode,
+		});
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
+			dataProviderShortCode: dataProvider.shortCode,
+			scope: [
+				PermissionGrantEntityType.DATA_PROVIDER,
+				PermissionGrantEntityType.SOURCE,
+			],
+			verbs: [PermissionGrantVerb.MANAGE],
+		});
+
+		await expectAllTrue(
+			NON_MANAGE_VERBS.flatMap((verb) => [
+				hasDataProviderPermission(db, testUserAuthContext, {
+					dataProviderShortCode: dataProvider.shortCode,
+					permission: verb,
+					scope: PermissionGrantEntityType.DATA_PROVIDER,
+				}),
+				hasSourcePermission(db, testUserAuthContext, {
+					sourceId: source.id,
+					permission: verb,
+					scope: PermissionGrantEntityType.SOURCE,
+				}),
+			]),
+		);
+	});
+
+	it('satisfies any verb check on a direct source grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
+		const source = await createSource(db, testUserAuthContext, {
+			label: 'Directly granted source',
+			changemakerId: changemaker.id,
+		});
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.SOURCE,
+			sourceId: source.id,
+			scope: [PermissionGrantEntityType.SOURCE],
+			verbs: [PermissionGrantVerb.MANAGE],
+		});
+
+		await expectAllTrue(
+			NON_MANAGE_VERBS.map(
+				async (verb) =>
+					await hasSourcePermission(db, testUserAuthContext, {
+						sourceId: source.id,
+						permission: verb,
+						scope: PermissionGrantEntityType.SOURCE,
+					}),
+			),
+		);
+	});
+
+	it('does not grant access to a scope outside the grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const funder = await createTestFunder(db, testUserAuthContext);
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.FUNDER,
+			funderShortCode: funder.shortCode,
+			scope: [PermissionGrantEntityType.PROPOSAL],
+			verbs: [PermissionGrantVerb.MANAGE],
+		});
+
+		// Manage on proposal scope does not confer access to the funder scope.
+		expect(
+			await hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.FUNDER,
+			}),
+		).toBe(false);
+		// And does not confer access to the opportunity scope.
+		expect(
+			await hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.OPPORTUNITY,
+			}),
+		).toBe(false);
+	});
+
+	it('does not leak a manage grant from one funder to another', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const ownedFunder = await createTestFunder(db, testUserAuthContext);
+		const otherFunder = await createTestFunder(db, testUserAuthContext);
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.FUNDER,
+			funderShortCode: ownedFunder.shortCode,
+			scope: [PermissionGrantEntityType.FUNDER],
+			verbs: [PermissionGrantVerb.MANAGE],
+		});
+
+		expect(
+			await hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: ownedFunder.shortCode,
+				permission: PermissionGrantVerb.EDIT,
+				scope: PermissionGrantEntityType.FUNDER,
+			}),
+		).toBe(true);
+		expect(
+			await hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: otherFunder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.FUNDER,
+			}),
+		).toBe(false);
+	});
+
+	it('honors conditions on a conditional manage grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const funder = await createTestFunder(db, testUserAuthContext);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext, {
+			funderShortCode: funder.shortCode,
+		});
+		const proposal = await createProposal(db, testUserAuthContext, {
+			externalId: 'conditional-manage-proposal',
+			opportunityId: opportunity.id,
+		});
+		const applicationForm = await createApplicationForm(db, null, {
+			opportunityId: opportunity.id,
+			name: null,
+		});
+		const systemSource = await loadSystemSource(db, null);
+		const proposalVersion = await createProposalVersion(
+			db,
+			testUserAuthContext,
+			{
+				proposalId: proposal.id,
+				applicationFormId: applicationForm.id,
+				sourceId: systemSource.id,
+			},
+		);
+		const budgetField = await createTestBaseField(db, null, {
+			category: BaseFieldCategory.BUDGET,
+		});
+		const projectField = await createTestBaseField(db, null, {
+			category: BaseFieldCategory.PROJECT,
+		});
+		const budgetApplicationFormField = await createApplicationFormField(
+			db,
+			null,
+			{
+				applicationFormId: applicationForm.id,
+				baseFieldShortCode: budgetField.shortCode,
+				position: 1,
+				label: 'Budget',
+				instructions: 'budget',
+				inputType: null,
+			},
+		);
+		const projectApplicationFormField = await createApplicationFormField(
+			db,
+			null,
+			{
+				applicationFormId: applicationForm.id,
+				baseFieldShortCode: projectField.shortCode,
+				position: 2,
+				label: 'Project',
+				instructions: 'project',
+				inputType: null,
+			},
+		);
+		const budgetValue = await createProposalFieldValue(db, null, {
+			proposalVersionId: proposalVersion.id,
+			applicationFormFieldId: budgetApplicationFormField.id,
+			position: 1,
+			value: 'Budget value',
+			isValid: true,
+			goodAsOf: null,
+		});
+		const projectValue = await createProposalFieldValue(db, null, {
+			proposalVersionId: proposalVersion.id,
+			applicationFormFieldId: projectApplicationFormField.id,
+			position: 2,
+			value: 'Project value',
+			isValid: true,
+			goodAsOf: null,
+		});
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.FUNDER,
+			funderShortCode: funder.shortCode,
+			scope: [PermissionGrantEntityType.PROPOSAL_FIELD_VALUE],
+			verbs: [PermissionGrantVerb.MANAGE],
+			conditions: {
+				[PermissionGrantEntityType.PROPOSAL_FIELD_VALUE]: {
+					property: 'baseFieldCategory',
+					operator: 'in',
+					value: [BaseFieldCategory.BUDGET],
+				},
+			},
+		});
+
+		expect(
+			await hasProposalFieldValuePermission(db, testUserAuthContext, {
+				proposalFieldValueId: budgetValue.id,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
+			}),
+		).toBe(true);
+		expect(
+			await hasProposalFieldValuePermission(db, testUserAuthContext, {
+				proposalFieldValueId: projectValue.id,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
+			}),
+		).toBe(false);
+	});
+
+	it('a view-only grant does not imply edit or create', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const funder = await createTestFunder(db, testUserAuthContext);
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.FUNDER,
+			funderShortCode: funder.shortCode,
+			scope: [PermissionGrantEntityType.FUNDER],
+			verbs: [PermissionGrantVerb.VIEW],
+		});
+
+		expect(
+			await hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.FUNDER,
+			}),
+		).toBe(true);
+		expect(
+			await hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.EDIT,
+				scope: PermissionGrantEntityType.FUNDER,
+			}),
+		).toBe(false);
+	});
+
+	it('extends to proposal field values via an inherited funder grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const adminAuthContext = getAuthContext(testUser, true);
+		const funder = await createTestFunder(db, testUserAuthContext);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext, {
+			funderShortCode: funder.shortCode,
+		});
+		const proposal = await createProposal(db, testUserAuthContext, {
+			externalId: 'pfv-inherited-proposal',
+			opportunityId: opportunity.id,
+		});
+		const applicationForm = await createApplicationForm(db, null, {
+			opportunityId: opportunity.id,
+			name: null,
+		});
+		const systemSource = await loadSystemSource(db, null);
+		const proposalVersion = await createProposalVersion(
+			db,
+			testUserAuthContext,
+			{
+				proposalId: proposal.id,
+				applicationFormId: applicationForm.id,
+				sourceId: systemSource.id,
+			},
+		);
+		const baseField = await createTestBaseField(db, null);
+		const applicationFormField = await createApplicationFormField(db, null, {
+			applicationFormId: applicationForm.id,
+			baseFieldShortCode: baseField.shortCode,
+			position: 1,
+			label: 'Field',
+			instructions: 'field',
+			inputType: null,
+		});
+		const pfv = await createProposalFieldValue(db, null, {
+			proposalVersionId: proposalVersion.id,
+			applicationFormFieldId: applicationFormField.id,
+			position: 1,
+			value: 'Value',
+			isValid: true,
+			goodAsOf: null,
+		});
+
+		await createPermissionGrant(db, adminAuthContext, {
+			granteeType: PermissionGrantGranteeType.USER,
+			granteeUserKeycloakUserId: testUser.keycloakUserId,
+			contextEntityType: PermissionGrantEntityType.FUNDER,
+			funderShortCode: funder.shortCode,
+			scope: [PermissionGrantEntityType.PROPOSAL_FIELD_VALUE],
+			verbs: [PermissionGrantVerb.MANAGE],
+		});
+
+		await expectAllTrue(
+			NON_MANAGE_VERBS.map(
+				async (verb) =>
+					await hasProposalFieldValuePermission(db, testUserAuthContext, {
+						proposalFieldValueId: pfv.id,
+						permission: verb,
+						scope: PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
+					}),
+			),
+		);
+	});
+});

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -510,7 +510,7 @@ describe('/sources', () => {
 				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
 				changemakerId: changemaker.id,
 				scope: [PermissionGrantEntityType.SOURCE],
-				verbs: [PermissionGrantVerb.MANAGE, PermissionGrantVerb.VIEW],
+				verbs: [PermissionGrantVerb.VIEW],
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
@@ -636,7 +636,7 @@ describe('/sources', () => {
 				contextEntityType: PermissionGrantEntityType.FUNDER,
 				funderShortCode: funder.shortCode,
 				scope: [PermissionGrantEntityType.SOURCE],
-				verbs: [PermissionGrantVerb.MANAGE, PermissionGrantVerb.VIEW],
+				verbs: [PermissionGrantVerb.VIEW],
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
@@ -771,7 +771,7 @@ describe('/sources', () => {
 				contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
 				dataProviderShortCode: dataProvider.shortCode,
 				scope: [PermissionGrantEntityType.SOURCE],
-				verbs: [PermissionGrantVerb.MANAGE, PermissionGrantVerb.VIEW],
+				verbs: [PermissionGrantVerb.VIEW],
 			});
 
 			// Also create a userGroup permission grant with CREATE|source but an EXPIRED association

--- a/src/database/initialization/has_changemaker_field_value_permission.sql
+++ b/src/database/initialization/has_changemaker_field_value_permission.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION has_changemaker_field_value_permission(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
 	changemaker_field_value_id int,
-	permission permission_grant_verb_t,
+	verb permission_grant_verb_t,
 	scope permission_grant_entity_type_t
 ) RETURNS boolean AS $$
 DECLARE
@@ -22,7 +22,7 @@ BEGIN
 	END IF;
 
 	-- Public fields are viewable by any authenticated user
-	IF sensitivity = 'public' AND permission = 'view' THEN
+	IF sensitivity = 'public' AND verb = 'view' THEN
 		RETURN TRUE;
 	END IF;
 
@@ -31,9 +31,8 @@ BEGIN
 		RETURN TRUE;
 	END IF;
 
-	-- Check if the user has the specified permission on the specified changemaker field value
+	-- Check if the user has the specified verb on the specified changemaker field value
 	-- via direct user grant, group membership, or inherited from parent entities.
-	-- A granted 'manage' verb satisfies any verb check.
 	SELECT EXISTS (
 		SELECT 1
 		FROM changemaker_field_values cfv
@@ -52,9 +51,8 @@ BEGIN
 			)
 		)
 		WHERE cfv.id = has_changemaker_field_value_permission.changemaker_field_value_id
-			AND (
-				has_changemaker_field_value_permission.permission = ANY(pg.verbs)
-				OR 'manage' = ANY(pg.verbs)
+			AND verb_set_permits_verb(
+				pg.verbs, has_changemaker_field_value_permission.verb
 			)
 			AND (
 				(

--- a/src/database/initialization/has_changemaker_field_value_permission.sql
+++ b/src/database/initialization/has_changemaker_field_value_permission.sql
@@ -32,7 +32,8 @@ BEGIN
 	END IF;
 
 	-- Check if the user has the specified permission on the specified changemaker field value
-	-- via direct user grant, group membership, or inherited from parent entities
+	-- via direct user grant, group membership, or inherited from parent entities.
+	-- A granted 'manage' verb satisfies any verb check.
 	SELECT EXISTS (
 		SELECT 1
 		FROM changemaker_field_values cfv
@@ -51,7 +52,10 @@ BEGIN
 			)
 		)
 		WHERE cfv.id = has_changemaker_field_value_permission.changemaker_field_value_id
-			AND has_changemaker_field_value_permission.permission = ANY(pg.verbs)
+			AND (
+				has_changemaker_field_value_permission.permission = ANY(pg.verbs)
+				OR 'manage' = ANY(pg.verbs)
+			)
 			AND (
 				(
 					pg.grantee_type = 'user'

--- a/src/database/initialization/has_changemaker_permission.sql
+++ b/src/database/initialization/has_changemaker_permission.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION has_changemaker_permission(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
 	changemaker_id int,
-	permission permission_grant_verb_t,
+	verb permission_grant_verb_t,
 	scope permission_grant_entity_type_t
 ) RETURNS boolean AS $$
 DECLARE
@@ -13,18 +13,16 @@ BEGIN
 		RETURN TRUE;
 	END IF;
 
-	-- Check if the user has the specified permission on the specified changemaker
-	-- via direct user grant or group membership. A granted 'manage' verb
-	-- satisfies any verb check.
+	-- Check if the user has the specified verb on the specified changemaker
+	-- via direct user grant or group membership.
 	SELECT EXISTS (
 		SELECT 1
 		FROM permission_grants pg
 		WHERE pg.context_entity_type = 'changemaker'
 			AND pg.changemaker_id
 				= has_changemaker_permission.changemaker_id
-			AND (
-				has_changemaker_permission.permission = ANY(pg.verbs)
-				OR 'manage' = ANY(pg.verbs)
+			AND verb_set_permits_verb(
+				pg.verbs, has_changemaker_permission.verb
 			)
 			AND has_changemaker_permission.scope = ANY(pg.scope)
 			AND (

--- a/src/database/initialization/has_changemaker_permission.sql
+++ b/src/database/initialization/has_changemaker_permission.sql
@@ -14,14 +14,18 @@ BEGIN
 	END IF;
 
 	-- Check if the user has the specified permission on the specified changemaker
-	-- via direct user grant or group membership
+	-- via direct user grant or group membership. A granted 'manage' verb
+	-- satisfies any verb check.
 	SELECT EXISTS (
 		SELECT 1
 		FROM permission_grants pg
 		WHERE pg.context_entity_type = 'changemaker'
 			AND pg.changemaker_id
 				= has_changemaker_permission.changemaker_id
-			AND has_changemaker_permission.permission = ANY(pg.verbs)
+			AND (
+				has_changemaker_permission.permission = ANY(pg.verbs)
+				OR 'manage' = ANY(pg.verbs)
+			)
 			AND has_changemaker_permission.scope = ANY(pg.scope)
 			AND (
 				(

--- a/src/database/initialization/has_data_provider_permission.sql
+++ b/src/database/initialization/has_data_provider_permission.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION has_data_provider_permission(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
 	data_provider_short_code short_code_t,
-	permission permission_grant_verb_t,
+	verb permission_grant_verb_t,
 	scope permission_grant_entity_type_t
 ) RETURNS boolean AS $$
 DECLARE
@@ -13,18 +13,16 @@ BEGIN
 		RETURN TRUE;
 	END IF;
 
-	-- Check if the user has the specified permission on the specified data provider
-	-- via direct user grant or group membership. A granted 'manage' verb
-	-- satisfies any verb check.
+	-- Check if the user has the specified verb on the specified data provider
+	-- via direct user grant or group membership.
 	SELECT EXISTS (
 		SELECT 1
 		FROM permission_grants pg
 		WHERE pg.context_entity_type = 'dataProvider'
 			AND pg.data_provider_short_code
 				= has_data_provider_permission.data_provider_short_code
-			AND (
-				has_data_provider_permission.permission = ANY(pg.verbs)
-				OR 'manage' = ANY(pg.verbs)
+			AND verb_set_permits_verb(
+				pg.verbs, has_data_provider_permission.verb
 			)
 			AND has_data_provider_permission.scope = ANY(pg.scope)
 			AND (

--- a/src/database/initialization/has_data_provider_permission.sql
+++ b/src/database/initialization/has_data_provider_permission.sql
@@ -14,14 +14,18 @@ BEGIN
 	END IF;
 
 	-- Check if the user has the specified permission on the specified data provider
-	-- via direct user grant or group membership
+	-- via direct user grant or group membership. A granted 'manage' verb
+	-- satisfies any verb check.
 	SELECT EXISTS (
 		SELECT 1
 		FROM permission_grants pg
 		WHERE pg.context_entity_type = 'dataProvider'
 			AND pg.data_provider_short_code
 				= has_data_provider_permission.data_provider_short_code
-			AND has_data_provider_permission.permission = ANY(pg.verbs)
+			AND (
+				has_data_provider_permission.permission = ANY(pg.verbs)
+				OR 'manage' = ANY(pg.verbs)
+			)
 			AND has_data_provider_permission.scope = ANY(pg.scope)
 			AND (
 				(

--- a/src/database/initialization/has_funder_permission.sql
+++ b/src/database/initialization/has_funder_permission.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION has_funder_permission(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
 	funder_short_code short_code_t,
-	permission permission_grant_verb_t,
+	verb permission_grant_verb_t,
 	scope permission_grant_entity_type_t
 ) RETURNS boolean AS $$
 DECLARE
@@ -13,18 +13,16 @@ BEGIN
 		RETURN TRUE;
 	END IF;
 
-	-- Check if the user has the specified permission on the specified funder
-	-- via direct user grant or group membership. A granted 'manage' verb
-	-- satisfies any verb check.
+	-- Check if the user has the specified verb on the specified funder
+	-- via direct user grant or group membership.
 	SELECT EXISTS (
 		SELECT 1
 		FROM permission_grants pg
 		WHERE pg.context_entity_type = 'funder'
 			AND pg.funder_short_code
 				= has_funder_permission.funder_short_code
-			AND (
-				has_funder_permission.permission = ANY(pg.verbs)
-				OR 'manage' = ANY(pg.verbs)
+			AND verb_set_permits_verb(
+				pg.verbs, has_funder_permission.verb
 			)
 			AND has_funder_permission.scope = ANY(pg.scope)
 			AND (

--- a/src/database/initialization/has_funder_permission.sql
+++ b/src/database/initialization/has_funder_permission.sql
@@ -14,14 +14,18 @@ BEGIN
 	END IF;
 
 	-- Check if the user has the specified permission on the specified funder
-	-- via direct user grant or group membership
+	-- via direct user grant or group membership. A granted 'manage' verb
+	-- satisfies any verb check.
 	SELECT EXISTS (
 		SELECT 1
 		FROM permission_grants pg
 		WHERE pg.context_entity_type = 'funder'
 			AND pg.funder_short_code
 				= has_funder_permission.funder_short_code
-			AND has_funder_permission.permission = ANY(pg.verbs)
+			AND (
+				has_funder_permission.permission = ANY(pg.verbs)
+				OR 'manage' = ANY(pg.verbs)
+			)
 			AND has_funder_permission.scope = ANY(pg.scope)
 			AND (
 				(

--- a/src/database/initialization/has_opportunity_permission.sql
+++ b/src/database/initialization/has_opportunity_permission.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION has_opportunity_permission(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
 	opportunity_id int,
-	permission permission_grant_verb_t,
+	verb permission_grant_verb_t,
 	scope permission_grant_entity_type_t
 ) RETURNS boolean AS $$
 DECLARE
@@ -13,7 +13,7 @@ BEGIN
 		RETURN TRUE;
 	END IF;
 
-	-- Check if the user has the specified permission on the specified opportunity
+	-- Check if the user has the specified verb on the specified opportunity
 	-- via direct user grant, group membership, or inherited from funder
 	SELECT EXISTS (
 		SELECT 1
@@ -31,10 +31,8 @@ BEGIN
 			)
 		)
 		WHERE o.id = has_opportunity_permission.opportunity_id
-			-- A granted 'manage' verb satisfies any verb check.
-			AND (
-				has_opportunity_permission.permission = ANY(pg.verbs)
-				OR 'manage' = ANY(pg.verbs)
+			AND verb_set_permits_verb(
+				pg.verbs, has_opportunity_permission.verb
 			)
 			AND has_opportunity_permission.scope = ANY(pg.scope)
 			AND (

--- a/src/database/initialization/has_opportunity_permission.sql
+++ b/src/database/initialization/has_opportunity_permission.sql
@@ -31,7 +31,11 @@ BEGIN
 			)
 		)
 		WHERE o.id = has_opportunity_permission.opportunity_id
-			AND has_opportunity_permission.permission = ANY(pg.verbs)
+			-- A granted 'manage' verb satisfies any verb check.
+			AND (
+				has_opportunity_permission.permission = ANY(pg.verbs)
+				OR 'manage' = ANY(pg.verbs)
+			)
 			AND has_opportunity_permission.scope = ANY(pg.scope)
 			AND (
 				(

--- a/src/database/initialization/has_proposal_field_value_permission.sql
+++ b/src/database/initialization/has_proposal_field_value_permission.sql
@@ -34,7 +34,8 @@ BEGIN
 	END IF;
 
 	-- Check if the user has the specified permission on the specified proposal field value
-	-- via direct user grant, group membership, or inherited from parent entities
+	-- via direct user grant, group membership, or inherited from parent entities.
+	-- A granted 'manage' verb satisfies any verb check.
 	SELECT EXISTS (
 		SELECT 1
 		FROM proposal_field_values pfv
@@ -75,7 +76,10 @@ BEGIN
 			)
 		)
 		WHERE pfv.id = has_proposal_field_value_permission.proposal_field_value_id
-			AND has_proposal_field_value_permission.permission = ANY(pg.verbs)
+			AND (
+				has_proposal_field_value_permission.permission = ANY(pg.verbs)
+				OR 'manage' = ANY(pg.verbs)
+			)
 			AND (
 				(
 					pg.grantee_type = 'user'
@@ -95,21 +99,21 @@ BEGIN
 					)
 				)
 			)
-		AND (
-			pg.conditions IS NULL
-			OR NOT pg.conditions ? 'proposalFieldValue'
-			OR (
-				pg.conditions #>> '{proposalFieldValue,property}'
-					= 'baseFieldCategory'
-				AND pg.conditions #>> '{proposalFieldValue,operator}'
-					= 'in'
-				AND base_field_category::text IN (
-					SELECT jsonb_array_elements_text(
-						pg.conditions #> '{proposalFieldValue,value}'
+			AND (
+				pg.conditions IS NULL
+				OR NOT pg.conditions ? 'proposalFieldValue'
+				OR (
+					pg.conditions #>> '{proposalFieldValue,property}'
+						= 'baseFieldCategory'
+					AND pg.conditions #>> '{proposalFieldValue,operator}'
+						= 'in'
+					AND base_field_category::text IN (
+						SELECT jsonb_array_elements_text(
+							pg.conditions #> '{proposalFieldValue,value}'
+						)
 					)
 				)
 			)
-		)
 	) INTO has_permission;
 
 	RETURN has_permission;

--- a/src/database/initialization/has_proposal_field_value_permission.sql
+++ b/src/database/initialization/has_proposal_field_value_permission.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION has_proposal_field_value_permission(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
 	proposal_field_value_id int,
-	permission permission_grant_verb_t,
+	verb permission_grant_verb_t,
 	scope permission_grant_entity_type_t
 ) RETURNS boolean AS $$
 DECLARE
@@ -24,7 +24,7 @@ BEGIN
 	END IF;
 
 	-- Public fields are viewable by any authenticated user
-	IF sensitivity = 'public' AND permission = 'view' THEN
+	IF sensitivity = 'public' AND verb = 'view' THEN
 		RETURN TRUE;
 	END IF;
 
@@ -33,9 +33,8 @@ BEGIN
 		RETURN TRUE;
 	END IF;
 
-	-- Check if the user has the specified permission on the specified proposal field value
+	-- Check if the user has the specified verb on the specified proposal field value
 	-- via direct user grant, group membership, or inherited from parent entities.
-	-- A granted 'manage' verb satisfies any verb check.
 	SELECT EXISTS (
 		SELECT 1
 		FROM proposal_field_values pfv
@@ -76,9 +75,8 @@ BEGIN
 			)
 		)
 		WHERE pfv.id = has_proposal_field_value_permission.proposal_field_value_id
-			AND (
-				has_proposal_field_value_permission.permission = ANY(pg.verbs)
-				OR 'manage' = ANY(pg.verbs)
+			AND verb_set_permits_verb(
+				pg.verbs, has_proposal_field_value_permission.verb
 			)
 			AND (
 				(

--- a/src/database/initialization/has_proposal_permission.sql
+++ b/src/database/initialization/has_proposal_permission.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION has_proposal_permission(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
 	proposal_id int,
-	permission permission_grant_verb_t,
+	verb permission_grant_verb_t,
 	scope permission_grant_entity_type_t
 ) RETURNS boolean AS $$
 DECLARE
@@ -13,9 +13,8 @@ BEGIN
 		RETURN TRUE;
 	END IF;
 
-	-- Check if the user has the specified permission on the specified proposal
+	-- Check if the user has the specified verb on the specified proposal
 	-- via direct user grant, group membership, or inherited from parent entities.
-	-- A granted 'manage' verb satisfies any verb check.
 	SELECT EXISTS (
 		SELECT 1
 		FROM proposals p
@@ -48,9 +47,8 @@ BEGIN
 			)
 		)
 		WHERE p.id = has_proposal_permission.proposal_id
-			AND (
-				has_proposal_permission.permission = ANY(pg.verbs)
-				OR 'manage' = ANY(pg.verbs)
+			AND verb_set_permits_verb(
+				pg.verbs, has_proposal_permission.verb
 			)
 			AND (
 				(

--- a/src/database/initialization/has_proposal_permission.sql
+++ b/src/database/initialization/has_proposal_permission.sql
@@ -14,7 +14,8 @@ BEGIN
 	END IF;
 
 	-- Check if the user has the specified permission on the specified proposal
-	-- via direct user grant, group membership, or inherited from parent entities
+	-- via direct user grant, group membership, or inherited from parent entities.
+	-- A granted 'manage' verb satisfies any verb check.
 	SELECT EXISTS (
 		SELECT 1
 		FROM proposals p
@@ -47,7 +48,10 @@ BEGIN
 			)
 		)
 		WHERE p.id = has_proposal_permission.proposal_id
-			AND has_proposal_permission.permission = ANY(pg.verbs)
+			AND (
+				has_proposal_permission.permission = ANY(pg.verbs)
+				OR 'manage' = ANY(pg.verbs)
+			)
 			AND (
 				(
 					pg.grantee_type = 'user'

--- a/src/database/initialization/has_source_permission.sql
+++ b/src/database/initialization/has_source_permission.sql
@@ -43,7 +43,11 @@ BEGIN
 			)
 		)
 		WHERE s.id = has_source_permission.source_id
-			AND has_source_permission.permission = ANY(pg.verbs)
+			-- A granted 'manage' verb satisfies any verb check.
+			AND (
+				has_source_permission.permission = ANY(pg.verbs)
+				OR 'manage' = ANY(pg.verbs)
+			)
 			AND has_source_permission.scope = ANY(pg.scope)
 			AND (
 				(

--- a/src/database/initialization/has_source_permission.sql
+++ b/src/database/initialization/has_source_permission.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION has_source_permission(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
 	source_id int,
-	permission permission_grant_verb_t,
+	verb permission_grant_verb_t,
 	scope permission_grant_entity_type_t
 ) RETURNS boolean AS $$
 DECLARE
@@ -13,7 +13,7 @@ BEGIN
 		RETURN TRUE;
 	END IF;
 
-	-- Check if the user has the specified permission on the specified source
+	-- Check if the user has the specified verb on the specified source
 	-- via direct user grant, group membership, or inherited from parent entities.
 	-- Inherited grants are treated the same as direct source grants: the grant's
 	-- scope array must include the requested scope.
@@ -43,10 +43,8 @@ BEGIN
 			)
 		)
 		WHERE s.id = has_source_permission.source_id
-			-- A granted 'manage' verb satisfies any verb check.
-			AND (
-				has_source_permission.permission = ANY(pg.verbs)
-				OR 'manage' = ANY(pg.verbs)
+			AND verb_set_permits_verb(
+				pg.verbs, has_source_permission.verb
 			)
 			AND has_source_permission.scope = ANY(pg.scope)
 			AND (

--- a/src/database/initialization/verb_set_permits_verb.sql
+++ b/src/database/initialization/verb_set_permits_verb.sql
@@ -1,0 +1,8 @@
+-- Returns TRUE when `verb` is in `verbs`, or when `verbs` contains 'manage'
+-- (a granted 'manage' verb satisfies any verb check).
+CREATE OR REPLACE FUNCTION verb_set_permits_verb(
+	verbs permission_grant_verb_t [],
+	verb permission_grant_verb_t
+) RETURNS boolean AS $$
+	SELECT verb = ANY(verbs) OR 'manage' = ANY(verbs);
+$$ LANGUAGE sql IMMUTABLE;


### PR DESCRIPTION
This PR expands `manage` so that it implicitly provides all verbs for the items it has been granted to.

I want to call out that "manage" does NOT affect permission inheritance (e.g. "manage opportunities of funder A" does not translate to "manage opportunities AND proposals associated with those opportunities"); an entity will still only have the permission applied to it according to scope.

Related to #2368