### PR TITLE
Add a permission to preview envs `post-app`

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -143,6 +143,7 @@ jobs:
   post-app:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     if: |
       !cancelled() &&


### PR DESCRIPTION
Explicit `contents: read` may be needed for a comments action to work for all users. See
https://github.com/thollander/actions-comment-pull-request/issues/181#issuecomment-2151213457 and
https://github.com/PhilanthropyDataCommons/service/issues/1275#issuecomment-4345158519

Issue #1275 Build out PR deploy previews