### PR TITLE
Remove leading slash from `api.json` path

### DIFF
--- a/src/routers/documentationRouter.ts
+++ b/src/routers/documentationRouter.ts
@@ -21,7 +21,7 @@ const options: SwaggerUiOptions = {
 			usePkceWithAuthorizationCodeGrant: true,
 		},
 	},
-	swaggerUrl: '/openapi/api.json',
+	swaggerUrl: 'openapi/api.json',
 };
 
 const documentationRouter = express.Router();


### PR DESCRIPTION
The `npm build` process compiles an `api.json` from many smaller components and then the documentationRouter serves it. When using a context root or path in the URL beyond a slash, such as in preview environments, everything but the `api.json` can be found. Perhaps removing this slash will help.

Issue #2383 OpenAPI `api.json` relative URL needed Issue #1275 Build out PR deploy previews (found here)