### PR TITLE
Decorate permissions grant with user entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Permission grant responses now include a `createdByUser` field containing the full user entity, similar to what we've
+  implemented for Bulk Uploads.
+
 ### Changed
 
 - Upsert endpoints now distinguish a created row from an updated one via the HTTP response status: a fresh insert returns `201 Created`, while updating an existing row returns `200 OK`. This applies to `PUT /baseFields/:shortCode`, `PUT /baseFields/:shortCode/localizations/:language`, `PUT /changemakers/:id/fiscalSponsors/:fiscalSponsorChangemakerId`, `PUT /dataProviders/:shortCode`, `PUT /funders/:shortCode`, `POST /funders/:shortCode/members/:memberFunderShortCode`, and `POST /funders/:shortCode/invitations/sent/:invitedFunderShortCode`. Previously each endpoint returned a fixed status (some `200`, some `201`) regardless of whether a row was inserted or updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.36.0 2026-05-12
 
 ### Added
 

--- a/src/__tests__/permissionGrants.int.test.ts
+++ b/src/__tests__/permissionGrants.int.test.ts
@@ -72,6 +72,7 @@ describe('/permissionGrants', () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
 			const permissionGrant = await createTestPermissionGrant(db, authContext);
+			const expectedCreatedByUser = await loadTestUser(db);
 
 			const response = await agent
 				.get('/permissionGrants')
@@ -90,6 +91,7 @@ describe('/permissionGrants', () => {
 						scope: ['changemaker'],
 						verbs: ['view'],
 						createdBy: testUserKeycloakUserId,
+						createdByUser: expectedCreatedByUser,
 						createdAt: expectTimestamp(),
 					},
 				],
@@ -141,6 +143,7 @@ describe('/permissionGrants', () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
 			const permissionGrant = await createTestPermissionGrant(db, authContext);
+			const expectedCreatedByUser = await loadTestUser(db);
 
 			const response = await agent
 				.get(`/permissionGrants/${permissionGrant.id}`)
@@ -157,6 +160,7 @@ describe('/permissionGrants', () => {
 				scope: ['changemaker'],
 				verbs: ['view'],
 				createdBy: testUserKeycloakUserId,
+				createdByUser: expectedCreatedByUser,
 				createdAt: expectTimestamp(),
 			});
 		});
@@ -235,6 +239,7 @@ describe('/permissionGrants', () => {
 				})
 				.expect(201);
 			const after = await loadTableMetrics(db, 'permission_grants');
+			const expectedCreatedByUser = await loadTestUser(db);
 
 			expect(result.body).toMatchObject({
 				id: expectNumber(),
@@ -245,6 +250,7 @@ describe('/permissionGrants', () => {
 				scope: ['changemaker'],
 				verbs: ['view', 'edit'],
 				createdBy: testUserKeycloakUserId,
+				createdByUser: expectedCreatedByUser,
 				createdAt: expectTimestamp(),
 			});
 			expect(after.count).toEqual(before.count + 1);
@@ -270,6 +276,7 @@ describe('/permissionGrants', () => {
 				})
 				.expect(201);
 			const after = await loadTableMetrics(db, 'permission_grants');
+			const expectedCreatedByUser = await loadTestUser(db);
 
 			expect(result.body).toMatchObject({
 				id: expectNumber(),
@@ -280,6 +287,7 @@ describe('/permissionGrants', () => {
 				scope: ['funder'],
 				verbs: ['view', 'create'],
 				createdBy: testUserKeycloakUserId,
+				createdByUser: expectedCreatedByUser,
 				createdAt: expectTimestamp(),
 			});
 			expect(after.count).toEqual(before.count + 1);
@@ -304,6 +312,7 @@ describe('/permissionGrants', () => {
 					verbs: ['view'],
 				})
 				.expect(201);
+			const expectedCreatedByUser = await loadTestUser(db);
 
 			expect(result.body).toMatchObject({
 				id: expectNumber(),
@@ -314,6 +323,7 @@ describe('/permissionGrants', () => {
 				scope: ['changemaker'],
 				verbs: ['view'],
 				createdBy: testUserKeycloakUserId,
+				createdByUser: expectedCreatedByUser,
 				createdAt: expectTimestamp(),
 			});
 		});
@@ -690,6 +700,7 @@ describe('/permissionGrants', () => {
 					},
 				})
 				.expect(201);
+			const expectedCreatedByUser = await loadTestUser(db);
 
 			expect(result.body).toMatchObject({
 				id: expectNumber(),
@@ -707,6 +718,7 @@ describe('/permissionGrants', () => {
 					},
 				},
 				createdBy: testUserKeycloakUserId,
+				createdByUser: expectedCreatedByUser,
 				createdAt: expectTimestamp(),
 			});
 		});
@@ -894,6 +906,7 @@ describe('/permissionGrants', () => {
 				scope: [PermissionGrantEntityType.CHANGEMAKER],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
+			const expectedCreatedByUser = await loadTestUser(db);
 
 			const response = await agent
 				.put(`/permissionGrants/${permissionGrant.id}`)
@@ -918,6 +931,7 @@ describe('/permissionGrants', () => {
 				scope: ['changemaker'],
 				verbs: ['view', 'edit'],
 				createdBy: testUserKeycloakUserId,
+				createdByUser: expectedCreatedByUser,
 				createdAt: expectTimestamp(),
 			});
 		});

--- a/src/database/initialization/permission_grant_to_json.sql
+++ b/src/database/initialization/permission_grant_to_json.sql
@@ -2,7 +2,14 @@ SELECT drop_function('permission_grant_to_json');
 
 CREATE FUNCTION permission_grant_to_json(permission_grant permission_grants)
 RETURNS jsonb AS $$
+DECLARE
+	created_by_user_json JSONB;
 BEGIN
+	SELECT user_to_json(users.*, NULL::uuid, FALSE)
+	INTO created_by_user_json
+	FROM users
+	WHERE users.keycloak_user_id = permission_grant.created_by;
+
 	RETURN jsonb_build_object(
 		'id', permission_grant.id,
 		'granteeType', permission_grant.grantee_type,
@@ -13,6 +20,7 @@ BEGIN
 		'scope', permission_grant.scope,
 		'verbs', permission_grant.verbs,
 		'createdBy', permission_grant.created_by,
+		'createdByUser', created_by_user_json,
 		'conditions', permission_grant.conditions,
 		'createdAt', permission_grant.created_at
 	) || CASE permission_grant.context_entity_type

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.35.0",
+		"version": "0.36.0",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"

--- a/src/openapi/components/schemas/PermissionGrantBase.json
+++ b/src/openapi/components/schemas/PermissionGrantBase.json
@@ -40,6 +40,11 @@
 			"description": "The Keycloak user ID of the user who created this grant.",
 			"example": "770e8400-e29b-41d4-a716-446655440002"
 		},
+		"createdByUser": {
+			"$ref": "./User.json",
+			"readOnly": true,
+			"description": "The user record for the user who created this grant."
+		},
 		"createdAt": {
 			"type": "string",
 			"format": "date-time",

--- a/src/types/PermissionGrant.ts
+++ b/src/types/PermissionGrant.ts
@@ -11,6 +11,7 @@ import type { TypeGuardWithAjvErrors } from '../ajv';
 import type { Id } from './Id';
 import type { KeycloakId } from './KeycloakId';
 import type { PermissionGrantVerb } from './PermissionGrantVerb';
+import type { User } from './User';
 import type { Writable } from './Writable';
 import type { ValidateFunction } from 'ajv';
 
@@ -200,6 +201,7 @@ interface UnkeyedPermissionGrant {
 	readonly id: Id;
 	verbs: PermissionGrantVerb[];
 	readonly createdBy: KeycloakId;
+	readonly createdByUser: User;
 	readonly createdAt: string;
 	contextEntityType: PermissionGrantEntityType;
 	granteeType: PermissionGrantGranteeType;


### PR DESCRIPTION
This PR adds the user entity as a decorated field on the permission grant entity in the initilization function. This gives us access to the human-readable name for the grant creator, which is a useful feature to have for our front-end permissions interface

Closes #2396 