### PR TITLE
Add funder query param for opportunities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.37.0 2026-05-25
+
 ### Fixed
 
 - Bulk upload processing no longer fails when a row leaves a file-typed field blank. The empty cell is stored as a non-file value (`value: ""`, `isValid: false`) and no attachment lookup is attempted for that field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `GET /opportunities` now accepts an optional `funder` query parameter to filter opportunities by funder shortCode.
 - Creating an entity now automatically grants the creator a `manage` permission with `any` scope on the new entity. This applies to opportunities, changemakers, proposals, sources, bulk upload tasks, application forms (and their fields), proposal versions (and their field values), and changemaker field values created via the HTTP API, as well as proposals, proposal versions, proposal field values, and newly inserted changemakers created during bulk upload processing.
 - Viewing application forms now requires explicit `view | applicationForm` scope, checked via a new `has_application_form_permission` function. The scope can be granted at the applicationForm, opportunity, or funder context level and is inherited appropriately. Previously this was implicitly granted by any `view | opportunity` grant.
 - Viewing application form fields now requires explicit `view | applicationForm` scope on the parent application form, checked via `has_application_form_permission`. Previously this was implicitly granted by any `view | opportunity` grant. Application form fields do not have their own independent permission scope; access to a field is determined entirely by access to its parent form.

--- a/src/__tests__/opportunities.int.test.ts
+++ b/src/__tests__/opportunities.int.test.ts
@@ -21,6 +21,7 @@ import {
 	expectArray,
 	expectArrayContaining,
 	expectObjectContaining,
+	expectString,
 	expectTimestamp,
 } from '../test/asymettricMatchers';
 import {
@@ -66,6 +67,82 @@ describe('/opportunities', () => {
 			expect(response.body).toEqual({
 				entries: [systemOpportunity, opportunity1, opportunity2],
 				total: 3,
+			});
+		});
+
+		it('returns a subset of opportunities present in the database when a funder filter is provided', async () => {
+			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const testFunder = await createTestFunder(db, testUserAuthContext);
+
+			await createTestOpportunity(db, testUserAuthContext);
+			const testFunderOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{
+					funderShortCode: testFunder.shortCode,
+				},
+			);
+
+			const response = await request(app)
+				.get(`/opportunities?funder=${testFunder.shortCode}`)
+				.set(authHeaderWithAdminRole)
+				.expect(200);
+
+			expect(response.body).toEqual({
+				total: 1,
+				entries: [testFunderOpportunity],
+			});
+		});
+
+		it('filters opportunities when the funder shortCode is numeric', async () => {
+			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const numericShortCodeFunder = await createTestFunder(
+				db,
+				testUserAuthContext,
+				{ shortCode: '12345' },
+			);
+
+			await createTestOpportunity(db, testUserAuthContext);
+			const numericFunderOpportunity = await createTestOpportunity(
+				db,
+				testUserAuthContext,
+				{ funderShortCode: numericShortCodeFunder.shortCode },
+			);
+
+			const response = await request(app)
+				.get(`/opportunities?funder=${numericShortCodeFunder.shortCode}`)
+				.set(authHeaderWithAdminRole)
+				.expect(200);
+
+			expect(response.body).toEqual({
+				total: 1,
+				entries: [numericFunderOpportunity],
+			});
+		});
+
+		it('returns a 400 error if an invalid funder filter is provided', async () => {
+			const response = await request(app)
+				.get(`/opportunities?funder=\u{1F600}`)
+				.set(authHeader)
+				.expect(400);
+			expect(response.body).toMatchObject({
+				name: 'InputValidationError',
+				message: expectString(),
+			});
+		});
+
+		it('returns a 400 error if the funder filter is repeated', async () => {
+			const response = await request(app)
+				.get('/opportunities?funder=foo&funder=bar')
+				.set(authHeader)
+				.expect(400);
+			expect(response.body).toMatchObject({
+				name: 'InputValidationError',
+				message: expectString(),
 			});
 		});
 

--- a/src/database/operations/opportunities/loadOpportunityBundle.ts
+++ b/src/database/operations/opportunities/loadOpportunityBundle.ts
@@ -1,9 +1,9 @@
 import { generateLoadBundleOperation } from '../generators';
-import type { Opportunity } from '../../../types';
+import type { Opportunity, ShortCode } from '../../../types';
 
-const loadOpportunityBundle = generateLoadBundleOperation<Opportunity, []>(
-	'opportunities.selectWithPagination',
-	[],
-);
+const loadOpportunityBundle = generateLoadBundleOperation<
+	Opportunity,
+	[funderShortCode: ShortCode | undefined]
+>('opportunities.selectWithPagination', ['funderShortCode']);
 
 export { loadOpportunityBundle };

--- a/src/database/queries/opportunities/selectWithPagination.sql
+++ b/src/database/queries/opportunities/selectWithPagination.sql
@@ -3,7 +3,13 @@ WITH
 		SELECT opportunities.*
 		FROM opportunities
 		WHERE
-			has_opportunity_permission(
+			CASE
+				WHEN :funderShortCode::short_code_t IS NULL THEN
+					TRUE
+				ELSE
+					opportunities.funder_short_code = :funderShortCode
+			END
+			AND has_opportunity_permission(
 				:authContextKeycloakUserId,
 				:authContextIsAdministrator,
 				opportunities.id,

--- a/src/handlers/opportunitiesHandlers.ts
+++ b/src/handlers/opportunitiesHandlers.ts
@@ -21,7 +21,10 @@ import {
 	InputValidationError,
 	UnauthorizedError,
 } from '../errors';
-import { extractPaginationParameters } from '../queryParameters';
+import {
+	extractFunderParameters,
+	extractPaginationParameters,
+} from '../queryParameters';
 import { coerceParams } from '../coercion';
 import type { Request, Response } from 'express';
 
@@ -32,7 +35,14 @@ const getOpportunities = async (req: Request, res: Response): Promise<void> => {
 	const db = getDatabase();
 	const paginationParameters = extractPaginationParameters(req);
 	const { offset, limit } = getLimitValues(paginationParameters);
-	const opportunityBundle = await loadOpportunityBundle(db, req, limit, offset);
+	const { funderShortCode } = extractFunderParameters(req);
+	const opportunityBundle = await loadOpportunityBundle(
+		db,
+		req,
+		funderShortCode,
+		limit,
+		offset,
+	);
 	res
 		.status(HTTP_STATUS.SUCCESSFUL.OK)
 		.contentType('application/json')

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.36.0",
+		"version": "0.37.0",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"

--- a/src/openapi/components/parameters/funderParam.json
+++ b/src/openapi/components/parameters/funderParam.json
@@ -1,6 +1,6 @@
 {
 	"schema": {
-		"type": "string"
+		"$ref": "../schemas/shortCode.json"
 	},
 	"in": "query",
 	"name": "funder",

--- a/src/openapi/paths/opportunities.json
+++ b/src/openapi/paths/opportunities.json
@@ -10,7 +10,8 @@
 		],
 		"parameters": [
 			{ "$ref": "../components/parameters/pageParam.json" },
-			{ "$ref": "../components/parameters/countParam.json" }
+			{ "$ref": "../components/parameters/countParam.json" },
+			{ "$ref": "../components/parameters/funderParam.json" }
 		],
 		"responses": {
 			"200": {

--- a/src/queryParameters/extractFunderParameters.ts
+++ b/src/queryParameters/extractFunderParameters.ts
@@ -1,7 +1,6 @@
 import { ajv } from '../ajv';
 import { InputValidationError } from '../errors';
 import { shortCodeSchema } from '../types';
-import { coerceQuery } from '../coercion';
 import type { JSONSchemaType } from 'ajv';
 import type { Request } from 'express';
 import type { ShortCode } from '../types';
@@ -29,15 +28,14 @@ const isFunderParametersQuery = ajv.compile(funderParametersQuerySchema);
 
 const extractFunderParameters = (request: Request): FunderParameters => {
 	const { query } = request;
-	const coercedQuery = coerceQuery(query);
-	if (!isFunderParametersQuery(coercedQuery)) {
+	if (!isFunderParametersQuery(query)) {
 		throw new InputValidationError(
 			'Invalid funder parameters.',
 			isFunderParametersQuery.errors ?? [],
 		);
 	}
 	return {
-		funderShortCode: coercedQuery.funder,
+		funderShortCode: query.funder,
 	};
 };
 


### PR DESCRIPTION
This commit adds in a funder query parameter to the opportunities handler, and corresponding database query, that allows for filtering on funder shortCode.

Closes #2372 