### PR TITLE
Set an OpenAPI server URL of `/`

### DIFF
--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -9,6 +9,11 @@
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"
 		}
 	},
+	"servers": [
+		{
+			"url": "/"
+		}
+	],
 	"components": {
 		"responses": {
 			"NotFound": {

--- a/src/routers/documentationRouter.ts
+++ b/src/routers/documentationRouter.ts
@@ -21,7 +21,7 @@ const options: SwaggerUiOptions = {
 			usePkceWithAuthorizationCodeGrant: true,
 		},
 	},
-	swaggerUrl: '/openapi/api.json',
+	swaggerUrl: 'openapi/api.json',
 };
 
 const documentationRouter = express.Router();


### PR DESCRIPTION
This is a long-shot attempt at fixing relative URLs in SwaggerUI.

Issue #2385 OpenAPI docs needs relative URLs for all endpoints