### PR TITLE
Improve performance of `proposal_to_json`

### DIFF
--- a/src/database/initialization/1_changemaker_to_json.sql
+++ b/src/database/initialization/1_changemaker_to_json.sql
@@ -26,6 +26,16 @@ BEGIN
 	WHERE NOT shallow;
 
 	-- Combine ProposalFieldValues and ChangemakerFieldValues, select gold per base field
+	WITH changemaker_proposal_field_value_ids AS (
+		SELECT pfv.id
+		FROM proposal_field_values pfv
+		INNER JOIN proposal_versions pv
+			ON pfv.proposal_version_id = pv.id
+		INNER JOIN changemakers_proposals op
+			ON pv.proposal_id = op.proposal_id
+		WHERE op.changemaker_id = changemaker.id
+	)
+
 	SELECT jsonb_agg(field_value_json)
 	INTO field_values_json
 	FROM (
@@ -61,12 +71,17 @@ BEGIN
 				ON pv.proposal_id = op.proposal_id
 			INNER JOIN sources s
 				ON pv.source_id = s.id
-			-- Restrict to field values the user may view.
-			INNER JOIN permitted_proposal_field_value_ids(
+			-- Restrict to field values the user may view, bounded to this
+			-- changemaker's proposals so permission is computed only for them.
+			INNER JOIN permitted_proposal_field_value_ids_among(
 				auth_context_keycloak_user_id,
 				auth_context_is_administrator,
 				'view',
-				'proposalFieldValue'
+				'proposalFieldValue',
+				ARRAY(
+					SELECT changemaker_proposal_field_value_ids.id
+					FROM changemaker_proposal_field_value_ids
+				)
 			) AS permitted_field_values
 				ON permitted_field_values.id = pfv.id
 			WHERE op.changemaker_id = changemaker.id

--- a/src/database/initialization/1_permitted_proposal_field_value_ids_among.sql
+++ b/src/database/initialization/1_permitted_proposal_field_value_ids_among.sql
@@ -1,46 +1,57 @@
-SELECT drop_function('permitted_proposal_field_value_ids');
+SELECT drop_function('permitted_proposal_field_value_ids_among');
 
--- Every proposal field value the user may access for `verb` at `scope`.
--- Forbidden fields are never included; public fields are included for any
--- authenticated user when `verb` is `view`; otherwise access is granted on the
--- field value or inherited from its proposal, opportunity, funder, or
+-- Returns the subset of `filter_ids` that the user may access for `verb` at
+-- `scope`. Forbidden fields are never included; public fields are included for
+-- any authenticated user when `verb` is `view`; otherwise access is granted on
+-- the field value or inherited from its proposal, opportunity, funder, or
 -- changemaker, subject to the grant's base field category `conditions`.
 --
 -- The inheritance is expanded here rather than reusing permitted_proposal_ids
 -- because the per-field-value category conditions cannot be expressed at the
--- proposal level.
-CREATE FUNCTION permitted_proposal_field_value_ids(
+-- proposal level. Taking the ids as a parameter keeps the work proportional to
+-- the candidates instead of every field value the user can see.
+CREATE FUNCTION permitted_proposal_field_value_ids_among(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
 	verb permission_grant_verb_t,
-	scope permission_grant_entity_type_t
+	scope permission_grant_entity_type_t,
+	filter_ids int []
 ) RETURNS TABLE (id int) AS $$
 	-- Public fields are viewable by any authenticated user.
 	SELECT pfv.id
-	FROM proposal_field_values pfv
+	FROM unnest(
+		permitted_proposal_field_value_ids_among.filter_ids
+	) AS candidate (id)
+	INNER JOIN proposal_field_values pfv ON pfv.id = candidate.id
 	INNER JOIN application_form_fields aff
 		ON pfv.application_form_field_id = aff.id
 	INNER JOIN base_fields bf ON aff.base_field_short_code = bf.short_code
 	WHERE bf.sensitivity_classification = 'public'
-		AND permitted_proposal_field_value_ids.verb = 'view'
+		AND permitted_proposal_field_value_ids_among.verb = 'view'
 
 	UNION
 
 	-- Administrators have all permissions, except on forbidden fields.
 	SELECT pfv.id
-	FROM proposal_field_values pfv
+	FROM unnest(
+		permitted_proposal_field_value_ids_among.filter_ids
+	) AS candidate (id)
+	INNER JOIN proposal_field_values pfv ON pfv.id = candidate.id
 	INNER JOIN application_form_fields aff
 		ON pfv.application_form_field_id = aff.id
 	INNER JOIN base_fields bf ON aff.base_field_short_code = bf.short_code
 	WHERE bf.sensitivity_classification <> 'forbidden'
-		AND permitted_proposal_field_value_ids.user_is_admin
+		AND permitted_proposal_field_value_ids_among.user_is_admin
 
 	UNION
 
 	-- Granted on the field value or inherited from its proposal, opportunity,
 	-- funder, or changemaker -- subject to the grant's base field conditions.
 	SELECT pfv.id
-	FROM proposal_field_values pfv
+	FROM unnest(
+		permitted_proposal_field_value_ids_among.filter_ids
+	) AS candidate (id)
+	INNER JOIN proposal_field_values pfv ON pfv.id = candidate.id
 	INNER JOIN application_form_fields aff
 		ON pfv.application_form_field_id = aff.id
 	INNER JOIN base_fields bf ON aff.base_field_short_code = bf.short_code
@@ -73,16 +84,16 @@ CREATE FUNCTION permitted_proposal_field_value_ids(
 		)
 	WHERE bf.sensitivity_classification <> 'forbidden'
 		AND verb_set_permits_verb(
-			pg.verbs, permitted_proposal_field_value_ids.verb
+			pg.verbs, permitted_proposal_field_value_ids_among.verb
 		)
 		AND scope_set_permits_scope(
-			pg.scope, permitted_proposal_field_value_ids.scope
+			pg.scope, permitted_proposal_field_value_ids_among.scope
 		)
 		AND grantee_permits_user(
 			pg.grantee_type,
 			pg.grantee_user_keycloak_user_id,
 			pg.grantee_keycloak_organization_id,
-			permitted_proposal_field_value_ids.user_keycloak_user_id
+			permitted_proposal_field_value_ids_among.user_keycloak_user_id
 		)
 		AND (
 			pg.conditions IS NULL

--- a/src/database/initialization/1_proposal_version_to_json.sql
+++ b/src/database/initialization/1_proposal_version_to_json.sql
@@ -10,20 +10,26 @@ DECLARE
 	proposal_field_values_json JSONB;
 	source_json JSONB;
 BEGIN
+	WITH version_field_values AS MATERIALIZED (
+		SELECT proposal_field_values.*
+		FROM proposal_field_values
+		WHERE proposal_field_values.proposal_version_id = proposal_version.id
+	)
+
 	SELECT jsonb_agg(
-		proposal_field_value_to_json(proposal_field_values.*)
-		ORDER BY proposal_field_values.position, proposal_field_values.id DESC
+		proposal_field_value_to_json(version_field_values.*)
+		ORDER BY version_field_values.position, version_field_values.id DESC
 	)
 	INTO proposal_field_values_json
-	FROM proposal_field_values
-	INNER JOIN permitted_proposal_field_value_ids(
+	FROM version_field_values
+	INNER JOIN permitted_proposal_field_value_ids_among(
 		auth_context_keycloak_user_id,
 		auth_context_is_administrator,
 		'view',
-		'proposalFieldValue'
+		'proposalFieldValue',
+		ARRAY(SELECT version_field_values.id FROM version_field_values)
 	) AS permitted_field_values
-		ON permitted_field_values.id = proposal_field_values.id
-	WHERE proposal_field_values.proposal_version_id = proposal_version.id;
+		ON permitted_field_values.id = version_field_values.id;
 
 	SELECT source_to_json(
 		sources.*,


### PR DESCRIPTION
This PR addresses an issue where the query planner would not effectively narrow the potential list of proposal field value IDs when loading field value permissions in the context of proposal collections.

Resolves #2473