### PR TITLE
Use factory for `Source` in tests

### DIFF
--- a/src/__tests__/bulkUploadTasks.int.test.ts
+++ b/src/__tests__/bulkUploadTasks.int.test.ts
@@ -4,7 +4,6 @@ import {
 	getDatabase,
 	createApplicationForm,
 	createBulkUploadTask,
-	createSource,
 	loadPermissionGrantBundle,
 	loadSystemSource,
 	loadSystemUser,
@@ -16,6 +15,7 @@ import {
 	createTestFile,
 	createTestFunder,
 	createTestOpportunity,
+	createTestSource,
 	createTestUser,
 } from '../test/factories';
 import {
@@ -756,10 +756,13 @@ describe('/tasks/bulkUploads', () => {
 				db,
 				systemUserAuthContext,
 			);
-			const dataProviderSource = await createSource(db, systemUserAuthContext, {
-				label: 'Provider-owned Source',
-				dataProviderShortCode: dataProvider.shortCode,
-			});
+			const dataProviderSource = await createTestSource(
+				db,
+				systemUserAuthContext,
+				{
+					dataProviderShortCode: dataProvider.shortCode,
+				},
+			);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,

--- a/src/__tests__/changemakerFieldValueBatches.int.test.ts
+++ b/src/__tests__/changemakerFieldValueBatches.int.test.ts
@@ -4,11 +4,14 @@ import {
 	getDatabase,
 	createChangemakerFieldValueBatch,
 	createPermissionGrant,
-	createSource,
 	loadSystemUser,
 } from '../database';
 import { expectNumber, expectTimestamp } from '../test/asymettricMatchers';
-import { createTestChangemaker, createTestUser } from '../test/factories';
+import {
+	createTestChangemaker,
+	createTestSource,
+	createTestUser,
+} from '../test/factories';
 import {
 	mockJwt as authHeader,
 	mockJwtWithAdminRole as authHeaderWithAdminRole,
@@ -27,12 +30,7 @@ describe('POST /changemakerFieldValueBatches', () => {
 		const systemUserAuthContext = getAuthContext(systemUser);
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
-		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
-			changemakerId: changemaker.id,
-		});
+		const source = await createTestSource(db, testUserAuthContext);
 		await createPermissionGrant(db, systemUserAuthContext, {
 			granteeType: PermissionGrantGranteeType.USER,
 			granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -57,10 +55,7 @@ describe('POST /changemakerFieldValueBatches', () => {
 			sourceId: source.id,
 			notes: 'Routine annual import',
 			createdAt: expectTimestamp(),
-			source: {
-				id: source.id,
-				label: 'Test Source',
-			},
+			source,
 		});
 	});
 
@@ -70,12 +65,7 @@ describe('POST /changemakerFieldValueBatches', () => {
 		const systemUserAuthContext = getAuthContext(systemUser);
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
-		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
-			changemakerId: changemaker.id,
-		});
+		const source = await createTestSource(db, testUserAuthContext);
 		await createPermissionGrant(db, systemUserAuthContext, {
 			granteeType: PermissionGrantGranteeType.USER,
 			granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -150,12 +140,7 @@ describe('POST /changemakerFieldValueBatches', () => {
 		const db = getDatabase();
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
-		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
-			changemakerId: changemaker.id,
-		});
+		const source = await createTestSource(db, testUserAuthContext);
 
 		const result = await request(app)
 			.post('/changemakerFieldValueBatches')
@@ -180,8 +165,7 @@ describe('POST /changemakerFieldValueBatches', () => {
 		const testUserAuthContext = getAuthContext(testUser);
 		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 		await createPermissionGrant(db, systemUserAuthContext, {
@@ -231,12 +215,7 @@ describe('GET /changemakerFieldValueBatches', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 
-		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
-			changemakerId: changemaker.id,
-		});
+		const source = await createTestSource(db, testUserAuthContext);
 
 		const firstBatch = await createChangemakerFieldValueBatch(
 			db,
@@ -274,12 +253,7 @@ describe('GET /changemakerFieldValueBatches', () => {
 		const anotherUser = await createTestUser(db, null);
 		const anotherUserAuthContext = getAuthContext(anotherUser);
 
-		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
-			changemakerId: changemaker.id,
-		});
+		const source = await createTestSource(db, testUserAuthContext);
 
 		const testUserBatch = await createChangemakerFieldValueBatch(
 			db,
@@ -313,12 +287,7 @@ describe('GET /changemakerFieldValueBatches', () => {
 		const anotherUser = await createTestUser(db, null);
 		const anotherUserAuthContext = getAuthContext(anotherUser);
 
-		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
-			changemakerId: changemaker.id,
-		});
+		const source = await createTestSource(db, testUserAuthContext);
 
 		const testUserBatch = await createChangemakerFieldValueBatch(
 			db,
@@ -360,12 +329,7 @@ describe('GET /changemakerFieldValueBatches/:batchId', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 
-		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
-			changemakerId: changemaker.id,
-		});
+		const source = await createTestSource(db, testUserAuthContext);
 
 		const batch = await createChangemakerFieldValueBatch(
 			db,
@@ -391,12 +355,7 @@ describe('GET /changemakerFieldValueBatches/:batchId', () => {
 		const anotherUser = await createTestUser(db, null);
 		const anotherUserAuthContext = getAuthContext(anotherUser);
 
-		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
-			changemakerId: changemaker.id,
-		});
+		const source = await createTestSource(db, testUserAuthContext);
 
 		const batch = await createChangemakerFieldValueBatch(
 			db,
@@ -424,12 +383,7 @@ describe('GET /changemakerFieldValueBatches/:batchId', () => {
 		const anotherUser = await createTestUser(db, null);
 		const anotherUserAuthContext = getAuthContext(anotherUser);
 
-		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
-			changemakerId: changemaker.id,
-		});
+		const source = await createTestSource(db, testUserAuthContext);
 
 		const batch = await createChangemakerFieldValueBatch(
 			db,

--- a/src/__tests__/changemakerFieldValues.int.test.ts
+++ b/src/__tests__/changemakerFieldValues.int.test.ts
@@ -2,7 +2,6 @@ import request from 'supertest';
 import { app } from '../app';
 import {
 	getDatabase,
-	createSource,
 	createChangemakerFieldValueBatch,
 	createChangemakerFieldValue,
 	createEphemeralUserGroupAssociation,
@@ -16,7 +15,11 @@ import {
 	expectObjectContaining,
 	expectTimestamp,
 } from '../test/asymettricMatchers';
-import { createTestBaseField, createTestChangemaker } from '../test/factories';
+import {
+	createTestBaseField,
+	createTestChangemaker,
+	createTestSource,
+} from '../test/factories';
 import {
 	getAuthContext,
 	loadTestUser,
@@ -46,8 +49,7 @@ describe('POST /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -92,8 +94,7 @@ describe('POST /changemakerFieldValues', () => {
 		const testUserAuthContext = getAuthContext(testUser, true);
 		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 		const baseField = await createTestBaseField(db, null);
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Self-grant Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 		const batch = await createChangemakerFieldValueBatch(
@@ -144,8 +145,7 @@ describe('POST /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -236,8 +236,7 @@ describe('POST /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -298,8 +297,7 @@ describe('POST /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -355,8 +353,7 @@ describe('POST /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -399,8 +396,7 @@ describe('POST /changemakerFieldValues', () => {
 
 		const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -444,8 +440,7 @@ describe('POST /changemakerFieldValues', () => {
 			sensitivityClassification: BaseFieldSensitivityClassification.PUBLIC,
 		});
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -487,8 +482,7 @@ describe('POST /changemakerFieldValues', () => {
 			sensitivityClassification: BaseFieldSensitivityClassification.FORBIDDEN,
 		});
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -556,8 +550,7 @@ describe('POST /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -600,8 +593,7 @@ describe('GET /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -688,13 +680,11 @@ describe('GET /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const visibleSource = await createSource(db, testUserAuthContext, {
-			label: 'Visible Source',
+		const visibleSource = await createTestSource(db, testUserAuthContext, {
 			changemakerId: visibleChangemaker.id,
 		});
 
-		const hiddenSource = await createSource(db, testUserAuthContext, {
-			label: 'Hidden Source',
+		const hiddenSource = await createTestSource(db, testUserAuthContext, {
 			changemakerId: hiddenChangemaker.id,
 		});
 
@@ -760,8 +750,7 @@ describe('GET /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -820,8 +809,7 @@ describe('GET /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -891,13 +879,11 @@ describe('GET /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source1 = await createSource(db, testUserAuthContext, {
-			label: 'Source 1',
+		const source1 = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker1.id,
 		});
 
-		const source2 = await createSource(db, testUserAuthContext, {
-			label: 'Source 2',
+		const source2 = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker2.id,
 		});
 
@@ -961,8 +947,7 @@ describe('GET /changemakerFieldValues', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -1045,8 +1030,7 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -1103,8 +1087,7 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 
@@ -1149,8 +1132,7 @@ describe('GET /changemakerFieldValues/:fieldValueId', () => {
 
 		const baseField = await createTestBaseField(db, null);
 
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Test Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 

--- a/src/__tests__/changemakerProposals.int.test.ts
+++ b/src/__tests__/changemakerProposals.int.test.ts
@@ -10,7 +10,6 @@ import {
 	createProposalFieldValue,
 	createApplicationForm,
 	createApplicationFormField,
-	createSource,
 	loadTableMetrics,
 	loadSystemUser,
 	createPermissionGrant,
@@ -21,6 +20,7 @@ import {
 	createTestFile,
 	createTestFunder,
 	createTestOpportunity,
+	createTestSource,
 } from '../test/factories';
 import { getAuthContext, loadTestUser } from '../test/utils';
 import {
@@ -386,9 +386,8 @@ describe('/changemakerProposals', () => {
 			});
 
 			// Create funder source
-			const funderSource = await createSource(db, testUserAuthContext, {
+			const funderSource = await createTestSource(db, testUserAuthContext, {
 				funderShortCode: testFunder.shortCode,
-				label: 'Proposal Version File Funder Source',
 			});
 
 			// Create opportunity and proposal
@@ -495,10 +494,13 @@ describe('/changemakerProposals', () => {
 			});
 
 			// Create changemaker-sourced source and batch for changemaker field values
-			const changemakerSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: `${changemaker.name} source`,
-			});
+			const changemakerSource = await createTestSource(
+				db,
+				testUserAuthContext,
+				{
+					changemakerId: changemaker.id,
+				},
+			);
 			const batch = await createChangemakerFieldValueBatch(
 				db,
 				systemUserAuthContext,

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -13,7 +13,6 @@ import {
 	createProposal,
 	createProposalFieldValue,
 	createProposalVersion,
-	createSource,
 	loadPermissionGrantBundle,
 	loadSystemSource,
 	loadSystemUser,
@@ -26,6 +25,7 @@ import {
 	createTestFile,
 	createTestFunder,
 	createTestOpportunity,
+	createTestSource,
 } from '../test/factories';
 import {
 	getAuthContext,
@@ -98,12 +98,11 @@ const setupTestContext = async (db: TinyPg) => {
 		name: 'Changemaker 5387',
 		keycloakOrganizationId: '8b15d276-be48-11ef-a061-5b4a50e82d50',
 	});
-	const { id: secondChangemakerSourceId } = await createSource(
+	const { id: secondChangemakerSourceId } = await createTestSource(
 		db,
 		testUserAuthContext,
 		{
 			changemakerId: secondChangemaker.id,
-			label: `${secondChangemaker.name} source`,
 		},
 	);
 	const firstFunder = await createTestFunder(db, testUserAuthContext, {
@@ -131,12 +130,11 @@ const setupTestContext = async (db: TinyPg) => {
 			funderShortCode: firstFunder.shortCode,
 		},
 	);
-	const { id: firstFunderSourceId } = await createSource(
+	const { id: firstFunderSourceId } = await createTestSource(
 		db,
 		testUserAuthContext,
 		{
 			funderShortCode: firstFunder.shortCode,
-			label: `${firstFunder.name} source`,
 		},
 	);
 	const firstDataProvider = await createTestDataProvider(
@@ -147,20 +145,18 @@ const setupTestContext = async (db: TinyPg) => {
 		db,
 		testUserAuthContext,
 	);
-	const { id: firstDataProviderSourceId } = await createSource(
+	const { id: firstDataProviderSourceId } = await createTestSource(
 		db,
 		testUserAuthContext,
 		{
 			dataProviderShortCode: firstDataProvider.shortCode,
-			label: `${firstDataProvider.name} source`,
 		},
 	);
-	const { id: secondDataProviderSourceId } = await createSource(
+	const { id: secondDataProviderSourceId } = await createTestSource(
 		db,
 		testUserAuthContext,
 		{
 			dataProviderShortCode: secondDataProvider.shortCode,
-			label: `${secondDataProvider.name} source`,
 		},
 	);
 
@@ -1764,10 +1760,13 @@ describe('/changemakers', () => {
 			const baseField = await createTestBaseField(db, null);
 			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 			// Create a changemaker-sourced source
-			const changemakerSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: `${changemaker.name} source`,
-			});
+			const changemakerSource = await createTestSource(
+				db,
+				testUserAuthContext,
+				{
+					changemakerId: changemaker.id,
+				},
+			);
 			// Create a batch linked to the source
 			const batch = await createChangemakerFieldValueBatch(
 				db,
@@ -1827,9 +1826,8 @@ describe('/changemakers', () => {
 			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 			});
-			const funderSource = await createSource(db, testUserAuthContext, {
+			const funderSource = await createTestSource(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
-				label: 'Funder Priority Source',
 			});
 
 			// Create ProposalFieldValue from funder source (should be lower priority)
@@ -1872,10 +1870,13 @@ describe('/changemakers', () => {
 			});
 
 			// Create changemaker-sourced ChangemakerFieldValue (should win)
-			const changemakerSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: `${changemaker.name} source`,
-			});
+			const changemakerSource = await createTestSource(
+				db,
+				testUserAuthContext,
+				{
+					changemakerId: changemaker.id,
+				},
+			);
 			const batch = await createChangemakerFieldValueBatch(
 				db,
 				systemUserAuthContext,
@@ -1932,10 +1933,13 @@ describe('/changemakers', () => {
 			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 			// Create changemaker-sourced source
-			const changemakerSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: `${changemaker.name} source`,
-			});
+			const changemakerSource = await createTestSource(
+				db,
+				testUserAuthContext,
+				{
+					changemakerId: changemaker.id,
+				},
+			);
 
 			// Create older ChangemakerFieldValue
 			const olderBatch = await createChangemakerFieldValueBatch(
@@ -2011,10 +2015,13 @@ describe('/changemakers', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
-			const changemakerSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: `${changemaker.name} source`,
-			});
+			const changemakerSource = await createTestSource(
+				db,
+				testUserAuthContext,
+				{
+					changemakerId: changemaker.id,
+				},
+			);
 			const batch = await createChangemakerFieldValueBatch(
 				db,
 				systemUserAuthContext,
@@ -2061,10 +2068,13 @@ describe('/changemakers', () => {
 			const changemaker = await createTestChangemaker(db, testUserAuthContext);
 
 			// Create ChangemakerFieldValue for email
-			const changemakerSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: `${changemaker.name} source`,
-			});
+			const changemakerSource = await createTestSource(
+				db,
+				testUserAuthContext,
+				{
+					changemakerId: changemaker.id,
+				},
+			);
 			const batch = await createChangemakerFieldValueBatch(
 				db,
 				systemUserAuthContext,
@@ -2111,9 +2121,8 @@ describe('/changemakers', () => {
 			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 			});
-			const funderSource = await createSource(db, testUserAuthContext, {
+			const funderSource = await createTestSource(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
-				label: 'Funder Multi Source',
 			});
 			const proposal = await createProposal(db, systemUserAuthContext, {
 				opportunityId: opportunity.id,
@@ -2247,9 +2256,8 @@ describe('/changemakers', () => {
 					funderShortCode: funderWithFieldValueScope.shortCode,
 				},
 			);
-			const source1 = await createSource(db, testUserAuthContext, {
+			const source1 = await createTestSource(db, testUserAuthContext, {
 				funderShortCode: funderWithFieldValueScope.shortCode,
-				label: 'Source With FV Scope',
 			});
 			const proposal1 = await createProposal(db, systemUserAuthContext, {
 				opportunityId: opportunity1.id,
@@ -2297,9 +2305,8 @@ describe('/changemakers', () => {
 					funderShortCode: funderWithoutFieldValueScope.shortCode,
 				},
 			);
-			const source2 = await createSource(db, testUserAuthContext, {
+			const source2 = await createTestSource(db, testUserAuthContext, {
 				funderShortCode: funderWithoutFieldValueScope.shortCode,
-				label: 'Source Without FV Scope',
 			});
 			const proposal2 = await createProposal(db, systemUserAuthContext, {
 				opportunityId: opportunity2.id,
@@ -2378,10 +2385,13 @@ describe('/changemakers', () => {
 			});
 
 			// Create changemaker-sourced source and batch
-			const changemakerSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: `${changemaker.name} source`,
-			});
+			const changemakerSource = await createTestSource(
+				db,
+				testUserAuthContext,
+				{
+					changemakerId: changemaker.id,
+				},
+			);
 			const batch = await createChangemakerFieldValueBatch(
 				db,
 				systemUserAuthContext,
@@ -2490,10 +2500,13 @@ describe('/changemakers', () => {
 			});
 
 			// Create changemaker-sourced source and batch
-			const changemakerSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: `${changemaker.name} source`,
-			});
+			const changemakerSource = await createTestSource(
+				db,
+				testUserAuthContext,
+				{
+					changemakerId: changemaker.id,
+				},
+			);
 			const batch = await createChangemakerFieldValueBatch(
 				db,
 				systemUserAuthContext,
@@ -2578,9 +2591,8 @@ describe('/changemakers', () => {
 			const opportunity = await createTestOpportunity(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
 			});
-			const funderSource = await createSource(db, testUserAuthContext, {
+			const funderSource = await createTestSource(db, testUserAuthContext, {
 				funderShortCode: funder.shortCode,
-				label: 'Funder Proposal File Source',
 			});
 
 			const proposal = await createProposal(db, systemUserAuthContext, {

--- a/src/__tests__/permissionGrantManageVerb.int.test.ts
+++ b/src/__tests__/permissionGrantManageVerb.int.test.ts
@@ -7,7 +7,6 @@ import {
 	createProposal,
 	createProposalFieldValue,
 	createProposalVersion,
-	createSource,
 	getDatabase,
 	hasChangemakerFieldValuePermission,
 	hasChangemakerPermission,
@@ -25,6 +24,7 @@ import {
 	createTestDataProvider,
 	createTestFunder,
 	createTestOpportunity,
+	createTestSource,
 } from '../test/factories';
 import { getAuthContext, loadTestUser } from '../test/utils';
 import {
@@ -102,8 +102,7 @@ describe('`manage` verb semantics', () => {
 		const testUserAuthContext = getAuthContext(testUser);
 		const adminAuthContext = getAuthContext(testUser, true);
 		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Source under changemaker',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 		const baseField = await createTestBaseField(db, null);
@@ -226,8 +225,7 @@ describe('`manage` verb semantics', () => {
 		const testUserAuthContext = getAuthContext(testUser);
 		const adminAuthContext = getAuthContext(testUser, true);
 		const dataProvider = await createTestDataProvider(db, testUserAuthContext);
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'DP-owned Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			dataProviderShortCode: dataProvider.shortCode,
 		});
 
@@ -265,8 +263,7 @@ describe('`manage` verb semantics', () => {
 		const testUserAuthContext = getAuthContext(testUser);
 		const adminAuthContext = getAuthContext(testUser, true);
 		const changemaker = await createTestChangemaker(db, testUserAuthContext);
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'Directly granted source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			changemakerId: changemaker.id,
 		});
 

--- a/src/__tests__/permissionGrants.int.test.ts
+++ b/src/__tests__/permissionGrants.int.test.ts
@@ -2,7 +2,6 @@ import request from 'supertest';
 import { app } from '../app';
 import {
 	createProposal,
-	createSource,
 	getDatabase,
 	hasChangemakerPermission,
 	hasDataProviderPermission,
@@ -24,6 +23,7 @@ import {
 	createTestFunder,
 	createTestOpportunity,
 	createTestPermissionGrant,
+	createTestSource,
 } from '../test/factories';
 import {
 	mockJwt as authHeader,
@@ -1544,8 +1544,7 @@ describe('/permissionGrants', () => {
 			const db = getDatabase();
 			const authContext = await getTestAuthContext(db);
 			const changemaker = await createTestChangemaker(db, authContext);
-			const source = await createSource(db, authContext, {
-				label: 'Cascade Test Source',
+			const source = await createTestSource(db, authContext, {
 				changemakerId: changemaker.id,
 			});
 			await createTestPermissionGrant(db, authContext, {
@@ -1831,8 +1830,7 @@ describe('`any` scope semantics', () => {
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
 		const dataProvider = await createTestDataProvider(db, testUserAuthContext);
-		const source = await createSource(db, testUserAuthContext, {
-			label: 'DP-owned Source',
+		const source = await createTestSource(db, testUserAuthContext, {
 			dataProviderShortCode: dataProvider.shortCode,
 		});
 

--- a/src/__tests__/proposalVersions.int.test.ts
+++ b/src/__tests__/proposalVersions.int.test.ts
@@ -8,7 +8,6 @@ import {
 	createOrUpdateBaseField,
 	createProposal,
 	createProposalVersion,
-	createSource,
 	loadPermissionGrantBundle,
 	loadSystemFunder,
 	loadSystemSource,
@@ -24,6 +23,7 @@ import {
 	createTestChangemaker,
 	createTestFunder,
 	createTestOpportunity,
+	createTestSource,
 } from '../test/factories';
 import {
 	BaseFieldCategory,
@@ -583,8 +583,7 @@ describe('/proposalVersions', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const sourceFunder = await createTestFunder(db, systemUserAuthContext);
-			const funderSource = await createSource(db, systemUserAuthContext, {
-				label: 'Funder-owned Source',
+			const funderSource = await createTestSource(db, systemUserAuthContext, {
 				funderShortCode: sourceFunder.shortCode,
 			});
 			const opportunity = await createTestOpportunity(db, testUserAuthContext);

--- a/src/__tests__/sources.int.test.ts
+++ b/src/__tests__/sources.int.test.ts
@@ -3,7 +3,6 @@ import { app } from '../app';
 import {
 	getDatabase,
 	createEphemeralUserGroupAssociation,
-	createSource,
 	loadPermissionGrantBundle,
 	loadSystemSource,
 	loadTableMetrics,
@@ -24,6 +23,7 @@ import {
 	createTestDataProvider,
 	createTestFunder,
 	createTestOpportunity,
+	createTestSource,
 } from '../test/factories';
 import {
 	getAuthContext,
@@ -55,11 +55,7 @@ describe('/sources', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemSource = await loadSystemSource(db, null);
-			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			const source = await createSource(db, testUserAuthContext, {
-				label: 'Example Inc.',
-				changemakerId: changemaker.id,
-			});
+			const source = await createTestSource(db, testUserAuthContext);
 			const response = await agent
 				.get('/sources')
 				.set(adminUserAuthHeader)
@@ -74,11 +70,7 @@ describe('/sources', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			await createSource(db, testUserAuthContext, {
-				label: 'Example Inc.',
-				changemakerId: changemaker.id,
-			});
+			await createTestSource(db, testUserAuthContext);
 			await agent.get('/sources').set(authHeader).expect(200, {
 				entries: [],
 				total: 0,
@@ -91,15 +83,8 @@ describe('/sources', () => {
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			const visibleSource = await createSource(db, testUserAuthContext, {
-				label: 'Visible Inc.',
-				changemakerId: changemaker.id,
-			});
-			await createSource(db, testUserAuthContext, {
-				label: 'Hidden Inc.',
-				changemakerId: changemaker.id,
-			});
+			const visibleSource = await createTestSource(db, testUserAuthContext);
+			await createTestSource(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -130,12 +115,10 @@ describe('/sources', () => {
 				db,
 				testUserAuthContext,
 			);
-			const visibleSource = await createSource(db, testUserAuthContext, {
-				label: 'Visible Inc.',
+			const visibleSource = await createTestSource(db, testUserAuthContext, {
 				changemakerId: visibleChangemaker.id,
 			});
-			await createSource(db, testUserAuthContext, {
-				label: 'Hidden Inc.',
+			await createTestSource(db, testUserAuthContext, {
 				changemakerId: hiddenChangemaker.id,
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -162,12 +145,10 @@ describe('/sources', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const visibleFunder = await createTestFunder(db, testUserAuthContext);
 			const hiddenFunder = await createTestFunder(db, testUserAuthContext);
-			const visibleSource = await createSource(db, testUserAuthContext, {
-				label: 'Visible Inc.',
+			const visibleSource = await createTestSource(db, testUserAuthContext, {
 				funderShortCode: visibleFunder.shortCode,
 			});
-			await createSource(db, testUserAuthContext, {
-				label: 'Hidden Inc.',
+			await createTestSource(db, testUserAuthContext, {
 				funderShortCode: hiddenFunder.shortCode,
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -200,12 +181,10 @@ describe('/sources', () => {
 				db,
 				testUserAuthContext,
 			);
-			const visibleSource = await createSource(db, testUserAuthContext, {
-				label: 'Visible Inc.',
+			const visibleSource = await createTestSource(db, testUserAuthContext, {
 				dataProviderShortCode: visibleDataProvider.shortCode,
 			});
-			await createSource(db, testUserAuthContext, {
-				label: 'Hidden Inc.',
+			await createTestSource(db, testUserAuthContext, {
 				dataProviderShortCode: hiddenDataProvider.shortCode,
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -234,11 +213,7 @@ describe('/sources', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			const source = await createSource(db, testUserAuthContext, {
-				label: 'Example Inc.',
-				changemakerId: changemaker.id,
-			});
+			const source = await createTestSource(db, testUserAuthContext);
 
 			const response = await agent
 				.get(`/sources/${source.id}`)
@@ -253,11 +228,7 @@ describe('/sources', () => {
 			const systemUserAuthContext = getAuthContext(systemUser);
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			const source = await createSource(db, testUserAuthContext, {
-				label: 'Example Inc.',
-				changemakerId: changemaker.id,
-			});
+			const source = await createTestSource(db, testUserAuthContext);
 			await createPermissionGrant(db, systemUserAuthContext, {
 				granteeType: PermissionGrantGranteeType.USER,
 				granteeUserKeycloakUserId: testUser.keycloakUserId,
@@ -281,8 +252,7 @@ describe('/sources', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			const source = await createSource(db, testUserAuthContext, {
-				label: 'Example Inc.',
+			const source = await createTestSource(db, testUserAuthContext, {
 				changemakerId: changemaker.id,
 			});
 			await createPermissionGrant(db, systemUserAuthContext, {
@@ -328,11 +298,7 @@ describe('/sources', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			const source = await createSource(db, testUserAuthContext, {
-				label: 'Example Inc.',
-				changemakerId: changemaker.id,
-			});
+			const source = await createTestSource(db, testUserAuthContext);
 			await agent.get(`/sources/${source.id}`).set(authHeader).expect(404);
 		});
 	});
@@ -416,7 +382,7 @@ describe('/sources', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			await createSource(db, testUserAuthContext, {
+			await createTestSource(db, testUserAuthContext, {
 				label: 'Example Corp',
 				changemakerId: changemaker.id,
 			});
@@ -447,7 +413,7 @@ describe('/sources', () => {
 				db,
 				testUserAuthContext,
 			);
-			await createSource(db, testUserAuthContext, {
+			await createTestSource(db, testUserAuthContext, {
 				label: 'Example Corp',
 				dataProviderShortCode: dataProvider.shortCode,
 			});
@@ -475,7 +441,7 @@ describe('/sources', () => {
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
 			const funder = await createTestFunder(db, testUserAuthContext);
-			await createSource(db, testUserAuthContext, {
+			await createTestSource(db, testUserAuthContext, {
 				label: 'Example Corp',
 				funderShortCode: funder.shortCode,
 			});
@@ -903,11 +869,7 @@ describe('/sources', () => {
 			const db = getDatabase();
 			const testUser = await loadTestUser(db);
 			const testUserAuthContext = getAuthContext(testUser);
-			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			const localSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: 'Example Inc.',
-			});
+			const localSource = await createTestSource(db, testUserAuthContext);
 			const before = await loadTableMetrics(db, 'sources');
 
 			await agent
@@ -928,11 +890,7 @@ describe('/sources', () => {
 			const testUserAuthContext = getAuthContext(testUser);
 			const systemUser = await loadSystemUser(db, null);
 			const systemUserAuthContext = getAuthContext(systemUser);
-			const changemaker = await createTestChangemaker(db, testUserAuthContext);
-			const localSource = await createSource(db, testUserAuthContext, {
-				changemakerId: changemaker.id,
-				label: 'Example Inc.',
-			});
+			const localSource = await createTestSource(db, testUserAuthContext);
 			const opportunity = await createTestOpportunity(db, testUserAuthContext);
 			const proposal = await createProposal(db, systemUserAuthContext, {
 				externalId: 'proposal-1',

--- a/src/test/factories/createTestSource.ts
+++ b/src/test/factories/createTestSource.ts
@@ -1,0 +1,70 @@
+import { v4 as uuidv4 } from 'uuid';
+import { createChangemaker, createSource } from '../../database';
+import type { TinyPg } from 'tinypg';
+import type {
+	AuthContext,
+	Changemaker,
+	Id,
+	Source,
+	WritableSource,
+} from '../../types';
+
+type ObjectWithOrganizationKey =
+	| { changemakerId: Id }
+	| { funderShortCode: string }
+	| { dataProviderShortCode: string };
+
+let defaultChangemakerPromise: Promise<Changemaker> | null = null;
+
+const getOrCreateDefaultChangemaker = async (
+	db: TinyPg,
+	authContext: AuthContext | null,
+): Promise<Changemaker> => {
+	defaultChangemakerPromise ??= createChangemaker(db, authContext, {
+		taxId: `default_test_source_changemaker_${uuidv4()}`,
+		name: 'Default Test Source Changemaker',
+		keycloakOrganizationId: null,
+	});
+	return await defaultChangemakerPromise;
+};
+
+const resetTestSourceFactory = (): void => {
+	defaultChangemakerPromise = null;
+};
+
+const isObjectWithOrganizationKey = (
+	overrideValues: unknown,
+): overrideValues is ObjectWithOrganizationKey =>
+	overrideValues instanceof Object &&
+	(('changemakerId' in overrideValues &&
+		overrideValues.changemakerId !== undefined) ||
+		('funderShortCode' in overrideValues &&
+			overrideValues.funderShortCode !== undefined) ||
+		('dataProviderShortCode' in overrideValues &&
+			overrideValues.dataProviderShortCode !== undefined));
+
+const createTestSource = async (
+	db: TinyPg,
+	authContext: AuthContext | null,
+	overrideValues?: Partial<WritableSource>,
+): Promise<Source> => {
+	const defaultChangemaker = await getOrCreateDefaultChangemaker(
+		db,
+		authContext,
+	);
+	const defaultValues = {
+		label: `Test Source ${uuidv4()}`,
+	};
+	const resolvedObjectWithOrganizationKey: ObjectWithOrganizationKey =
+		isObjectWithOrganizationKey(overrideValues)
+			? overrideValues // This will have more than just the organization key, but that's OK
+			: { changemakerId: defaultChangemaker.id };
+
+	return await createSource(db, authContext, {
+		...defaultValues,
+		...resolvedObjectWithOrganizationKey,
+		...overrideValues,
+	});
+};
+
+export { createTestSource, resetTestSourceFactory };

--- a/src/test/factories/index.ts
+++ b/src/test/factories/index.ts
@@ -6,4 +6,5 @@ export * from './createTestFunder';
 export * from './createTestOpportunity';
 export * from './createTestPermissionGrant';
 export * from './createTestS3Bucket';
+export * from './createTestSource';
 export * from './createTestUser';

--- a/src/test/integrationSuiteSetup.ts
+++ b/src/test/integrationSuiteSetup.ts
@@ -4,7 +4,10 @@ import nock from 'nock';
  * via `setupFilesAfterEnv`.
  */
 import { loadConfig } from '../config';
-import { resetTestPermissionGrantFactory } from './factories';
+import {
+	resetTestPermissionGrantFactory,
+	resetTestSourceFactory,
+} from './factories';
 import {
 	closeAdminClient,
 	createWorkerDatabase,
@@ -26,6 +29,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
 	resetTestPermissionGrantFactory();
+	resetTestSourceFactory();
 	mockJwks.start();
 	await createWorkerDatabase();
 	await loadConfig();


### PR DESCRIPTION
This PR adds a `sourceFactory` test utility.

Related to #2189 