### PR TITLE
Use a factory for test `Funders`

### DIFF
--- a/src/__tests__/permissionGrants.int.test.ts
+++ b/src/__tests__/permissionGrants.int.test.ts
@@ -1,7 +1,6 @@
 import request from 'supertest';
 import { app } from '../app';
 import {
-	createOrUpdateFunder,
 	createProposal,
 	createSource,
 	getDatabase,
@@ -670,12 +669,7 @@ describe('/permissionGrants', () => {
 		it('creates and returns a permission grant with conditions', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const funder = await createOrUpdateFunder(db, authContext, {
-				shortCode: 'condFunder',
-				name: 'Conditions Test Funder',
-				keycloakOrganizationId: null,
-				isCollaborative: false,
-			});
+			const funder = await createTestFunder(db, authContext);
 			const result = await agent
 				.post('/permissionGrants')
 				.type('application/json')
@@ -720,12 +714,7 @@ describe('/permissionGrants', () => {
 		it('creates a permission grant with null conditions', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const funder = await createOrUpdateFunder(db, authContext, {
-				shortCode: 'nullCondFunder',
-				name: 'Null Conditions Funder',
-				keycloakOrganizationId: null,
-				isCollaborative: false,
-			});
+			const funder = await createTestFunder(db, authContext);
 			const result = await agent
 				.post('/permissionGrants')
 				.type('application/json')
@@ -749,12 +738,7 @@ describe('/permissionGrants', () => {
 		it('creates a permission grant with in operator condition', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const funder = await createOrUpdateFunder(db, authContext, {
-				shortCode: 'eqCondFunder',
-				name: 'In Condition Funder',
-				keycloakOrganizationId: null,
-				isCollaborative: false,
-			});
+			const funder = await createTestFunder(db, authContext);
 			const result = await agent
 				.post('/permissionGrants')
 				.type('application/json')
@@ -790,12 +774,7 @@ describe('/permissionGrants', () => {
 		it('returns 400 when conditions has invalid property name', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const funder = await createOrUpdateFunder(db, authContext, {
-				shortCode: 'badFieldFunder',
-				name: 'Bad Field Funder',
-				keycloakOrganizationId: null,
-				isCollaborative: false,
-			});
+			const funder = await createTestFunder(db, authContext);
 			const result = await agent
 				.post('/permissionGrants')
 				.type('application/json')
@@ -825,12 +804,7 @@ describe('/permissionGrants', () => {
 		it('returns 400 when conditions has invalid operator', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const funder = await createOrUpdateFunder(db, authContext, {
-				shortCode: 'badOpFunder',
-				name: 'Bad Op Funder',
-				keycloakOrganizationId: null,
-				isCollaborative: false,
-			});
+			const funder = await createTestFunder(db, authContext);
 			const result = await agent
 				.post('/permissionGrants')
 				.type('application/json')
@@ -860,12 +834,7 @@ describe('/permissionGrants', () => {
 		it('returns 400 when condition key is not in scope', async () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
-			const funder = await createOrUpdateFunder(db, authContext, {
-				shortCode: 'noScopeFunder',
-				name: 'No Scope Funder',
-				keycloakOrganizationId: null,
-				isCollaborative: false,
-			});
+			const funder = await createTestFunder(db, authContext);
 			const result = await agent
 				.post('/permissionGrants')
 				.type('application/json')

--- a/src/middleware/__tests__/requireFunderPermission.int.test.ts
+++ b/src/middleware/__tests__/requireFunderPermission.int.test.ts
@@ -2,11 +2,11 @@ import { requireFunderPermission } from '../requireFunderPermission';
 import { InputValidationError, UnauthorizedError } from '../../errors';
 import {
 	getDatabase,
-	createOrUpdateFunder,
 	createPermissionGrant,
 	loadSystemUser,
 } from '../../database';
 import { getAuthContext, getMockedUser, loadTestUser } from '../../test/utils';
+import { createTestFunder } from '../../test/factories';
 import { getMockRequest, getMockResponse } from '../../test/mockExpress';
 import {
 	PermissionGrantEntityType,
@@ -66,18 +66,13 @@ describe('requireFunderPermission', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			await createOrUpdateFunder(db, testUserAuthContext, {
-				shortCode: 'test_funder_no_perm',
-				name: 'Test Funder No Permission',
-				keycloakOrganizationId: null,
-				isCollaborative: false,
-			});
+			const unpermittedFunder = await createTestFunder(db, testUserAuthContext);
 
 			const req = getMockRequest() as AuthenticatedRequest;
 			const res = getMockResponse();
 			req.user = testUser;
 			req.role = { isAdministrator: false };
-			req.params = { funderShortCode: 'test_funder_no_perm' };
+			req.params = { funderShortCode: unpermittedFunder.shortCode };
 			const nextMock = jest.fn((error: unknown) => {
 				expect(error).toBeInstanceOf(UnauthorizedError);
 				expect(error).toMatchObject({
@@ -102,18 +97,13 @@ describe('requireFunderPermission', () => {
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const funder = await createOrUpdateFunder(db, testUserAuthContext, {
-				shortCode: 'test_funder_with_perm',
-				name: 'Permitted Funder',
-				keycloakOrganizationId: null,
-				isCollaborative: false,
-			});
+			const permittedFunder = await createTestFunder(db, testUserAuthContext);
 
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
-				funderShortCode: funder.shortCode,
+				funderShortCode: permittedFunder.shortCode,
 				scope: [PermissionGrantEntityType.FUNDER],
 				verbs: [PermissionGrantVerb.EDIT],
 			});
@@ -122,7 +112,7 @@ describe('requireFunderPermission', () => {
 			const res = getMockResponse();
 			req.user = testUser;
 			req.role = { isAdministrator: false };
-			req.params = { funderShortCode: funder.shortCode };
+			req.params = { funderShortCode: permittedFunder.shortCode };
 			const nextMock = jest.fn((error: unknown) => {
 				expect(error).toBe(undefined);
 				done();
@@ -143,18 +133,13 @@ describe('requireFunderPermission', () => {
 			const systemUserAuthContext = getAuthContext(systemUser, true);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const funder = await createOrUpdateFunder(db, testUserAuthContext, {
-				shortCode: 'test_funder_view_only',
-				name: 'View Only Funder',
-				keycloakOrganizationId: null,
-				isCollaborative: false,
-			});
+			const viewOnlyFunder = await createTestFunder(db, testUserAuthContext);
 
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
 				contextEntityType: PermissionGrantEntityType.FUNDER,
-				funderShortCode: funder.shortCode,
+				funderShortCode: viewOnlyFunder.shortCode,
 				scope: [PermissionGrantEntityType.FUNDER],
 				verbs: [PermissionGrantVerb.VIEW],
 			});
@@ -163,7 +148,7 @@ describe('requireFunderPermission', () => {
 			const res = getMockResponse();
 			req.user = testUser;
 			req.role = { isAdministrator: false };
-			req.params = { funderShortCode: funder.shortCode };
+			req.params = { funderShortCode: viewOnlyFunder.shortCode };
 			const nextMock = jest.fn((error: unknown) => {
 				expect(error).toBeInstanceOf(UnauthorizedError);
 				expect(error).toMatchObject({


### PR DESCRIPTION
This PR updates our test to use a factory for `Funder` entities.

Related to #2189