### PR TITLE
Set an OpenAPI server URL of `/..`

### DIFF
--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -389,5 +389,10 @@
 		"/users": {
 			"$ref": "./paths/users.json"
 		}
-	}
+	},
+	"servers": [
+		{
+			"url": "/.."
+		}
+	]
 }

--- a/src/routers/documentationRouter.ts
+++ b/src/routers/documentationRouter.ts
@@ -21,7 +21,7 @@ const options: SwaggerUiOptions = {
 			usePkceWithAuthorizationCodeGrant: true,
 		},
 	},
-	swaggerUrl: '/openapi/api.json',
+	swaggerUrl: 'openapi/api.json',
 };
 
 const documentationRouter = express.Router();


### PR DESCRIPTION
It's another long-shot attempt at fixing relative URLs in SwaggerUI.

Issue #2385 OpenAPI docs needs relative URLs for all endpoints