### PR TITLE
Add handling for explicit changemaker column in bulk uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Bulk uploads accept an optional `pdc_changemaker_id` column. When a row supplies a value in that column, the proposal is attached to that exact existing changemaker instead of matching/creating one by `organization_tax_id` + `organization_name`. An invalid or unknown id fails the task with a logged error.
+
 ## 0.39.0 2026-06-24
 
 ### Changed

--- a/src/tasks/__tests__/fixtures/processBulkUploadTask/csvTemplateWithChangemakerIdAndTaxId.csv
+++ b/src/tasks/__tests__/fixtures/processBulkUploadTask/csvTemplateWithChangemakerIdAndTaxId.csv
@@ -1,0 +1,2 @@
+proposal_submitter_email,organization_name,organization_tax_id,pdc_changemaker_id
+foo@example.com,A Deliberately Different Name,99-9999999,1

--- a/src/tasks/__tests__/fixtures/processBulkUploadTask/csvTemplateWithInvalidChangemakerId.csv
+++ b/src/tasks/__tests__/fixtures/processBulkUploadTask/csvTemplateWithInvalidChangemakerId.csv
@@ -1,0 +1,2 @@
+proposal_submitter_email,organization_name,pdc_changemaker_id
+foo@example.com,Some Name,notanumber

--- a/src/tasks/__tests__/fixtures/processBulkUploadTask/csvTemplateWithNonexistentChangemakerId.csv
+++ b/src/tasks/__tests__/fixtures/processBulkUploadTask/csvTemplateWithNonexistentChangemakerId.csv
@@ -1,0 +1,2 @@
+proposal_submitter_email,organization_name,pdc_changemaker_id
+foo@example.com,Some Name,999999

--- a/src/tasks/__tests__/fixtures/processBulkUploadTask/validCsvTemplateWithChangemakerId.csv
+++ b/src/tasks/__tests__/fixtures/processBulkUploadTask/validCsvTemplateWithChangemakerId.csv
@@ -1,0 +1,2 @@
+proposal_submitter_email,organization_name,pdc_changemaker_id
+foo@example.com,A Deliberately Different Name,1

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -41,6 +41,7 @@ import {
 } from '../../test/asymettricMatchers';
 import {
 	createTestBaseField,
+	createTestChangemaker,
 	createTestFile,
 	createTestOpportunity,
 } from '../../test/factories';
@@ -127,6 +128,12 @@ const createTestBaseFields = async (db: TinyPg): Promise<void> => {
 		description: 'Just a file we want to attach.',
 		shortCode: 'favorite_file',
 		dataType: BaseFieldDataType.FILE,
+	});
+	await createTestBaseField(db, null, {
+		label: 'PDC Changemaker ID',
+		description:
+			'The PDC id of an existing changemaker to attach this proposal to.',
+		shortCode: 'pdc_changemaker_id',
 	});
 };
 
@@ -954,6 +961,253 @@ describe('processBulkUploadTask', () => {
 			],
 			total: 2,
 		});
+	});
+
+	it('attaches a proposal to an existing changemaker given by pdc_changemaker_id, creating no duplicate', async () => {
+		const db = getDatabase();
+		await createTestBaseFields(db);
+		const testAuthContext = await getTestAuthContext(db);
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const existingChangemaker = await createTestChangemaker(
+			db,
+			systemUserAuthContext,
+			{ name: 'Original Changemaker Name', taxId: '11-1111111' },
+		);
+		const proposalsDataFile = await createTestFile(db, systemUserAuthContext);
+		const { applicationFormId } = await createTestApplicationForm(
+			db,
+			systemUserAuthContext,
+			['proposal_submitter_email', 'organization_name', 'pdc_changemaker_id'],
+		);
+		const bulkUploadTask = await createTestBulkUploadTask(
+			db,
+			systemUserAuthContext,
+			{ proposalsDataFileId: proposalsDataFile.id, applicationFormId },
+		);
+		s3Mock.on(GetObjectCommand).resolves({
+			Body: sdkStreamMixin(
+				fs.createReadStream(
+					path.join(
+						__dirname,
+						'fixtures',
+						'processBulkUploadTask',
+						'validCsvTemplateWithChangemakerId.csv',
+					),
+				),
+			),
+		});
+
+		await processBulkUploadTask(
+			{ bulkUploadId: bulkUploadTask.id },
+			getMockJobHelpers(),
+		);
+
+		const changemakerBundle = await loadChangemakerBundle(
+			db,
+			null,
+			undefined,
+			undefined,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
+		// No new changemaker is created and the existing name is left untouched,
+		// even though the uploaded row carried a different organization_name.
+		expect(changemakerBundle.total).toBe(1);
+		expect(changemakerBundle.entries).toEqual([
+			expectObjectContaining({
+				id: existingChangemaker.id,
+				name: 'Original Changemaker Name',
+			}),
+		]);
+
+		const changemakerProposalBundle = await loadChangemakerProposalBundle(
+			db,
+			testAuthContext,
+			undefined,
+			undefined,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
+		expect(changemakerProposalBundle.total).toBe(1);
+		expect(changemakerProposalBundle.entries).toEqual([
+			expectObjectContaining({ changemakerId: existingChangemaker.id }),
+		]);
+
+		const updatedBulkUploadTask = await loadBulkUploadTask(
+			db,
+			testAuthContext,
+			bulkUploadTask.id,
+		);
+		expect(updatedBulkUploadTask.status).toEqual(TaskStatus.COMPLETED);
+	});
+
+	it('prefers pdc_changemaker_id over organization_tax_id when both are present', async () => {
+		const db = getDatabase();
+		await createTestBaseFields(db);
+		const testAuthContext = await getTestAuthContext(db);
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const existingChangemaker = await createTestChangemaker(
+			db,
+			systemUserAuthContext,
+			{ name: 'Original Changemaker Name', taxId: '11-1111111' },
+		);
+		const proposalsDataFile = await createTestFile(db, systemUserAuthContext);
+		const { applicationFormId } = await createTestApplicationForm(
+			db,
+			systemUserAuthContext,
+			[
+				'proposal_submitter_email',
+				'organization_name',
+				'organization_tax_id',
+				'pdc_changemaker_id',
+			],
+		);
+		const bulkUploadTask = await createTestBulkUploadTask(
+			db,
+			systemUserAuthContext,
+			{ proposalsDataFileId: proposalsDataFile.id, applicationFormId },
+		);
+		s3Mock.on(GetObjectCommand).resolves({
+			Body: sdkStreamMixin(
+				fs.createReadStream(
+					path.join(
+						__dirname,
+						'fixtures',
+						'processBulkUploadTask',
+						'csvTemplateWithChangemakerIdAndTaxId.csv',
+					),
+				),
+			),
+		});
+
+		await processBulkUploadTask(
+			{ bulkUploadId: bulkUploadTask.id },
+			getMockJobHelpers(),
+		);
+
+		const changemakerBundle = await loadChangemakerBundle(
+			db,
+			null,
+			undefined,
+			undefined,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
+		// The tax id matched nothing, but no new changemaker is created because the
+		// explicit pdc_changemaker_id takes precedence.
+		expect(changemakerBundle.total).toBe(1);
+		expect(changemakerBundle.entries).toEqual([
+			expectObjectContaining({ id: existingChangemaker.id }),
+		]);
+
+		const changemakerProposalBundle = await loadChangemakerProposalBundle(
+			db,
+			testAuthContext,
+			undefined,
+			undefined,
+			NO_LIMIT,
+			NO_OFFSET,
+		);
+		expect(changemakerProposalBundle.entries).toEqual([
+			expectObjectContaining({ changemakerId: existingChangemaker.id }),
+		]);
+	});
+
+	it('fails the task when pdc_changemaker_id is not a valid id', async () => {
+		const db = getDatabase();
+		await createTestBaseFields(db);
+		const testAuthContext = await getTestAuthContext(db);
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const proposalsDataFile = await createTestFile(db, systemUserAuthContext);
+		const { applicationFormId } = await createTestApplicationForm(
+			db,
+			systemUserAuthContext,
+			['proposal_submitter_email', 'organization_name', 'pdc_changemaker_id'],
+		);
+		const bulkUploadTask = await createTestBulkUploadTask(
+			db,
+			systemUserAuthContext,
+			{ proposalsDataFileId: proposalsDataFile.id, applicationFormId },
+		);
+		s3Mock.on(GetObjectCommand).resolves({
+			Body: sdkStreamMixin(
+				fs.createReadStream(
+					path.join(
+						__dirname,
+						'fixtures',
+						'processBulkUploadTask',
+						'csvTemplateWithInvalidChangemakerId.csv',
+					),
+				),
+			),
+		});
+
+		await processBulkUploadTask(
+			{ bulkUploadId: bulkUploadTask.id },
+			getMockJobHelpers(),
+		);
+
+		const updatedBulkUploadTask = await loadBulkUploadTask(
+			db,
+			testAuthContext,
+			bulkUploadTask.id,
+		);
+		expect(updatedBulkUploadTask.status).toEqual(TaskStatus.FAILED);
+		expect(updatedBulkUploadTask.logs).toEqual(
+			expectArrayContaining([
+				expectObjectContaining({
+					isError: true,
+					details: expectObjectContaining({ name: 'InputValidationError' }),
+				}),
+			]),
+		);
+	});
+
+	it('fails the task when pdc_changemaker_id refers to a changemaker that does not exist', async () => {
+		const db = getDatabase();
+		await createTestBaseFields(db);
+		const testAuthContext = await getTestAuthContext(db);
+		const systemUser = await loadSystemUser(db, null);
+		const systemUserAuthContext = getAuthContext(systemUser);
+		const proposalsDataFile = await createTestFile(db, systemUserAuthContext);
+		const { applicationFormId } = await createTestApplicationForm(
+			db,
+			systemUserAuthContext,
+			['proposal_submitter_email', 'organization_name', 'pdc_changemaker_id'],
+		);
+		const bulkUploadTask = await createTestBulkUploadTask(
+			db,
+			systemUserAuthContext,
+			{ proposalsDataFileId: proposalsDataFile.id, applicationFormId },
+		);
+		s3Mock.on(GetObjectCommand).resolves({
+			Body: sdkStreamMixin(
+				fs.createReadStream(
+					path.join(
+						__dirname,
+						'fixtures',
+						'processBulkUploadTask',
+						'csvTemplateWithNonexistentChangemakerId.csv',
+					),
+				),
+			),
+		});
+
+		await processBulkUploadTask(
+			{ bulkUploadId: bulkUploadTask.id },
+			getMockJobHelpers(),
+		);
+
+		const updatedBulkUploadTask = await loadBulkUploadTask(
+			db,
+			testAuthContext,
+			bulkUploadTask.id,
+		);
+		expect(updatedBulkUploadTask.status).toEqual(TaskStatus.FAILED);
+		expect(updatedBulkUploadTask.logs.length).toBeGreaterThan(0);
 	});
 
 	it('should grant the upload-initiating user manage permissions on every entity it creates', async () => {

--- a/src/tasks/processBulkUploadTask.ts
+++ b/src/tasks/processBulkUploadTask.ts
@@ -21,6 +21,7 @@ import {
 	createProposalFieldValue,
 	createProposalVersion,
 	loadBulkUploadTask,
+	loadChangemaker,
 	loadOrCreateChangemaker,
 	updateBulkUploadTask,
 	loadSystemUser,
@@ -30,10 +31,12 @@ import {
 import {
 	TaskStatus,
 	getSelfManageGrantFragment,
+	isId,
 	isProcessBulkUploadJobPayload,
 	BaseFieldDataType,
 	PermissionGrantEntityType,
 } from '../types';
+import { InputValidationError } from '../errors';
 import { fieldValueIsValid } from '../fieldValidation';
 import { allNoLeaks } from '../promises';
 import { SINGLE_STEP } from '../constants';
@@ -52,6 +55,7 @@ import type {
 
 const CHANGEMAKER_TAX_ID_SHORT_CODE = 'organization_tax_id';
 const CHANGEMAKER_NAME_SHORT_CODE = 'organization_name';
+const CHANGEMAKER_PDC_ID_SHORT_CODE = 'pdc_changemaker_id';
 const SINGLE_ENTRY = 1;
 
 const downloadFileDataToTemporaryStorage = async (
@@ -149,6 +153,11 @@ const getChangemakerTaxIdIndex = (fields: ApplicationFormField[]): number =>
 const getChangemakerNameIndex = (fields: ApplicationFormField[]): number =>
 	fields.findIndex(
 		(field) => field.baseFieldShortCode === CHANGEMAKER_NAME_SHORT_CODE,
+	);
+
+const getChangemakerPdcIdIndex = (fields: ApplicationFormField[]): number =>
+	fields.findIndex(
+		(field) => field.baseFieldShortCode === CHANGEMAKER_PDC_ID_SHORT_CODE,
 	);
 
 // THIS FUNCTION IS A MONKEY PATCH
@@ -545,6 +554,9 @@ export const processBulkUploadTask = async (
 		const changemakerTaxIdIndex = getChangemakerTaxIdIndex(
 			applicationFormFields,
 		);
+		const changemakerPdcIdIndex = getChangemakerPdcIdIndex(
+			applicationFormFields,
+		);
 
 		await db.transaction(async (transactionDb) => {
 			const attachmentsManager = new AttachmentsManager(
@@ -594,8 +606,28 @@ export const processBulkUploadTask = async (
 				const {
 					[changemakerNameIndex]: changemakerName,
 					[changemakerTaxIdIndex]: changemakerTaxId,
+					[changemakerPdcIdIndex]: changemakerPdcIdValue,
 				} = record;
-				if (changemakerTaxId !== undefined) {
+				const changemakerPdcId = changemakerPdcIdValue?.trim();
+				if (changemakerPdcId !== undefined && changemakerPdcId !== '') {
+					const changemakerId = Number(changemakerPdcId);
+					if (!isId(changemakerId)) {
+						throw new InputValidationError(
+							`Row ${recordNumber}: invalid ${CHANGEMAKER_PDC_ID_SHORT_CODE} ` +
+								`value "${changemakerPdcIdValue}"; expected an existing changemaker id.`,
+							isId.errors ?? [],
+						);
+					}
+					const changemaker = await loadChangemaker(
+						transactionDb,
+						taskAuthContext,
+						changemakerId,
+					);
+					await createChangemakerProposal(transactionDb, taskAuthContext, {
+						changemakerId: changemaker.id,
+						proposalId: proposal.id,
+					});
+				} else if (changemakerTaxId !== undefined) {
 					const { item: changemaker, wasInserted } =
 						await loadOrCreateChangemaker(transactionDb, taskAuthContext, {
 							name: changemakerName ?? 'Unnamed Organization',


### PR DESCRIPTION
This commit adds another 'special' column for bulk uploads, `pdc_changemaker_id`, which is considered the highest truth to identify a changemaker in a bulk upload. This is to allow there to be a single source for identifying the related changemaker in a bulk upload, as opposed to being matched on name AND tax id.

Closes #2466 