### PR TITLE
Add `any` scope to permission grant system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `any` to the permission grant entity type set. When `any` is included in a grant's `scope` array, that grant satisfies any scope check on its context (e.g., `view | any` on a funder context grants view access for funder-, opportunity-, proposal-, and proposal-field-value-scoped data on that funder, including scope types added in the future). `any` is also recognized as a context entity type for forward compatibility but is not yet accepted by the API as a context.
+
 ### Changed
 
 - The `manage` permission verb now satisfies any verb check on the scope to which it is granted. A grantee with `manage` on a given scope no longer needs the other verbs listed alongside it to perform view, create, edit, delete, or reference operations at that scope. Scope matching is unchanged: `manage` does not grant access to scopes that are not explicitly included in the grant.

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -197,6 +197,15 @@ a grantee holding `manage | proposal` does not gain access to `funder`-,
 `opportunity`-, or `source`-scoped data unless those scopes are also
 included in the grant.
 
+The `any` scope is treated as satisfying any scope check on the same context.
+A grant of `view | any` on a funder context, for example, lets the grantee
+view funder-, opportunity-, proposal-, and proposal-field-value-scoped data
+for that funder without naming each scope separately. The `any` scope is
+useful for "owner" or "admin"-style grants that should automatically extend
+to scope types added in the future. Combining `any` with `manage` (e.g.,
+`manage | any`) effectively grants full administrative access on the given
+context.
+
 The `reference` verb is separate from `view` and `create` so that permission to
 see an entity does not automatically imply permission to cite it from elsewhere,
 and permission to create entities in one context does not automatically imply

--- a/src/__tests__/permissionGrants.int.test.ts
+++ b/src/__tests__/permissionGrants.int.test.ts
@@ -2,8 +2,15 @@ import request from 'supertest';
 import { app } from '../app';
 import {
 	createOrUpdateFunder,
+	createProposal,
 	createSource,
 	getDatabase,
+	hasChangemakerPermission,
+	hasDataProviderPermission,
+	hasFunderPermission,
+	hasOpportunityPermission,
+	hasProposalPermission,
+	hasSourcePermission,
 	loadTableMetrics,
 	removeSource,
 } from '../database';
@@ -14,14 +21,21 @@ import {
 } from '../test/asymettricMatchers';
 import {
 	createTestChangemaker,
+	createTestDataProvider,
 	createTestFunder,
+	createTestOpportunity,
 	createTestPermissionGrant,
 } from '../test/factories';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as adminUserAuthHeader,
 } from '../test/mockJwt';
-import { getTestAuthContext, getTestUserKeycloakUserId } from '../test/utils';
+import {
+	getAuthContext,
+	getTestAuthContext,
+	getTestUserKeycloakUserId,
+	loadTestUser,
+} from '../test/utils';
 import {
 	nonNullKeycloakIdToString,
 	PermissionGrantEntityType,
@@ -441,6 +455,25 @@ describe('/permissionGrants', () => {
 			expect(result.body).toMatchObject({
 				name: 'InputValidationError',
 				details: expectArray(),
+			});
+		});
+
+		it('returns 400 bad request when contextEntityType is `any`', async () => {
+			const result = await agent
+				.post('/permissionGrants')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUserKeycloakUserId,
+					granteeKeycloakOrganizationId: null,
+					contextEntityType: 'any',
+					scope: ['any'],
+					verbs: ['view'],
+				})
+				.expect(400);
+			expect(result.body).toMatchObject({
+				name: 'InputValidationError',
 			});
 		});
 
@@ -1262,5 +1295,308 @@ describe('/permissionGrants', () => {
 				.set(adminUserAuthHeader)
 				.expect(404);
 		});
+	});
+});
+
+describe('`any` scope semantics', () => {
+	const expectAllTrue = async (
+		checks: Array<Promise<boolean>>,
+	): Promise<void> => {
+		const results = await Promise.all(checks);
+		results.forEach((result) => {
+			expect(result).toBe(true);
+		});
+	};
+
+	it('satisfies any scope check on a funder grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const funder = await createTestFunder(db, testUserAuthContext);
+
+		await agent
+			.post('/permissionGrants')
+			.type('application/json')
+			.set(adminUserAuthHeader)
+			.send({
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: funder.shortCode,
+				scope: [PermissionGrantEntityType.ANY],
+				verbs: [PermissionGrantVerb.VIEW],
+			})
+			.expect(201);
+
+		await expectAllTrue([
+			hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.FUNDER,
+			}),
+			hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.OPPORTUNITY,
+			}),
+			hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.PROPOSAL,
+			}),
+			hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
+			}),
+		]);
+	});
+
+	it('satisfies any scope check on a changemaker grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
+
+		await agent
+			.post('/permissionGrants')
+			.type('application/json')
+			.set(adminUserAuthHeader)
+			.send({
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+				changemakerId: changemaker.id,
+				scope: [PermissionGrantEntityType.ANY],
+				verbs: [PermissionGrantVerb.VIEW],
+			})
+			.expect(201);
+
+		await expectAllTrue([
+			hasChangemakerPermission(db, testUserAuthContext, {
+				changemakerId: changemaker.id,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.CHANGEMAKER,
+			}),
+			hasChangemakerPermission(db, testUserAuthContext, {
+				changemakerId: changemaker.id,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.PROPOSAL,
+			}),
+			hasChangemakerPermission(db, testUserAuthContext, {
+				changemakerId: changemaker.id,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.CHANGEMAKER_FIELD_VALUE,
+			}),
+		]);
+	});
+
+	it('does not extend `any` scope to a different context', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const ownedFunder = await createTestFunder(db, testUserAuthContext);
+		const otherFunder = await createTestFunder(db, testUserAuthContext);
+
+		await agent
+			.post('/permissionGrants')
+			.type('application/json')
+			.set(adminUserAuthHeader)
+			.send({
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: ownedFunder.shortCode,
+				scope: [PermissionGrantEntityType.ANY],
+				verbs: [PermissionGrantVerb.VIEW],
+			})
+			.expect(201);
+
+		expect(
+			await hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: otherFunder.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.FUNDER,
+			}),
+		).toBe(false);
+	});
+
+	it('does not satisfy a verb that is not in the grant', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const funder = await createTestFunder(db, testUserAuthContext);
+
+		await agent
+			.post('/permissionGrants')
+			.type('application/json')
+			.set(adminUserAuthHeader)
+			.send({
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: funder.shortCode,
+				scope: [PermissionGrantEntityType.ANY],
+				verbs: [PermissionGrantVerb.VIEW],
+			})
+			.expect(201);
+
+		expect(
+			await hasFunderPermission(db, testUserAuthContext, {
+				funderShortCode: funder.shortCode,
+				permission: PermissionGrantVerb.EDIT,
+				scope: PermissionGrantEntityType.FUNDER,
+			}),
+		).toBe(false);
+	});
+
+	it('combined with `manage` grants every verb on every scope', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const funder = await createTestFunder(db, testUserAuthContext);
+
+		await agent
+			.post('/permissionGrants')
+			.type('application/json')
+			.set(adminUserAuthHeader)
+			.send({
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: funder.shortCode,
+				scope: [PermissionGrantEntityType.ANY],
+				verbs: [PermissionGrantVerb.MANAGE],
+			})
+			.expect(201);
+
+		await expectAllTrue(
+			[
+				PermissionGrantVerb.VIEW,
+				PermissionGrantVerb.CREATE,
+				PermissionGrantVerb.EDIT,
+				PermissionGrantVerb.DELETE,
+				PermissionGrantVerb.REFERENCE,
+			].flatMap((verb) => [
+				hasFunderPermission(db, testUserAuthContext, {
+					funderShortCode: funder.shortCode,
+					permission: verb,
+					scope: PermissionGrantEntityType.FUNDER,
+				}),
+				hasFunderPermission(db, testUserAuthContext, {
+					funderShortCode: funder.shortCode,
+					permission: verb,
+					scope: PermissionGrantEntityType.OPPORTUNITY,
+				}),
+				hasFunderPermission(db, testUserAuthContext, {
+					funderShortCode: funder.shortCode,
+					permission: verb,
+					scope: PermissionGrantEntityType.PROPOSAL,
+				}),
+			]),
+		);
+	});
+
+	it('extends to opportunities inherited from a funder', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const funder = await createTestFunder(db, testUserAuthContext);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext, {
+			funderShortCode: funder.shortCode,
+		});
+
+		await agent
+			.post('/permissionGrants')
+			.type('application/json')
+			.set(adminUserAuthHeader)
+			.send({
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: funder.shortCode,
+				scope: [PermissionGrantEntityType.ANY],
+				verbs: [PermissionGrantVerb.VIEW],
+			})
+			.expect(201);
+
+		expect(
+			await hasOpportunityPermission(db, testUserAuthContext, {
+				opportunityId: opportunity.id,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.OPPORTUNITY,
+			}),
+		).toBe(true);
+	});
+
+	it('extends to sources inherited from a data provider', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const dataProvider = await createTestDataProvider(db, testUserAuthContext);
+		const source = await createSource(db, testUserAuthContext, {
+			label: 'DP-owned Source',
+			dataProviderShortCode: dataProvider.shortCode,
+		});
+
+		await agent
+			.post('/permissionGrants')
+			.type('application/json')
+			.set(adminUserAuthHeader)
+			.send({
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
+				dataProviderShortCode: dataProvider.shortCode,
+				scope: [PermissionGrantEntityType.ANY],
+				verbs: [PermissionGrantVerb.VIEW],
+			})
+			.expect(201);
+
+		await expectAllTrue([
+			hasDataProviderPermission(db, testUserAuthContext, {
+				dataProviderShortCode: dataProvider.shortCode,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.DATA_PROVIDER,
+			}),
+			hasSourcePermission(db, testUserAuthContext, {
+				sourceId: source.id,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.SOURCE,
+			}),
+		]);
+	});
+
+	it('extends to a proposal inherited from an opportunity', async () => {
+		const db = getDatabase();
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser);
+		const opportunity = await createTestOpportunity(db, testUserAuthContext);
+		const proposal = await createProposal(db, testUserAuthContext, {
+			externalId: 'any-scope-inherited-proposal',
+			opportunityId: opportunity.id,
+		});
+
+		await agent
+			.post('/permissionGrants')
+			.type('application/json')
+			.set(adminUserAuthHeader)
+			.send({
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.OPPORTUNITY,
+				opportunityId: opportunity.id,
+				scope: [PermissionGrantEntityType.ANY],
+				verbs: [PermissionGrantVerb.VIEW],
+			})
+			.expect(201);
+
+		expect(
+			await hasProposalPermission(db, testUserAuthContext, {
+				proposalId: proposal.id,
+				permission: PermissionGrantVerb.VIEW,
+				scope: PermissionGrantEntityType.PROPOSAL,
+			}),
+		).toBe(true);
 	});
 });

--- a/src/database/initialization/has_changemaker_field_value_permission.sql
+++ b/src/database/initialization/has_changemaker_field_value_permission.sql
@@ -43,16 +43,15 @@ BEGIN
 			(
 				pg.context_entity_type = 'changemakerFieldValue'
 				AND pg.changemaker_field_value_id = cfv.id
-				AND has_changemaker_field_value_permission.scope = ANY(pg.scope)
 			)
-			-- Inherited from changemaker with changemakerFieldValue scope
+			-- Inherited from changemaker
 			OR (
 				pg.context_entity_type = 'changemaker'
 				AND pg.changemaker_id = cfv.changemaker_id
-				AND 'changemakerFieldValue' = ANY(pg.scope)
 			)
 		)
 		WHERE cfv.id = has_changemaker_field_value_permission.changemaker_field_value_id
+			AND has_changemaker_field_value_permission.scope = ANY(pg.scope)
 			AND verb_set_permits_verb(
 				pg.verbs, has_changemaker_field_value_permission.verb
 			)

--- a/src/database/initialization/has_changemaker_field_value_permission.sql
+++ b/src/database/initialization/has_changemaker_field_value_permission.sql
@@ -51,7 +51,9 @@ BEGIN
 			)
 		)
 		WHERE cfv.id = has_changemaker_field_value_permission.changemaker_field_value_id
-			AND has_changemaker_field_value_permission.scope = ANY(pg.scope)
+			AND scope_set_permits_scope(
+				pg.scope, has_changemaker_field_value_permission.scope
+			)
 			AND verb_set_permits_verb(
 				pg.verbs, has_changemaker_field_value_permission.verb
 			)

--- a/src/database/initialization/has_changemaker_permission.sql
+++ b/src/database/initialization/has_changemaker_permission.sql
@@ -26,7 +26,9 @@ BEGIN
 			AND verb_set_permits_verb(
 				pg.verbs, has_changemaker_permission.verb
 			)
-			AND has_changemaker_permission.scope = ANY(pg.scope)
+			AND scope_set_permits_scope(
+				pg.scope, has_changemaker_permission.scope
+			)
 			AND (
 				(
 					pg.grantee_type = 'user'

--- a/src/database/initialization/has_data_provider_permission.sql
+++ b/src/database/initialization/has_data_provider_permission.sql
@@ -26,7 +26,9 @@ BEGIN
 			AND verb_set_permits_verb(
 				pg.verbs, has_data_provider_permission.verb
 			)
-			AND has_data_provider_permission.scope = ANY(pg.scope)
+			AND scope_set_permits_scope(
+				pg.scope, has_data_provider_permission.scope
+			)
 			AND (
 				(
 					pg.grantee_type = 'user'

--- a/src/database/initialization/has_funder_permission.sql
+++ b/src/database/initialization/has_funder_permission.sql
@@ -26,7 +26,9 @@ BEGIN
 			AND verb_set_permits_verb(
 				pg.verbs, has_funder_permission.verb
 			)
-			AND has_funder_permission.scope = ANY(pg.scope)
+			AND scope_set_permits_scope(
+				pg.scope, has_funder_permission.scope
+			)
 			AND (
 				(
 					pg.grantee_type = 'user'

--- a/src/database/initialization/has_opportunity_permission.sql
+++ b/src/database/initialization/has_opportunity_permission.sql
@@ -36,7 +36,9 @@ BEGIN
 			AND verb_set_permits_verb(
 				pg.verbs, has_opportunity_permission.verb
 			)
-			AND has_opportunity_permission.scope = ANY(pg.scope)
+			AND scope_set_permits_scope(
+				pg.scope, has_opportunity_permission.scope
+			)
 			AND (
 				(
 					pg.grantee_type = 'user'

--- a/src/database/initialization/has_proposal_field_value_permission.sql
+++ b/src/database/initialization/has_proposal_field_value_permission.sql
@@ -49,34 +49,30 @@ BEGIN
 			(
 				pg.context_entity_type = 'proposalFieldValue'
 				AND pg.proposal_field_value_id = pfv.id
-				AND has_proposal_field_value_permission.scope = ANY(pg.scope)
 			)
-			-- Inherited from proposal with proposalFieldValue scope
+			-- Inherited from proposal
 			OR (
 				pg.context_entity_type = 'proposal'
 				AND pg.proposal_id = pv.proposal_id
-				AND 'proposalFieldValue' = ANY(pg.scope)
 			)
-			-- Inherited from opportunity with proposalFieldValue scope
+			-- Inherited from opportunity
 			OR (
 				pg.context_entity_type = 'opportunity'
 				AND pg.opportunity_id = p.opportunity_id
-				AND 'proposalFieldValue' = ANY(pg.scope)
 			)
-			-- Inherited from funder with proposalFieldValue scope
+			-- Inherited from funder
 			OR (
 				pg.context_entity_type = 'funder'
 				AND pg.funder_short_code = o.funder_short_code
-				AND 'proposalFieldValue' = ANY(pg.scope)
 			)
-			-- Inherited from changemaker with proposalFieldValue scope
+			-- Inherited from changemaker
 			OR (
 				pg.context_entity_type = 'changemaker'
 				AND pg.changemaker_id = cp.changemaker_id
-				AND 'proposalFieldValue' = ANY(pg.scope)
 			)
 		)
 		WHERE pfv.id = has_proposal_field_value_permission.proposal_field_value_id
+			AND has_proposal_field_value_permission.scope = ANY(pg.scope)
 			AND verb_set_permits_verb(
 				pg.verbs, has_proposal_field_value_permission.verb
 			)

--- a/src/database/initialization/has_proposal_field_value_permission.sql
+++ b/src/database/initialization/has_proposal_field_value_permission.sql
@@ -72,7 +72,9 @@ BEGIN
 			)
 		)
 		WHERE pfv.id = has_proposal_field_value_permission.proposal_field_value_id
-			AND has_proposal_field_value_permission.scope = ANY(pg.scope)
+			AND scope_set_permits_scope(
+				pg.scope, has_proposal_field_value_permission.scope
+			)
 			AND verb_set_permits_verb(
 				pg.verbs, has_proposal_field_value_permission.verb
 			)

--- a/src/database/initialization/has_proposal_permission.sql
+++ b/src/database/initialization/has_proposal_permission.sql
@@ -27,28 +27,25 @@ BEGIN
 			(
 				pg.context_entity_type = 'proposal'
 				AND pg.proposal_id = p.id
-				AND has_proposal_permission.scope = ANY(pg.scope)
 			)
-			-- Inherited from opportunity with proposal scope
+			-- Inherited from opportunity
 			OR (
 				pg.context_entity_type = 'opportunity'
 				AND pg.opportunity_id = p.opportunity_id
-				AND 'proposal' = ANY(pg.scope)
 			)
-			-- Inherited from funder with proposal scope
+			-- Inherited from funder
 			OR (
 				pg.context_entity_type = 'funder'
 				AND pg.funder_short_code = o.funder_short_code
-				AND 'proposal' = ANY(pg.scope)
 			)
-			-- Inherited from changemaker with proposal scope
+			-- Inherited from changemaker
 			OR (
 				pg.context_entity_type = 'changemaker'
 				AND pg.changemaker_id = cp.changemaker_id
-				AND 'proposal' = ANY(pg.scope)
 			)
 		)
 		WHERE p.id = has_proposal_permission.proposal_id
+			AND has_proposal_permission.scope = ANY(pg.scope)
 			AND verb_set_permits_verb(
 				pg.verbs, has_proposal_permission.verb
 			)

--- a/src/database/initialization/has_proposal_permission.sql
+++ b/src/database/initialization/has_proposal_permission.sql
@@ -45,7 +45,9 @@ BEGIN
 			)
 		)
 		WHERE p.id = has_proposal_permission.proposal_id
-			AND has_proposal_permission.scope = ANY(pg.scope)
+			AND scope_set_permits_scope(
+				pg.scope, has_proposal_permission.scope
+			)
 			AND verb_set_permits_verb(
 				pg.verbs, has_proposal_permission.verb
 			)

--- a/src/database/initialization/has_source_permission.sql
+++ b/src/database/initialization/has_source_permission.sql
@@ -48,7 +48,9 @@ BEGIN
 			AND verb_set_permits_verb(
 				pg.verbs, has_source_permission.verb
 			)
-			AND has_source_permission.scope = ANY(pg.scope)
+			AND scope_set_permits_scope(
+				pg.scope, has_source_permission.scope
+			)
 			AND (
 				(
 					pg.grantee_type = 'user'

--- a/src/database/initialization/scope_set_permits_scope.sql
+++ b/src/database/initialization/scope_set_permits_scope.sql
@@ -1,0 +1,10 @@
+SELECT drop_function('scope_set_permits_scope');
+
+-- Returns TRUE when `scope` is in `scopes`, or when `scopes` contains 'any'
+-- (a granted 'any' scope satisfies any scope check).
+CREATE FUNCTION scope_set_permits_scope(
+	scopes permission_grant_entity_type_t [],
+	scope permission_grant_entity_type_t
+) RETURNS boolean AS $$
+	SELECT scope = ANY(scopes) OR 'any' = ANY(scopes);
+$$ LANGUAGE sql IMMUTABLE;

--- a/src/database/migrations/0109-add-any-to-permission_grant_entity_type_t.sql
+++ b/src/database/migrations/0109-add-any-to-permission_grant_entity_type_t.sql
@@ -1,0 +1,1 @@
+ALTER TYPE permission_grant_entity_type_t ADD VALUE IF NOT EXISTS 'any';

--- a/src/handlers/permissionGrantsHandlers.ts
+++ b/src/handlers/permissionGrantsHandlers.ts
@@ -22,12 +22,23 @@ import {
 	isAuthContext,
 	isId,
 	isWritablePermissionGrant,
-	type PermissionGrantEntityType,
+	PermissionGrantEntityType,
 	type PermissionGrantCondition,
 	type WritableUnkeyedPermissionGrant,
 } from '../types';
 import { coerceParams } from '../coercion';
 import type { Request, Response } from 'express';
+
+const assertPermissionGrantContextEntityTypeIsSupported = (
+	permissionGrant: WritableUnkeyedPermissionGrant,
+): void => {
+	if (permissionGrant.contextEntityType === PermissionGrantEntityType.ANY) {
+		throw new InputValidationError(
+			`Context entity type "${PermissionGrantEntityType.ANY}" is not currently supported.`,
+			[],
+		);
+	}
+};
 
 const assertPermissionGrantHasValidScope = (
 	permissionGrant: WritableUnkeyedPermissionGrant,
@@ -143,6 +154,7 @@ const postPermissionGrant = async (
 		);
 	}
 
+	assertPermissionGrantContextEntityTypeIsSupported(body);
 	assertPermissionGrantHasValidScope(body);
 	assertPermissionGrantHasValidConditions(body);
 	const permissionGrant = await createPermissionGrant(db, req, body);
@@ -201,6 +213,7 @@ const putPermissionGrant = async (
 		);
 	}
 
+	assertPermissionGrantContextEntityTypeIsSupported(body);
 	assertPermissionGrantHasValidScope(body);
 	assertPermissionGrantHasValidConditions(body);
 

--- a/src/openapi/components/schemas/ApplicationFormFieldPermissionGrant.json
+++ b/src/openapi/components/schemas/ApplicationFormFieldPermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["applicationFormField"]
+						"enum": ["applicationFormField", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/ApplicationFormPermissionGrant.json
+++ b/src/openapi/components/schemas/ApplicationFormPermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["applicationForm"]
+						"enum": ["applicationForm", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/BulkUploadPermissionGrant.json
+++ b/src/openapi/components/schemas/BulkUploadPermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["bulkUpload"]
+						"enum": ["bulkUpload", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/ChangemakerFieldValuePermissionGrant.json
+++ b/src/openapi/components/schemas/ChangemakerFieldValuePermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["changemakerFieldValue"]
+						"enum": ["changemakerFieldValue", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/ChangemakerPermissionGrant.json
+++ b/src/openapi/components/schemas/ChangemakerPermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["changemaker"]
+						"enum": ["changemaker", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/DataProviderPermissionGrant.json
+++ b/src/openapi/components/schemas/DataProviderPermissionGrant.json
@@ -17,7 +17,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["dataProvider"]
+						"enum": ["dataProvider", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/FunderPermissionGrant.json
+++ b/src/openapi/components/schemas/FunderPermissionGrant.json
@@ -17,7 +17,13 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["funder", "opportunity", "proposal", "proposalFieldValue"]
+						"enum": [
+							"funder",
+							"opportunity",
+							"proposal",
+							"proposalFieldValue",
+							"any"
+						]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/OpportunityPermissionGrant.json
+++ b/src/openapi/components/schemas/OpportunityPermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["opportunity", "proposal", "proposalFieldValue"]
+						"enum": ["opportunity", "proposal", "proposalFieldValue", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/PermissionGrantEntityType.json
+++ b/src/openapi/components/schemas/PermissionGrantEntityType.json
@@ -12,6 +12,7 @@
 		"proposalFieldValue",
 		"source",
 		"bulkUpload",
-		"changemakerFieldValue"
+		"changemakerFieldValue",
+		"any"
 	]
 }

--- a/src/openapi/components/schemas/ProposalFieldValuePermissionGrant.json
+++ b/src/openapi/components/schemas/ProposalFieldValuePermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["proposalFieldValue"]
+						"enum": ["proposalFieldValue", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/ProposalPermissionGrant.json
+++ b/src/openapi/components/schemas/ProposalPermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["proposal"]
+						"enum": ["proposal", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/ProposalVersionPermissionGrant.json
+++ b/src/openapi/components/schemas/ProposalVersionPermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["proposalVersion"]
+						"enum": ["proposalVersion", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/openapi/components/schemas/SourcePermissionGrant.json
+++ b/src/openapi/components/schemas/SourcePermissionGrant.json
@@ -16,7 +16,7 @@
 					"type": "array",
 					"items": {
 						"type": "string",
-						"enum": ["source"]
+						"enum": ["source", "any"]
 					},
 					"minItems": 1
 				}

--- a/src/types/PermissionGrant.ts
+++ b/src/types/PermissionGrant.ts
@@ -27,6 +27,7 @@ enum PermissionGrantEntityType {
 	SOURCE = 'source',
 	BULK_UPLOAD = 'bulkUpload',
 	CHANGEMAKER_FIELD_VALUE = 'changemakerFieldValue',
+	ANY = 'any',
 }
 
 enum PermissionGrantEntityKeyType {
@@ -105,12 +106,22 @@ const contextEntityKeyProperties = {
 		keyName: 'changemakerFieldValueId',
 		keyType: PermissionGrantEntityKeyType.ID,
 	},
-} as const satisfies Record<
-	PermissionGrantEntityType,
-	{ keyName: string; keyType: PermissionGrantEntityKeyType }
+} as const satisfies Omit<
+	Record<
+		PermissionGrantEntityType,
+		{ keyName: string; keyType: PermissionGrantEntityKeyType }
+	>,
+	PermissionGrantEntityType.ANY
 >;
 
-const contextEntityTypeScopes = {
+type PermissionGrantKeyedContextEntityType =
+	keyof typeof contextEntityKeyProperties;
+
+// Scopes that are valid against any context entity type, appended to a
+// context's native scopes by `getScopesForContextEntityType` below.
+const universalScopes = [PermissionGrantEntityType.ANY] as const;
+
+const contextEntityTypeNativeScopes = {
 	[PermissionGrantEntityType.CHANGEMAKER]: [
 		PermissionGrantEntityType.CHANGEMAKER,
 		PermissionGrantEntityType.CHANGEMAKER_FIELD_VALUE,
@@ -154,6 +165,7 @@ const contextEntityTypeScopes = {
 	[PermissionGrantEntityType.CHANGEMAKER_FIELD_VALUE]: [
 		PermissionGrantEntityType.CHANGEMAKER_FIELD_VALUE,
 	],
+	[PermissionGrantEntityType.ANY]: [],
 } as const satisfies Record<
 	PermissionGrantEntityType,
 	readonly PermissionGrantEntityType[]
@@ -178,6 +190,7 @@ const scopeConditions = {
 	[PermissionGrantEntityType.SOURCE]: [],
 	[PermissionGrantEntityType.BULK_UPLOAD]: [],
 	[PermissionGrantEntityType.CHANGEMAKER_FIELD_VALUE]: [],
+	[PermissionGrantEntityType.ANY]: [],
 } as const satisfies Record<
 	PermissionGrantEntityType,
 	readonly PermissionGrantCondition[]
@@ -204,7 +217,7 @@ type GranteeKeysByGranteeType = {
 };
 
 type ContextEntityKeysByContextEntityType = {
-	[T in PermissionGrantEntityType]: Record<
+	[T in PermissionGrantKeyedContextEntityType]: Record<
 		(typeof contextEntityKeyProperties)[T]['keyName'],
 		PermissionGrantEntityKeyValueType[(typeof contextEntityKeyProperties)[T]['keyType']]
 	>;
@@ -217,9 +230,11 @@ type PermissionGrantGranteeKeyVariant<G extends PermissionGrantGranteeType> =
 
 type PermissionGrantContextEntityKeyVariant<
 	C extends PermissionGrantEntityType,
-> = ContextEntityKeysByContextEntityType[C] & {
-	contextEntityType: C;
-};
+> = C extends PermissionGrantKeyedContextEntityType
+	? ContextEntityKeysByContextEntityType[C] & {
+			contextEntityType: C;
+		}
+	: { contextEntityType: C };
 
 type PermissionGrant = UnkeyedPermissionGrant &
 	{
@@ -294,12 +309,12 @@ const isWritableUnkeyedPermissionGrant =
 	});
 
 const contextKeyValidatorCache = new Map<
-	PermissionGrantEntityType,
+	PermissionGrantKeyedContextEntityType,
 	ValidateFunction
 >();
 
 const getContextKeyValidator = (
-	contextEntityType: PermissionGrantEntityType,
+	contextEntityType: PermissionGrantKeyedContextEntityType,
 ): ValidateFunction => {
 	const existing = contextKeyValidatorCache.get(contextEntityType);
 	if (existing !== undefined) {
@@ -355,12 +370,19 @@ const coreWritableKeys = new Set([
 	'conditions',
 ]);
 
+const isPermissionGrantKeyedContextEntityType = (
+	contextEntityType: PermissionGrantEntityType,
+): contextEntityType is PermissionGrantKeyedContextEntityType =>
+	contextEntityType in contextEntityKeyProperties;
+
 const getAllowedKeys = (
 	contextEntityType: PermissionGrantEntityType,
 	granteeType: PermissionGrantGranteeType,
 ): Set<string> => {
 	const allowed = new Set(coreWritableKeys);
-	allowed.add(contextEntityKeyProperties[contextEntityType].keyName);
+	if (isPermissionGrantKeyedContextEntityType(contextEntityType)) {
+		allowed.add(contextEntityKeyProperties[contextEntityType].keyName);
+	}
 	allowed.add(granteeKeyProperties[granteeType].keyName);
 	return allowed;
 };
@@ -376,10 +398,12 @@ const isWritablePermissionGrant: TypeGuardWithAjvErrors<
 
 	const { contextEntityType, granteeType } = data;
 
-	const validateContextKey = getContextKeyValidator(contextEntityType);
-	if (!validateContextKey(data)) {
-		isWritablePermissionGrant.errors = validateContextKey.errors ?? null;
-		return false;
+	if (isPermissionGrantKeyedContextEntityType(contextEntityType)) {
+		const validateContextKey = getContextKeyValidator(contextEntityType);
+		if (!validateContextKey(data)) {
+			isWritablePermissionGrant.errors = validateContextKey.errors ?? null;
+			return false;
+		}
 	}
 
 	const validateGranteeKey = getGranteeKeyValidator(granteeType);
@@ -409,8 +433,10 @@ const isWritablePermissionGrant: TypeGuardWithAjvErrors<
 
 const getScopesForContextEntityType = (
 	contextEntityType: PermissionGrantEntityType,
-): readonly PermissionGrantEntityType[] =>
-	contextEntityTypeScopes[contextEntityType];
+): readonly PermissionGrantEntityType[] => [
+	...contextEntityTypeNativeScopes[contextEntityType],
+	...universalScopes,
+];
 
 const getConditionsForScope = (
 	scopeKey: PermissionGrantEntityType,


### PR DESCRIPTION
This PR adds the `any` scope to the permission system which allows the creation of permissions that apply to all types of related entity to a given context.

Resolves #2368