### PR TITLE
Use stable functions

### DIFF
--- a/src/database/initialization/can_manage_permission_grant.sql
+++ b/src/database/initialization/can_manage_permission_grant.sql
@@ -93,4 +93,4 @@ BEGIN
 				permission_grant.context_entity_type;
 	END CASE;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/has_application_form_permission.sql
+++ b/src/database/initialization/has_application_form_permission.sql
@@ -56,4 +56,4 @@ BEGIN
 
 	RETURN has_permission;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/has_changemaker_field_value_permission.sql
+++ b/src/database/initialization/has_changemaker_field_value_permission.sql
@@ -67,4 +67,4 @@ BEGIN
 
 	RETURN has_permission;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/has_changemaker_permission.sql
+++ b/src/database/initialization/has_changemaker_permission.sql
@@ -39,4 +39,4 @@ BEGIN
 
 	RETURN has_permission;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/has_data_provider_permission.sql
+++ b/src/database/initialization/has_data_provider_permission.sql
@@ -39,4 +39,4 @@ BEGIN
 
 	RETURN has_permission;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/has_funder_permission.sql
+++ b/src/database/initialization/has_funder_permission.sql
@@ -39,4 +39,4 @@ BEGIN
 
 	RETURN has_permission;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/has_opportunity_permission.sql
+++ b/src/database/initialization/has_opportunity_permission.sql
@@ -49,4 +49,4 @@ BEGIN
 
 	RETURN has_permission;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/has_proposal_field_value_permission.sql
+++ b/src/database/initialization/has_proposal_field_value_permission.sql
@@ -103,4 +103,4 @@ BEGIN
 
 	RETURN has_permission;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/has_proposal_permission.sql
+++ b/src/database/initialization/has_proposal_permission.sql
@@ -61,4 +61,4 @@ BEGIN
 
 	RETURN has_permission;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/has_source_permission.sql
+++ b/src/database/initialization/has_source_permission.sql
@@ -61,4 +61,4 @@ BEGIN
 
 	RETURN has_permission;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/migrations/0112-alter-function-is_expired-stable.sql
+++ b/src/database/migrations/0112-alter-function-is_expired-stable.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION is_expired(
+	not_after timestamp with time zone DEFAULT NULL
+)
+RETURNS boolean AS $$
+	SELECT not_after IS NOT NULL AND not_after < now();
+$$ LANGUAGE sql STABLE;

--- a/src/database/queries/applicationFormFields/selectWithPagination.sql
+++ b/src/database/queries/applicationFormFields/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT application_form_fields.*
 		FROM application_form_fields
 		WHERE

--- a/src/database/queries/applicationForms/selectWithPagination.sql
+++ b/src/database/queries/applicationForms/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT application_forms.*
 		FROM application_forms
 		WHERE

--- a/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
+++ b/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT base_field_localizations.*
 		FROM base_field_localizations
 		WHERE

--- a/src/database/queries/baseFields/selectWithPagination.sql
+++ b/src/database/queries/baseFields/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT base_fields.*
 		FROM base_fields
 		WHERE

--- a/src/database/queries/baseFieldsCopyTasks/selectWithPagination.sql
+++ b/src/database/queries/baseFieldsCopyTasks/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT base_fields_copy_tasks.*
 		FROM base_fields_copy_tasks
 		WHERE

--- a/src/database/queries/bulkUploadTasks/selectWithPagination.sql
+++ b/src/database/queries/bulkUploadTasks/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT bulk_upload_tasks.*
 		FROM bulk_upload_tasks
 			INNER JOIN application_forms

--- a/src/database/queries/changemakerFieldValueBatches/selectWithPagination.sql
+++ b/src/database/queries/changemakerFieldValueBatches/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT changemaker_field_value_batches.*
 		FROM changemaker_field_value_batches
 		WHERE

--- a/src/database/queries/changemakerFieldValues/selectWithPagination.sql
+++ b/src/database/queries/changemakerFieldValues/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT changemaker_field_values.*
 		FROM changemaker_field_values
 		WHERE

--- a/src/database/queries/changemakers/selectWithPagination.sql
+++ b/src/database/queries/changemakers/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT changemakers.*
 		FROM changemakers
 		WHERE

--- a/src/database/queries/changemakersProposals/selectWithPagination.sql
+++ b/src/database/queries/changemakersProposals/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT changemakers_proposals.*
 		FROM changemakers_proposals
 		WHERE

--- a/src/database/queries/dataProviders/selectWithPagination.sql
+++ b/src/database/queries/dataProviders/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT data_providers.*
 		FROM data_providers
 	),

--- a/src/database/queries/files/selectWithPagination.sql
+++ b/src/database/queries/files/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT files.*
 		FROM files
 		WHERE

--- a/src/database/queries/funderCollaborativeInvitations/selectWithPagination.sql
+++ b/src/database/queries/funderCollaborativeInvitations/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT funder_collaborative_invitations.*
 		FROM funder_collaborative_invitations
 		WHERE

--- a/src/database/queries/funderCollaborativeMembers/selectWithPagination.sql
+++ b/src/database/queries/funderCollaborativeMembers/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT funder_collaborative_members.*
 		FROM funder_collaborative_members
 		WHERE

--- a/src/database/queries/funders/selectWithPagination.sql
+++ b/src/database/queries/funders/selectWithPagination.sql
@@ -12,7 +12,7 @@ WITH
 			END AS tsquery
 	),
 
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT funders.*
 		FROM funders
 			CROSS JOIN search_query

--- a/src/database/queries/opportunities/selectWithPagination.sql
+++ b/src/database/queries/opportunities/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT opportunities.*
 		FROM opportunities
 		WHERE

--- a/src/database/queries/permissionGrants/selectWithPagination.sql
+++ b/src/database/queries/permissionGrants/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT permission_grants.*
 		FROM permission_grants
 		WHERE can_manage_permission_grant(

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT proposals.*
 		FROM proposals
 			INNER JOIN opportunities

--- a/src/database/queries/sources/selectWithPagination.sql
+++ b/src/database/queries/sources/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT sources.*
 		FROM sources
 		WHERE has_source_permission(

--- a/src/database/queries/unifiedAuditLogs/selectWithPagination.sql
+++ b/src/database/queries/unifiedAuditLogs/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT unified_audit_logs.*
 		FROM unified_audit_logs
 	),

--- a/src/database/queries/users/selectWithPagination.sql
+++ b/src/database/queries/users/selectWithPagination.sql
@@ -1,5 +1,5 @@
 WITH
-	candidate_entries AS NOT MATERIALIZED (
+	candidate_entries AS MATERIALIZED (
 		SELECT users.*
 		FROM users
 		WHERE


### PR DESCRIPTION
This PR updates our functions to be `STABLE` where appropriate.  This exposed an issue where `NOT_MATERIALIZED` was ironically resulting in 2x processing, so it also updates our CTEs to be materialized.

Resolves #2329