### PR TITLE
Grant permissions on entity creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Creating an entity now automatically grants the creator a `manage` permission with `any` scope on the new entity. This applies to opportunities, changemakers, proposals, sources, bulk upload tasks, application forms (and their fields), proposal versions (and their field values), and changemaker field values created via the HTTP API, as well as proposals, proposal versions, proposal field values, and newly inserted changemakers created during bulk upload processing.
+
 ## 0.36.0 2026-05-12
 
 ### Added

--- a/src/__tests__/applicationForms.int.test.ts
+++ b/src/__tests__/applicationForms.int.test.ts
@@ -6,6 +6,7 @@ import {
 	createOrUpdateBaseField,
 	createPermissionGrant,
 	getDatabase,
+	loadPermissionGrantBundle,
 	loadSystemUser,
 	loadTableMetrics,
 } from '../database';
@@ -21,8 +22,18 @@ import {
 	PermissionGrantGranteeType,
 	PermissionGrantVerb,
 } from '../types';
-import { getAuthContext, loadTestUser } from '../test/utils';
-import { expectArray, expectTimestamp } from '../test/asymettricMatchers';
+import {
+	getAuthContext,
+	loadTestUser,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../test/utils';
+import {
+	expectArray,
+	expectArrayContaining,
+	expectObjectContaining,
+	expectTimestamp,
+} from '../test/asymettricMatchers';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
@@ -755,6 +766,60 @@ describe('/applicationForms', () => {
 				createdAt: expectTimestamp(),
 			});
 			expect(after.count).toEqual(before.count + 1);
+		});
+
+		it('grants the creator a manage permission on the new form and each field', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, null, {
+				shortCode: 'self_grant_field',
+			});
+			await request(app)
+				.post('/applicationForms')
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					opportunityId: opportunity.id,
+					name: 'Self-grant Form',
+					fields: [
+						{
+							baseFieldShortCode: baseField.shortCode,
+							label: 'Field Label',
+							position: 1,
+							instructions: null,
+							inputType: null,
+						},
+					],
+				})
+				.expect(201);
+			const grants = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(grants.entries).toEqual(
+				expectArrayContaining([
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: testUser.keycloakUserId,
+						contextEntityType: 'applicationForm',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: testUser.keycloakUserId,
+						contextEntityType: 'applicationFormField',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+				]),
+			);
 		});
 
 		it('creates an application form with a name', async () => {

--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -5,6 +5,7 @@ import {
 	createApplicationForm,
 	createBulkUploadTask,
 	createSource,
+	loadPermissionGrantBundle,
 	loadSystemSource,
 	loadSystemUser,
 	loadTableMetrics,
@@ -17,11 +18,18 @@ import {
 	createTestOpportunity,
 	createTestUser,
 } from '../test/factories';
-import { getAuthContext, loadTestUser } from '../test/utils';
+import {
+	getAuthContext,
+	loadTestUser,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../test/utils';
 import {
 	expectArray,
+	expectArrayContaining,
 	expectNumber,
 	expectObject,
+	expectObjectContaining,
 	expectTimestamp,
 } from '../test/asymettricMatchers';
 import {
@@ -485,6 +493,84 @@ describe('/tasks/bulkUploads', () => {
 				createdByUser: expectedCreatedByUser,
 			});
 			expect(after.count).toEqual(1);
+		});
+
+		it('grants the creator a manage permission on the new bulk upload task', async () => {
+			const db = getDatabase();
+			const systemSource = await loadSystemSource(db, null);
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, systemUserAuthContext);
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: testFunder.shortCode,
+				scope: [PermissionGrantEntityType.OPPORTUNITY],
+				verbs: [PermissionGrantVerb.VIEW],
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: testFunder.shortCode,
+				scope: [PermissionGrantEntityType.PROPOSAL],
+				verbs: [PermissionGrantVerb.CREATE],
+			});
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.SOURCE,
+				sourceId: systemSource.id,
+				scope: [PermissionGrantEntityType.SOURCE],
+				verbs: [PermissionGrantVerb.REFERENCE],
+			});
+			const proposalsDataFile = await createTestFile(db, testUserAuthContext);
+			const opportunity = await createTestOpportunity(
+				db,
+				systemUserAuthContext,
+				{
+					funderShortCode: testFunder.shortCode,
+				},
+			);
+			const applicationForm = await createApplicationForm(
+				db,
+				systemUserAuthContext,
+				{
+					opportunityId: opportunity.id,
+					name: null,
+				},
+			);
+			await request(app)
+				.post('/tasks/bulkUploads/')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					sourceId: systemSource.id,
+					applicationFormId: applicationForm.id,
+					proposalsDataFileId: proposalsDataFile.id,
+					attachmentsArchiveFileId: null,
+				})
+				.expect(201);
+			const grants = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(grants.entries).toEqual(
+				expectArrayContaining([
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: testUser.keycloakUserId,
+						contextEntityType: 'bulkUpload',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+				]),
+			);
 		});
 
 		it('creates a bulk upload task with attachments archive file', async () => {

--- a/src/__tests__/changemakerFieldValues.int.test.ts
+++ b/src/__tests__/changemakerFieldValues.int.test.ts
@@ -6,12 +6,23 @@ import {
 	createChangemakerFieldValueBatch,
 	createChangemakerFieldValue,
 	createEphemeralUserGroupAssociation,
+	loadPermissionGrantBundle,
 	loadSystemUser,
 	createPermissionGrant,
 } from '../database';
-import { expectNumber, expectTimestamp } from '../test/asymettricMatchers';
+import {
+	expectArrayContaining,
+	expectNumber,
+	expectObjectContaining,
+	expectTimestamp,
+} from '../test/asymettricMatchers';
 import { createTestBaseField, createTestChangemaker } from '../test/factories';
-import { getAuthContext, loadTestUser } from '../test/utils';
+import {
+	getAuthContext,
+	loadTestUser,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../test/utils';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as adminUserAuthHeader,
@@ -72,6 +83,57 @@ describe('POST /changemakerFieldValues', () => {
 			isValid: true,
 			createdAt: expectTimestamp(),
 		});
+	});
+
+	it('grants the creator a manage permission on the new changemaker field value', async () => {
+		const db = getDatabase();
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const testUser = await loadTestUser(db);
+		const testUserAuthContext = getAuthContext(testUser, true);
+		const changemaker = await createTestChangemaker(db, testUserAuthContext);
+		const baseField = await createTestBaseField(db, null);
+		const source = await createSource(db, testUserAuthContext, {
+			label: 'Self-grant Source',
+			changemakerId: changemaker.id,
+		});
+		const batch = await createChangemakerFieldValueBatch(
+			db,
+			testUserAuthContext,
+			{
+				sourceId: source.id,
+				notes: null,
+			},
+		);
+		await request(app)
+			.post('/changemakerFieldValues')
+			.type('application/json')
+			.set(adminUserAuthHeader)
+			.send({
+				changemakerId: changemaker.id,
+				baseFieldShortCode: baseField.shortCode,
+				batchId: batch.id,
+				value: 'Self-grant value',
+				goodAsOf: '2024-01-01T00:00:00Z',
+			})
+			.expect(201);
+		const grants = await loadPermissionGrantBundle(
+			db,
+			systemUserAuthContext,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
+		expect(grants.entries).toEqual(
+			expectArrayContaining([
+				expectObjectContaining({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUser.keycloakUserId,
+					contextEntityType: 'changemakerFieldValue',
+					scope: ['any'],
+					verbs: ['manage'],
+				}),
+			]),
+		);
 	});
 
 	it('Allows multiple values for same changemaker+field+batch combination', async () => {

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -14,6 +14,7 @@ import {
 	createProposalFieldValue,
 	createProposalVersion,
 	createSource,
+	loadPermissionGrantBundle,
 	loadSystemSource,
 	loadSystemUser,
 	loadTableMetrics,
@@ -30,6 +31,8 @@ import {
 	getAuthContext,
 	getTestUserKeycloakUserId,
 	loadTestUser,
+	NO_LIMIT,
+	NO_OFFSET,
 } from '../test/utils';
 import {
 	expectArray,
@@ -1108,6 +1111,40 @@ describe('/changemakers', () => {
 				fields: [],
 			});
 			expect(after.count).toEqual(1);
+		});
+
+		it('grants the creator a manage permission on the new changemaker', async () => {
+			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			await request(app)
+				.post('/changemakers')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					taxId: '22-2222222',
+					name: 'Self-grant Co.',
+					keycloakOrganizationId: null,
+				})
+				.expect(201);
+			const grants = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(grants.entries).toEqual(
+				expectArrayContaining([
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: testUser.keycloakUserId,
+						contextEntityType: 'changemaker',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+				]),
+			);
 		});
 
 		it('returns 400 bad request when no taxId is sent', async () => {

--- a/src/__tests__/dataProviders.int.test.ts
+++ b/src/__tests__/dataProviders.int.test.ts
@@ -3,10 +3,17 @@ import { app } from '../app';
 import {
 	getDatabase,
 	loadDataProvider,
+	loadPermissionGrantBundle,
 	loadSystemDataProvider,
+	loadSystemUser,
 	loadTableMetrics,
 } from '../database';
-import { expectArray, expectTimestamp } from '../test/asymettricMatchers';
+import {
+	expectArray,
+	expectArrayContaining,
+	expectObjectContaining,
+	expectTimestamp,
+} from '../test/asymettricMatchers';
 import { createTestDataProvider } from '../test/factories';
 import {
 	mockJwt as authHeader,
@@ -16,6 +23,8 @@ import {
 	loadTestUser,
 	getTestUserKeycloakUserId,
 	getAuthContext,
+	NO_LIMIT,
+	NO_OFFSET,
 } from '../test/utils';
 const agent = request.agent(app);
 
@@ -180,6 +189,64 @@ describe('/dataProviders', () => {
 				shortCode: 'repeatable',
 				name: 'second',
 			});
+		});
+
+		it('grants the creator a manage permission on the new data provider', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			await agent
+				.put('/dataProviders/self_grant_dp')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({ name: 'Self-grant DP' })
+				.expect(201);
+			const grants = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(grants.entries).toEqual(
+				expectArrayContaining([
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+						contextEntityType: 'dataProvider',
+						dataProviderShortCode: 'self_grant_dp',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+				]),
+			);
+		});
+
+		it('does not grant a permission when the PUT updates an existing data provider', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const existing = await createTestDataProvider(db, testUserAuthContext);
+			const before = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			await agent
+				.put(`/dataProviders/${existing.shortCode}`)
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({ name: 'Renamed' })
+				.expect(200);
+			const after = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(after.total).toEqual(before.total);
 		});
 
 		it('returns 400 bad request when no name is sent', async () => {

--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -3,6 +3,7 @@ import { app } from '../app';
 import {
 	getDatabase,
 	loadFunder,
+	loadPermissionGrantBundle,
 	loadTableMetrics,
 	loadSystemFunder,
 	createOrUpdateFunderCollaborativeMember,
@@ -15,6 +16,8 @@ import {
 	getAuthContext,
 	loadTestUser,
 	getTestUserKeycloakUserId,
+	NO_LIMIT,
+	NO_OFFSET,
 } from '../test/utils';
 import {
 	expectArray,
@@ -475,6 +478,66 @@ describe('/funders', () => {
 				shortCode: 'repeatable',
 				name: 'second',
 			});
+		});
+
+		it('grants the creator a manage permission on the new funder', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			await agent
+				.put('/funders/self_grant_funder')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({ name: 'Self-grant Funder', isCollaborative: false })
+				.expect(201);
+			const grants = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(grants.entries).toEqual(
+				expectArrayContaining([
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: getTestUserKeycloakUserId(),
+						contextEntityType: 'funder',
+						funderShortCode: 'self_grant_funder',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+				]),
+			);
+		});
+
+		it('does not grant a permission when the PUT updates an existing funder', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			await createTestFunder(db, testUserAuthContext, {
+				shortCode: 'existing_funder',
+			});
+			const before = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			await agent
+				.put('/funders/existing_funder')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({ name: 'Renamed', isCollaborative: false })
+				.expect(200);
+			const after = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(after.total).toEqual(before.total);
 		});
 
 		it('returns 400 bad request when no name is sent', async () => {

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -3,6 +3,7 @@ import { app } from '../app';
 import {
 	getDatabase,
 	createEphemeralUserGroupAssociation,
+	loadPermissionGrantBundle,
 	loadTableMetrics,
 	loadSystemFunder,
 	loadSystemOpportunity,
@@ -10,8 +11,18 @@ import {
 	loadSystemUser,
 } from '../database';
 import { createTestFunder, createTestOpportunity } from '../test/factories';
-import { getAuthContext, loadTestUser } from '../test/utils';
-import { expectArray, expectTimestamp } from '../test/asymettricMatchers';
+import {
+	getAuthContext,
+	loadTestUser,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../test/utils';
+import {
+	expectArray,
+	expectArrayContaining,
+	expectObjectContaining,
+	expectTimestamp,
+} from '../test/asymettricMatchers';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
@@ -261,6 +272,48 @@ describe('/opportunities', () => {
 				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(2);
+		});
+
+		it('grants the creator a manage permission on the new opportunity', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const systemFunder = await loadSystemFunder(db, null);
+			await createPermissionGrant(db, systemUserAuthContext, {
+				granteeType: PermissionGrantGranteeType.USER,
+				granteeUserKeycloakUserId: testUser.keycloakUserId,
+				contextEntityType: PermissionGrantEntityType.FUNDER,
+				funderShortCode: systemFunder.shortCode,
+				scope: [PermissionGrantEntityType.OPPORTUNITY],
+				verbs: [PermissionGrantVerb.CREATE],
+			});
+			await request(app)
+				.post('/opportunities')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					title: 'Self-grant test',
+					funderShortCode: systemFunder.shortCode,
+				})
+				.expect(201);
+			const grants = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(grants.entries).toEqual(
+				expectArrayContaining([
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: testUser.keycloakUserId,
+						contextEntityType: 'opportunity',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+				]),
+			);
 		});
 
 		it('returns 401 unauthorized if the user does not have create opportunity permission on the associated funder', async () => {

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -9,6 +9,7 @@ import {
 	createProposal,
 	createProposalVersion,
 	createSource,
+	loadPermissionGrantBundle,
 	loadSystemFunder,
 	loadSystemSource,
 	loadTableMetrics,
@@ -31,7 +32,12 @@ import {
 	PermissionGrantGranteeType,
 	PermissionGrantVerb,
 } from '../types';
-import { getAuthContext, loadTestUser } from '../test/utils';
+import {
+	getAuthContext,
+	loadTestUser,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../test/utils';
 import {
 	expectArray,
 	expectArrayContaining,
@@ -282,6 +288,76 @@ describe('/proposalVersions', () => {
 				fieldValues: [],
 			});
 			expect(after.count).toEqual(1);
+		});
+
+		it('grants the creator a manage permission on the new proposal version and field values', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const systemSource = await loadSystemSource(db, null);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			const proposal = await createProposal(db, testUserAuthContext, {
+				externalId: 'self-grant-proposal',
+				opportunityId: opportunity.id,
+			});
+			const applicationForm = await createApplicationForm(db, null, {
+				opportunityId: opportunity.id,
+				name: null,
+			});
+			const firstNameBaseField = await createTestBaseField(db, null);
+			const firstNameField = await createApplicationFormField(db, null, {
+				applicationFormId: applicationForm.id,
+				baseFieldShortCode: firstNameBaseField.shortCode,
+				position: 1,
+				label: 'First Name',
+				instructions: null,
+				inputType: null,
+			});
+			await request(app)
+				.post('/proposalVersions')
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					proposalId: proposal.id,
+					applicationFormId: applicationForm.id,
+					sourceId: systemSource.id,
+					fieldValues: [
+						{
+							applicationFormFieldId: firstNameField.id,
+							position: 1,
+							value: 'Self-grant',
+							isValid: true,
+							goodAsOf: null,
+						},
+					],
+				})
+				.expect(201);
+			const grants = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(grants.entries).toEqual(
+				expectArrayContaining([
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: testUser.keycloakUserId,
+						contextEntityType: 'proposalVersion',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: testUser.keycloakUserId,
+						contextEntityType: 'proposalFieldValue',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+				]),
+			);
 		});
 
 		it('creates exactly one proposal version for a user with read and write permissions on the funder', async () => {

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -10,6 +10,7 @@ import {
 	createProposalFieldValue,
 	createProposalVersion,
 	getDatabase,
+	loadPermissionGrantBundle,
 	loadSystemSource,
 	loadTableMetrics,
 	loadSystemFunder,
@@ -23,9 +24,16 @@ import {
 	createTestOpportunity,
 	createTestUser,
 } from '../test/factories';
-import { getAuthContext, loadTestUser } from '../test/utils';
+import {
+	getAuthContext,
+	loadTestUser,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../test/utils';
 import {
 	expectArray,
+	expectArrayContaining,
+	expectObjectContaining,
 	expectString,
 	expectTimestamp,
 } from '../test/asymettricMatchers';
@@ -1547,6 +1555,41 @@ describe('/proposals', () => {
 				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(1);
+		});
+
+		it('grants the creator a manage permission on the new proposal', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const opportunity = await createTestOpportunity(db, testUserAuthContext);
+			await request(app)
+				.post('/proposals')
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					externalId: 'self-grant-proposal',
+					opportunityId: opportunity.id,
+				})
+				.expect(201);
+			const grants = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(grants.entries).toEqual(
+				expectArrayContaining([
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: testUser.keycloakUserId,
+						contextEntityType: 'proposal',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+				]),
+			);
 		});
 
 		it('creates exactly one proposal when the user has write permissions on the opportunity funder', async () => {

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -4,6 +4,7 @@ import {
 	getDatabase,
 	createEphemeralUserGroupAssociation,
 	createSource,
+	loadPermissionGrantBundle,
 	loadSystemSource,
 	loadTableMetrics,
 	loadSystemUser,
@@ -12,14 +13,24 @@ import {
 	createApplicationForm,
 	createPermissionGrant,
 } from '../database';
-import { expectArray, expectTimestamp } from '../test/asymettricMatchers';
+import {
+	expectArray,
+	expectArrayContaining,
+	expectObjectContaining,
+	expectTimestamp,
+} from '../test/asymettricMatchers';
 import {
 	createTestChangemaker,
 	createTestDataProvider,
 	createTestFunder,
 	createTestOpportunity,
 } from '../test/factories';
-import { getAuthContext, loadTestUser } from '../test/utils';
+import {
+	getAuthContext,
+	loadTestUser,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../test/utils';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as adminUserAuthHeader,
@@ -364,6 +375,41 @@ describe('/sources', () => {
 				createdBy: testUser.keycloakUserId,
 			});
 			expect(after.count).toEqual(2);
+		});
+
+		it('grants the creator a manage permission on the new source', async () => {
+			const db = getDatabase();
+			const systemUser = await loadSystemUser(db, null);
+			const systemUserAuthContext = getAuthContext(systemUser);
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const changemaker = await createTestChangemaker(db, testUserAuthContext);
+			await agent
+				.post('/sources')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					label: 'Self-grant source',
+					changemakerId: changemaker.id,
+				})
+				.expect(201);
+			const grants = await loadPermissionGrantBundle(
+				db,
+				systemUserAuthContext,
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(grants.entries).toEqual(
+				expectArrayContaining([
+					expectObjectContaining({
+						granteeType: 'user',
+						granteeUserKeycloakUserId: testUser.keycloakUserId,
+						contextEntityType: 'source',
+						scope: ['any'],
+						verbs: ['manage'],
+					}),
+				]),
+			);
 		});
 
 		it('returns 409 conflict when label is not unique on changemaker foreign key', async () => {

--- a/src/handlers/applicationFormsHandlers.ts
+++ b/src/handlers/applicationFormsHandlers.ts
@@ -1,4 +1,5 @@
 import {
+	createPermissionGrant,
 	getDatabase,
 	createApplicationForm,
 	createApplicationFormField,
@@ -10,6 +11,7 @@ import {
 } from '../database';
 import { HTTP_STATUS } from '../constants';
 import {
+	getSelfManageGrantFragment,
 	isWritableApplicationFormWithFields,
 	isId,
 	isAuthContext,
@@ -99,29 +101,50 @@ const postApplicationForms = async (
 		) {
 			throw new UnauthorizedError();
 		}
-		const finalApplicationForm = await db.transaction(async (transactionDb) => {
-			const applicationForm = await createApplicationForm(transactionDb, null, {
-				opportunityId,
-				name,
-			});
-			const applicationFormFields = await Promise.all(
-				fields.map(
-					async (field) =>
-						await createApplicationFormField(transactionDb, null, {
-							...field,
-							applicationFormId: applicationForm.id,
-						}),
-				),
-			);
-			return {
-				...applicationForm,
-				fields: applicationFormFields,
-			};
-		});
+		const committedApplicationForm = await db.transaction(
+			async (transactionDb) => {
+				const applicationForm = await createApplicationForm(
+					transactionDb,
+					null,
+					{
+						opportunityId,
+						name,
+					},
+				);
+				await createPermissionGrant(transactionDb, req, {
+					...getSelfManageGrantFragment(req),
+					contextEntityType: PermissionGrantEntityType.APPLICATION_FORM,
+					applicationFormId: applicationForm.id,
+				});
+				const applicationFormFields = await Promise.all(
+					fields.map(async (field) => {
+						const applicationFormField = await createApplicationFormField(
+							transactionDb,
+							null,
+							{
+								...field,
+								applicationFormId: applicationForm.id,
+							},
+						);
+						await createPermissionGrant(transactionDb, req, {
+							...getSelfManageGrantFragment(req),
+							contextEntityType:
+								PermissionGrantEntityType.APPLICATION_FORM_FIELD,
+							applicationFormFieldId: applicationFormField.id,
+						});
+						return applicationFormField;
+					}),
+				);
+				return {
+					...applicationForm,
+					fields: applicationFormFields,
+				};
+			},
+		);
 		res
 			.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 			.contentType('application/json')
-			.send(finalApplicationForm);
+			.send(committedApplicationForm);
 	} catch (error: unknown) {
 		if (error instanceof NotFoundError) {
 			throw new UnprocessableEntityError('A related entity was not found');

--- a/src/handlers/bulkUploadTasksHandlers.ts
+++ b/src/handlers/bulkUploadTasksHandlers.ts
@@ -1,5 +1,6 @@
 import { HTTP_STATUS } from '../constants';
 import {
+	createPermissionGrant,
 	getDatabase,
 	createBulkUploadTask,
 	getLimitValues,
@@ -11,6 +12,7 @@ import {
 	loadOpportunity,
 } from '../database';
 import {
+	getSelfManageGrantFragment,
 	PermissionGrantEntityType,
 	PermissionGrantVerb,
 	TaskStatus,
@@ -144,20 +146,28 @@ const postBulkUploadTask = async (
 		);
 	}
 
-	const bulkUploadTask = await createBulkUploadTask(db, req, {
-		sourceId,
-		applicationFormId,
-		proposalsDataFileId,
-		attachmentsArchiveFileId,
-		status: TaskStatus.PENDING,
+	const committedBulkUploadTask = await db.transaction(async (txDb) => {
+		const bulkUploadTask = await createBulkUploadTask(txDb, req, {
+			sourceId,
+			applicationFormId,
+			proposalsDataFileId,
+			attachmentsArchiveFileId,
+			status: TaskStatus.PENDING,
+		});
+		await createPermissionGrant(txDb, req, {
+			...getSelfManageGrantFragment(req),
+			contextEntityType: PermissionGrantEntityType.BULK_UPLOAD,
+			bulkUploadTaskId: bulkUploadTask.id,
+		});
+		return bulkUploadTask;
 	});
 	await addProcessBulkUploadJob({
-		bulkUploadId: bulkUploadTask.id,
+		bulkUploadId: committedBulkUploadTask.id,
 	});
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')
-		.send(bulkUploadTask);
+		.send(committedBulkUploadTask);
 };
 
 const getBulkUploadTasks = async (

--- a/src/handlers/changemakerFieldValuesHandlers.ts
+++ b/src/handlers/changemakerFieldValuesHandlers.ts
@@ -1,5 +1,6 @@
 import { HTTP_STATUS } from '../constants';
 import {
+	createPermissionGrant,
 	getDatabase,
 	createChangemakerFieldValue,
 	getLimitValues,
@@ -11,6 +12,7 @@ import {
 	loadChangemakerFieldValueBundle,
 } from '../database';
 import {
+	getSelfManageGrantFragment,
 	isAuthContext,
 	isId,
 	isWritableChangemakerFieldValue,
@@ -122,19 +124,27 @@ const postChangemakerFieldValue = async (
 
 	const isValid = fieldValueIsValid(value, baseField.dataType);
 
-	const changemakerFieldValue = await createChangemakerFieldValue(db, req, {
-		changemakerId,
-		baseFieldShortCode,
-		batchId,
-		value,
-		isValid,
-		goodAsOf,
+	const committedChangemakerFieldValue = await db.transaction(async (txDb) => {
+		const changemakerFieldValue = await createChangemakerFieldValue(txDb, req, {
+			changemakerId,
+			baseFieldShortCode,
+			batchId,
+			value,
+			isValid,
+			goodAsOf,
+		});
+		await createPermissionGrant(txDb, req, {
+			...getSelfManageGrantFragment(req),
+			contextEntityType: PermissionGrantEntityType.CHANGEMAKER_FIELD_VALUE,
+			changemakerFieldValueId: changemakerFieldValue.id,
+		});
+		return changemakerFieldValue;
 	});
 
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')
-		.send(changemakerFieldValue);
+		.send(committedChangemakerFieldValue);
 };
 
 const getChangemakerFieldValues = async (

--- a/src/handlers/changemakersHandlers.ts
+++ b/src/handlers/changemakersHandlers.ts
@@ -1,5 +1,6 @@
 import { HTTP_STATUS } from '../constants';
 import {
+	createPermissionGrant,
 	getDatabase,
 	getLimitValues,
 	loadChangemakerBundle,
@@ -10,10 +11,12 @@ import {
 	removeFiscalSponsorship,
 } from '../database';
 import {
+	getSelfManageGrantFragment,
 	isId,
 	isWritableChangemaker,
 	isAuthContext,
 	isPartialWritableChangemaker,
+	PermissionGrantEntityType,
 } from '../types';
 import {
 	FailedMiddlewareError,
@@ -41,11 +44,19 @@ const postChangemaker = async (req: Request, res: Response): Promise<void> => {
 			isWritableChangemaker.errors ?? [],
 		);
 	}
-	const changemaker = await createChangemaker(db, req, body);
+	const committedChangemaker = await db.transaction(async (txDb) => {
+		const changemaker = await createChangemaker(txDb, req, body);
+		await createPermissionGrant(txDb, req, {
+			...getSelfManageGrantFragment(req),
+			contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+			changemakerId: changemaker.id,
+		});
+		return changemaker;
+	});
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')
-		.send(changemaker);
+		.send(committedChangemaker);
 };
 
 const getChangemakers = async (req: Request, res: Response): Promise<void> => {

--- a/src/handlers/changemakersHandlers.ts
+++ b/src/handlers/changemakersHandlers.ts
@@ -34,13 +34,14 @@ const postChangemaker = async (req: Request, res: Response): Promise<void> => {
 	if (!isAuthContext(req)) {
 		throw new FailedMiddlewareError('Unexpected lack of auth context.');
 	}
-	if (!isWritableChangemaker(req.body)) {
+	const body = req.body as unknown;
+	if (!isWritableChangemaker(body)) {
 		throw new InputValidationError(
 			'Invalid request body.',
 			isWritableChangemaker.errors ?? [],
 		);
 	}
-	const changemaker = await createChangemaker(db, req, req.body);
+	const changemaker = await createChangemaker(db, req, body);
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')

--- a/src/handlers/dataProvidersHandlers.ts
+++ b/src/handlers/dataProvidersHandlers.ts
@@ -3,10 +3,16 @@ import {
 	getDatabase,
 	getLimitValues,
 	createOrUpdateDataProvider,
+	createPermissionGrant,
 	loadDataProviderBundle,
 	loadDataProvider,
 } from '../database';
-import { isAuthContext, isWritableDataProvider } from '../types';
+import {
+	getSelfManageGrantFragment,
+	isAuthContext,
+	isWritableDataProvider,
+	PermissionGrantEntityType,
+} from '../types';
 import { FailedMiddlewareError, InputValidationError } from '../errors';
 import { extractPaginationParameters } from '../queryParameters';
 import { coerceParams } from '../coercion';
@@ -69,21 +75,37 @@ const putDataProvider = async (req: Request, res: Response): Promise<void> => {
 		);
 	}
 	const { name, keycloakOrganizationId } = body;
-	const { item: dataProvider, wasInserted } = await createOrUpdateDataProvider(
-		db,
-		req,
-		{
-			shortCode,
-			name,
-			keycloakOrganizationId,
-		},
-	);
+	const { committedDataProvider, committedDataProviderWasInserted } =
+		await db.transaction(async (txDb) => {
+			const { item, wasInserted } = await createOrUpdateDataProvider(
+				txDb,
+				req,
+				{
+					shortCode,
+					name,
+					keycloakOrganizationId,
+				},
+			);
+			if (wasInserted) {
+				await createPermissionGrant(txDb, req, {
+					...getSelfManageGrantFragment(req),
+					contextEntityType: PermissionGrantEntityType.DATA_PROVIDER,
+					dataProviderShortCode: item.shortCode,
+				});
+			}
+			return {
+				committedDataProvider: item,
+				committedDataProviderWasInserted: wasInserted,
+			};
+		});
 	res
 		.status(
-			wasInserted ? HTTP_STATUS.SUCCESSFUL.CREATED : HTTP_STATUS.SUCCESSFUL.OK,
+			committedDataProviderWasInserted
+				? HTTP_STATUS.SUCCESSFUL.CREATED
+				: HTTP_STATUS.SUCCESSFUL.OK,
 		)
 		.contentType('application/json')
-		.send(dataProvider);
+		.send(committedDataProvider);
 };
 
 export const dataProviderHandlers = {

--- a/src/handlers/funderCollaborativeInvitationsHandlers.ts
+++ b/src/handlers/funderCollaborativeInvitationsHandlers.ts
@@ -163,7 +163,7 @@ const patchFunderCollaborativeInvitation = async (
 	}
 
 	const { invitationStatus } = body;
-	const finalFunderCollaborativeInvitation = await db.transaction(
+	const committedFunderCollaborativeInvitation = await db.transaction(
 		async (transactionDb) => {
 			const funderCollaborativeInvitation =
 				await updateFunderCollaborativeInvitation(
@@ -189,7 +189,7 @@ const patchFunderCollaborativeInvitation = async (
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.OK)
 		.contentType('application/json')
-		.send(finalFunderCollaborativeInvitation);
+		.send(committedFunderCollaborativeInvitation);
 };
 
 export const funderCollaborativeInvitationsHandlers = {

--- a/src/handlers/fundersHandlers.ts
+++ b/src/handlers/fundersHandlers.ts
@@ -2,11 +2,17 @@ import { HTTP_STATUS } from '../constants';
 import {
 	getDatabase,
 	createOrUpdateFunder,
+	createPermissionGrant,
 	getLimitValues,
 	loadFunderBundle,
 	loadFunder,
 } from '../database';
-import { isAuthContext, isWritableFunder } from '../types';
+import {
+	getSelfManageGrantFragment,
+	isAuthContext,
+	isWritableFunder,
+	PermissionGrantEntityType,
+} from '../types';
 import { FailedMiddlewareError, InputValidationError } from '../errors';
 import {
 	extractIsCollaborativeParameters,
@@ -78,18 +84,32 @@ const putFunder = async (req: Request, res: Response): Promise<void> => {
 	}
 
 	const { name, keycloakOrganizationId, isCollaborative } = body;
-	const { item: funder, wasInserted } = await createOrUpdateFunder(db, req, {
-		shortCode,
-		name,
-		keycloakOrganizationId,
-		isCollaborative,
-	});
+	const { committedFunder, committedFunderWasInserted } = await db.transaction(
+		async (txDb) => {
+			const { item, wasInserted } = await createOrUpdateFunder(txDb, req, {
+				shortCode,
+				name,
+				keycloakOrganizationId,
+				isCollaborative,
+			});
+			if (wasInserted) {
+				await createPermissionGrant(txDb, req, {
+					...getSelfManageGrantFragment(req),
+					contextEntityType: PermissionGrantEntityType.FUNDER,
+					funderShortCode: item.shortCode,
+				});
+			}
+			return { committedFunder: item, committedFunderWasInserted: wasInserted };
+		},
+	);
 	res
 		.status(
-			wasInserted ? HTTP_STATUS.SUCCESSFUL.CREATED : HTTP_STATUS.SUCCESSFUL.OK,
+			committedFunderWasInserted
+				? HTTP_STATUS.SUCCESSFUL.CREATED
+				: HTTP_STATUS.SUCCESSFUL.OK,
 		)
 		.contentType('application/json')
-		.send(funder);
+		.send(committedFunder);
 };
 
 export const fundersHandlers = {

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -58,7 +58,8 @@ const postOpportunity = async (req: Request, res: Response): Promise<void> => {
 		throw new FailedMiddlewareError('Unexpected lack of auth context.');
 	}
 	const db = getDatabase();
-	if (!isWritableOpportunity(req.body)) {
+	const body = req.body as unknown;
+	if (!isWritableOpportunity(body)) {
 		throw new InputValidationError(
 			'Invalid request body.',
 			isWritableOpportunity.errors ?? [],
@@ -66,14 +67,14 @@ const postOpportunity = async (req: Request, res: Response): Promise<void> => {
 	}
 	if (
 		!(await hasFunderPermission(db, req, {
-			funderShortCode: req.body.funderShortCode,
+			funderShortCode: body.funderShortCode,
 			permission: PermissionGrantVerb.CREATE,
 			scope: PermissionGrantEntityType.OPPORTUNITY,
 		}))
 	) {
 		throw new UnauthorizedError();
 	}
-	const opportunity = await createOpportunity(db, req, req.body);
+	const opportunity = await createOpportunity(db, req, body);
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -1,5 +1,6 @@
 import { HTTP_STATUS } from '../constants';
 import {
+	createPermissionGrant,
 	getDatabase,
 	createOpportunity,
 	getLimitValues,
@@ -8,6 +9,7 @@ import {
 	loadOpportunityBundle,
 } from '../database';
 import {
+	getSelfManageGrantFragment,
 	isAuthContext,
 	isId,
 	isWritableOpportunity,
@@ -74,11 +76,19 @@ const postOpportunity = async (req: Request, res: Response): Promise<void> => {
 	) {
 		throw new UnauthorizedError();
 	}
-	const opportunity = await createOpportunity(db, req, body);
+	const committedOpportunity = await db.transaction(async (txDb) => {
+		const opportunity = await createOpportunity(txDb, req, body);
+		await createPermissionGrant(txDb, req, {
+			...getSelfManageGrantFragment(req),
+			contextEntityType: PermissionGrantEntityType.OPPORTUNITY,
+			opportunityId: opportunity.id,
+		});
+		return opportunity;
+	});
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')
-		.send(opportunity);
+		.send(committedOpportunity);
 };
 
 export const opportunitiesHandlers = {

--- a/src/handlers/proposalVersionsHandlers.ts
+++ b/src/handlers/proposalVersionsHandlers.ts
@@ -1,5 +1,6 @@
 import { HTTP_STATUS } from '../constants';
 import {
+	createPermissionGrant,
 	createProposalFieldValue,
 	createProposalVersion,
 	getDatabase,
@@ -11,6 +12,7 @@ import {
 	loadProposalVersion,
 } from '../database';
 import {
+	getSelfManageGrantFragment,
 	isAuthContext,
 	isWritableProposalVersionWithFieldValues,
 	isId,
@@ -179,45 +181,61 @@ const postProposalVersion = async (
 			applicationFormId,
 			fieldValues,
 		);
-		const finalProposalVersion = await db.transaction(async (transactionDb) => {
-			const proposalVersion = await createProposalVersion(transactionDb, req, {
-				proposalId,
-				applicationFormId,
-				sourceId,
-			});
-			const proposalFieldValues = await allNoLeaks(
-				fieldValues.map(async (fieldValue) => {
-					const { value, applicationFormFieldId } = fieldValue;
-					const applicationFormField = await loadApplicationFormField(
-						transactionDb,
-						req,
-						applicationFormFieldId,
-					);
-					const isValid = fieldValueIsValid(
-						value,
-						applicationFormField.baseField.dataType,
-					);
-					const proposalFieldValue = await createProposalFieldValue(
-						transactionDb,
-						req,
-						{
-							...fieldValue,
-							proposalVersionId: proposalVersion.id,
-							isValid,
-						},
-					);
-					return proposalFieldValue;
-				}),
-			);
-			return {
-				...proposalVersion,
-				fieldValues: proposalFieldValues,
-			};
-		});
+		const committedProposalVersion = await db.transaction(
+			async (transactionDb) => {
+				const proposalVersion = await createProposalVersion(
+					transactionDb,
+					req,
+					{
+						proposalId,
+						applicationFormId,
+						sourceId,
+					},
+				);
+				await createPermissionGrant(transactionDb, req, {
+					...getSelfManageGrantFragment(req),
+					contextEntityType: PermissionGrantEntityType.PROPOSAL_VERSION,
+					proposalVersionId: proposalVersion.id,
+				});
+				const proposalFieldValues = await allNoLeaks(
+					fieldValues.map(async (fieldValue) => {
+						const { value, applicationFormFieldId } = fieldValue;
+						const applicationFormField = await loadApplicationFormField(
+							transactionDb,
+							req,
+							applicationFormFieldId,
+						);
+						const isValid = fieldValueIsValid(
+							value,
+							applicationFormField.baseField.dataType,
+						);
+						const proposalFieldValue = await createProposalFieldValue(
+							transactionDb,
+							req,
+							{
+								...fieldValue,
+								proposalVersionId: proposalVersion.id,
+								isValid,
+							},
+						);
+						await createPermissionGrant(transactionDb, req, {
+							...getSelfManageGrantFragment(req),
+							contextEntityType: PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
+							proposalFieldValueId: proposalFieldValue.id,
+						});
+						return proposalFieldValue;
+					}),
+				);
+				return {
+					...proposalVersion,
+					fieldValues: proposalFieldValues,
+				};
+			},
+		);
 		res
 			.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 			.contentType('application/json')
-			.send(finalProposalVersion);
+			.send(committedProposalVersion);
 	} catch (error: unknown) {
 		if (error instanceof NotFoundError) {
 			if (error.details.entityType === 'Proposal') {

--- a/src/handlers/proposalsHandlers.ts
+++ b/src/handlers/proposalsHandlers.ts
@@ -1,5 +1,6 @@
 import { HTTP_STATUS } from '../constants';
 import {
+	createPermissionGrant,
 	getDatabase,
 	createProposal,
 	getLimitValues,
@@ -9,6 +10,7 @@ import {
 	loadOpportunity,
 } from '../database';
 import {
+	getSelfManageGrantFragment,
 	isId,
 	isAuthContext,
 	isWritableProposal,
@@ -105,14 +107,22 @@ const postProposal = async (req: Request, res: Response): Promise<void> => {
 				'You do not have permission to create a proposal for this opportunity.',
 			);
 		}
-		const proposal = await createProposal(db, req, {
-			opportunityId,
-			externalId,
+		const committedProposal = await db.transaction(async (txDb) => {
+			const proposal = await createProposal(txDb, req, {
+				opportunityId,
+				externalId,
+			});
+			await createPermissionGrant(txDb, req, {
+				...getSelfManageGrantFragment(req),
+				contextEntityType: PermissionGrantEntityType.PROPOSAL,
+				proposalId: proposal.id,
+			});
+			return proposal;
 		});
 		res
 			.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 			.contentType('application/json')
-			.send(proposal);
+			.send(committedProposal);
 	} catch (error: unknown) {
 		if (error instanceof NotFoundError) {
 			throw new UnprocessableEntityError(

--- a/src/handlers/sourcesHandlers.ts
+++ b/src/handlers/sourcesHandlers.ts
@@ -1,5 +1,6 @@
 import { HTTP_STATUS } from '../constants';
 import {
+	createPermissionGrant,
 	getDatabase,
 	createSource,
 	getLimitValues,
@@ -11,6 +12,7 @@ import {
 	removeSource,
 } from '../database';
 import {
+	getSelfManageGrantFragment,
 	isAuthContext,
 	isId,
 	isWritableSource,
@@ -78,11 +80,19 @@ const postSource = async (req: Request, res: Response): Promise<void> => {
 	// Normally we try to avoid passing the body directly vs extracting the values and passing them.
 	// Because because writableSource is a union type it is hard to extract the values directly without
 	// losing type context that the union provided.
-	const source = await createSource(db, req, body);
+	const committedSource = await db.transaction(async (txDb) => {
+		const source = await createSource(txDb, req, body);
+		await createPermissionGrant(txDb, req, {
+			...getSelfManageGrantFragment(req),
+			contextEntityType: PermissionGrantEntityType.SOURCE,
+			sourceId: source.id,
+		});
+		return source;
+	});
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')
-		.send(source);
+		.send(committedSource);
 };
 
 const getSources = async (req: Request, res: Response): Promise<void> => {

--- a/src/handlers/sourcesHandlers.ts
+++ b/src/handlers/sourcesHandlers.ts
@@ -31,16 +31,17 @@ const postSource = async (req: Request, res: Response): Promise<void> => {
 		throw new FailedMiddlewareError('Unexpected lack of auth context.');
 	}
 	const db = getDatabase();
-	if (!isWritableSource(req.body)) {
+	const body = req.body as unknown;
+	if (!isWritableSource(body)) {
 		throw new InputValidationError(
 			'Invalid request body.',
 			isWritableSource.errors ?? [],
 		);
 	}
 	if (
-		'funderShortCode' in req.body &&
+		'funderShortCode' in body &&
 		!(await hasFunderPermission(db, req, {
-			funderShortCode: req.body.funderShortCode,
+			funderShortCode: body.funderShortCode,
 			permission: PermissionGrantVerb.CREATE,
 			scope: PermissionGrantEntityType.SOURCE,
 		}))
@@ -50,9 +51,9 @@ const postSource = async (req: Request, res: Response): Promise<void> => {
 		);
 	}
 	if (
-		'dataProviderShortCode' in req.body &&
+		'dataProviderShortCode' in body &&
 		!(await hasDataProviderPermission(db, req, {
-			dataProviderShortCode: req.body.dataProviderShortCode,
+			dataProviderShortCode: body.dataProviderShortCode,
 			permission: PermissionGrantVerb.CREATE,
 			scope: PermissionGrantEntityType.SOURCE,
 		}))
@@ -62,9 +63,9 @@ const postSource = async (req: Request, res: Response): Promise<void> => {
 		);
 	}
 	if (
-		'changemakerId' in req.body &&
+		'changemakerId' in body &&
 		!(await hasChangemakerPermission(db, req, {
-			changemakerId: req.body.changemakerId,
+			changemakerId: body.changemakerId,
 			permission: PermissionGrantVerb.CREATE,
 			scope: PermissionGrantEntityType.SOURCE,
 		}))
@@ -77,7 +78,7 @@ const postSource = async (req: Request, res: Response): Promise<void> => {
 	// Normally we try to avoid passing the body directly vs extracting the values and passing them.
 	// Because because writableSource is a union type it is hard to extract the values directly without
 	// losing type context that the union provided.
-	const source = await createSource(db, req, req.body);
+	const source = await createSource(db, req, body);
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 		.contentType('application/json')

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -10,6 +10,7 @@ import {
 	loadBulkUploadTask,
 	loadProposalBundle,
 	createBulkUploadTask,
+	loadPermissionGrantBundle,
 	loadSystemUser,
 	loadChangemakerBundle,
 	loadChangemakerProposalBundle,
@@ -31,8 +32,10 @@ import {
 	NO_OFFSET,
 } from '../../test/utils';
 import {
+	expectArrayContaining,
 	expectNumber,
 	expectObject,
+	expectObjectContaining,
 	expectString,
 	expectTimestamp,
 } from '../../test/asymettricMatchers';
@@ -840,6 +843,80 @@ describe('processBulkUploadTask', () => {
 			],
 			total: 2,
 		});
+	});
+
+	it('should grant the upload-initiating user manage permissions on every entity it creates', async () => {
+		const db = getDatabase();
+		await createTestBaseFields(db);
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const proposalsDataFile = await createTestFile(db, systemUserAuthContext);
+		const { applicationFormId } = await createTestApplicationForm(
+			db,
+			systemUserAuthContext,
+			['proposal_submitter_email', 'organization_name', 'organization_tax_id'],
+		);
+		const bulkUploadTask = await createTestBulkUploadTask(
+			db,
+			systemUserAuthContext,
+			{
+				proposalsDataFileId: proposalsDataFile.id,
+				applicationFormId,
+			},
+		);
+
+		s3Mock.on(GetObjectCommand).resolves({
+			Body: sdkStreamMixin(
+				fs.createReadStream(
+					path.join(
+						__dirname,
+						'fixtures',
+						'processBulkUploadTask',
+						'validCsvTemplateWithChangemakers.csv',
+					),
+				),
+			),
+		});
+
+		await processBulkUploadTask(
+			{
+				bulkUploadId: bulkUploadTask.id,
+			},
+			getMockJobHelpers(),
+		);
+
+		const grantBundle = await loadPermissionGrantBundle(
+			db,
+			systemUserAuthContext,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
+		const granteeMatch = {
+			granteeType: 'user',
+			granteeUserKeycloakUserId: systemUser.keycloakUserId,
+			scope: ['any'],
+			verbs: ['manage'],
+		};
+		expect(grantBundle.entries).toEqual(
+			expectArrayContaining([
+				expectObjectContaining({
+					...granteeMatch,
+					contextEntityType: 'proposal',
+				}),
+				expectObjectContaining({
+					...granteeMatch,
+					contextEntityType: 'proposalVersion',
+				}),
+				expectObjectContaining({
+					...granteeMatch,
+					contextEntityType: 'proposalFieldValue',
+				}),
+				expectObjectContaining({
+					...granteeMatch,
+					contextEntityType: 'changemaker',
+				}),
+			]),
+		);
 	});
 
 	it('should resolve file attachment paths when archive has a single root folder and CSV uses stripped paths', async () => {

--- a/src/tasks/processBulkUploadTask.ts
+++ b/src/tasks/processBulkUploadTask.ts
@@ -16,6 +16,7 @@ import { getDefaultS3Bucket } from '../config';
 import {
 	createBulkUploadLog,
 	createChangemakerProposal,
+	createPermissionGrant,
 	createProposal,
 	createProposalFieldValue,
 	createProposalVersion,
@@ -28,8 +29,10 @@ import {
 } from '../database/operations';
 import {
 	TaskStatus,
+	getSelfManageGrantFragment,
 	isProcessBulkUploadJobPayload,
 	BaseFieldDataType,
+	PermissionGrantEntityType,
 } from '../types';
 import { fieldValueIsValid } from '../fieldValidation';
 import { allNoLeaks } from '../promises';
@@ -568,6 +571,11 @@ export const processBulkUploadTask = async (
 					opportunityId,
 					externalId: `${recordNumber}`,
 				});
+				await createPermissionGrant(transactionDb, taskAuthContext, {
+					...getSelfManageGrantFragment(taskAuthContext),
+					contextEntityType: PermissionGrantEntityType.PROPOSAL,
+					proposalId: proposal.id,
+				});
 				const proposalVersion = await createProposalVersion(
 					transactionDb,
 					taskAuthContext,
@@ -577,21 +585,30 @@ export const processBulkUploadTask = async (
 						sourceId: bulkUploadTask.sourceId,
 					},
 				);
+				await createPermissionGrant(transactionDb, taskAuthContext, {
+					...getSelfManageGrantFragment(taskAuthContext),
+					contextEntityType: PermissionGrantEntityType.PROPOSAL_VERSION,
+					proposalVersionId: proposalVersion.id,
+				});
 
 				const {
 					[changemakerNameIndex]: changemakerName,
 					[changemakerTaxIdIndex]: changemakerTaxId,
 				} = record;
 				if (changemakerTaxId !== undefined) {
-					const { item: changemaker } = await loadOrCreateChangemaker(
-						transactionDb,
-						taskAuthContext,
-						{
+					const { item: changemaker, wasInserted } =
+						await loadOrCreateChangemaker(transactionDb, taskAuthContext, {
 							name: changemakerName ?? 'Unnamed Organization',
 							taxId: changemakerTaxId,
 							keycloakOrganizationId: null,
-						},
-					);
+						});
+					if (wasInserted) {
+						await createPermissionGrant(transactionDb, taskAuthContext, {
+							...getSelfManageGrantFragment(taskAuthContext),
+							contextEntityType: PermissionGrantEntityType.CHANGEMAKER,
+							changemakerId: changemaker.id,
+						});
+					}
 					await createChangemakerProposal(transactionDb, taskAuthContext, {
 						changemakerId: changemaker.id,
 						proposalId: proposal.id,
@@ -625,7 +642,7 @@ export const processBulkUploadTask = async (
 							isValid = true;
 						}
 
-						return await createProposalFieldValue(
+						const proposalFieldValue = await createProposalFieldValue(
 							transactionDb,
 							taskAuthContext,
 							{
@@ -637,6 +654,12 @@ export const processBulkUploadTask = async (
 								goodAsOf: null,
 							},
 						);
+						await createPermissionGrant(transactionDb, taskAuthContext, {
+							...getSelfManageGrantFragment(taskAuthContext),
+							contextEntityType: PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
+							proposalFieldValueId: proposalFieldValue.id,
+						});
+						return proposalFieldValue;
 					}),
 				);
 			});

--- a/src/types/PermissionGrant.ts
+++ b/src/types/PermissionGrant.ts
@@ -6,11 +6,14 @@ import {
 	PermissionGrantGranteeType,
 	permissionGrantGranteeTypeSchema,
 } from './PermissionGrantGranteeType';
-import { permissionGrantVerbSchema } from './PermissionGrantVerb';
+import {
+	PermissionGrantVerb,
+	permissionGrantVerbSchema,
+} from './PermissionGrantVerb';
 import type { TypeGuardWithAjvErrors } from '../ajv';
+import type { AuthContext } from './AuthContext';
 import type { Id } from './Id';
 import type { KeycloakId } from './KeycloakId';
-import type { PermissionGrantVerb } from './PermissionGrantVerb';
 import type { User } from './User';
 import type { Writable } from './Writable';
 import type { ValidateFunction } from 'ajv';
@@ -444,14 +447,40 @@ const getConditionsForScope = (
 	scopeKey: PermissionGrantEntityType,
 ): readonly PermissionGrantCondition[] => scopeConditions[scopeKey];
 
+/**
+ * Returns the grantee + scope + verbs portion of a permission grant that
+ * gives the auth user `manage` against `any` scope. Spread into a grant
+ * alongside `contextEntityType` and the entity-specific key field.
+ */
+const getSelfManageGrantFragment = (
+	authContext: AuthContext,
+): Pick<
+	Extract<
+		WritablePermissionGrant,
+		{ granteeType: PermissionGrantGranteeType.USER }
+	>,
+	'granteeType' | 'granteeUserKeycloakUserId' | 'scope' | 'verbs'
+> => ({
+	granteeType: PermissionGrantGranteeType.USER,
+	granteeUserKeycloakUserId: authContext.user.keycloakUserId,
+	scope: [PermissionGrantEntityType.ANY],
+	verbs: [PermissionGrantVerb.MANAGE],
+});
+
 export {
+	contextEntityKeyProperties,
 	getConditionsForScope,
 	getScopesForContextEntityType,
+	getSelfManageGrantFragment,
+	isPermissionGrantKeyedContextEntityType,
 	isWritablePermissionGrant,
+	PermissionGrantEntityKeyType,
 	PermissionGrantEntityType,
 	PermissionGrantGranteeType,
 	type PermissionGrant,
 	type PermissionGrantCondition,
+	type PermissionGrantEntityKeyValueType,
+	type PermissionGrantKeyedContextEntityType,
 	type WritablePermissionGrant,
 	type WritableUnkeyedPermissionGrant,
 };


### PR DESCRIPTION
This PR updates the API to grant mange permissions on created entities for the creating user.

Resolves #2317 
Relies on #2401 