### PR TITLE
PR deploy previews exit on error

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -314,7 +314,7 @@ jobs:
             if [ "${phase}" == "ACTIVE" ]; then
               # You might expect to get the live URL from response, no.
               break
-            elif [ "${phase}" == "FAILED" ]; then
+            elif [ "${phase}" == "FAILED" ] || [ "${phase}" == "ERROR" ]; then
               exit 153
             fi
           done


### PR DESCRIPTION
DO sometimes returns `ERROR` rather than `FAILED` for app deployment. Handle that appropriately.