### PR TITLE
Link to glossary from ERD

### DIFF
--- a/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
+++ b/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
@@ -260,6 +260,8 @@ PDC would then:
 
 It would use the ProposalFieldValue set as the primary source, and the ChangemakerFieldValue set as a secondary source.
 
+See also the [PDC Glossary](GLOSSARY.md) for more information about some of the terms used above.
+
 ## Examples
 
 ### Registering an Application Form


### PR DESCRIPTION
This is a useful change in its own right, but the real motivation for it is to test that autopublication to the PDC web site works as per https://github.com/philanthropyDataCommons/meta/issues/170.