### PR TITLE
Batch proposal serialization

### DIFF
--- a/src/database/initialization/1_assert_proposal_field_value_not_forbidden.sql
+++ b/src/database/initialization/1_assert_proposal_field_value_not_forbidden.sql
@@ -1,0 +1,26 @@
+SELECT drop_function('assert_proposal_field_value_not_forbidden');
+
+-- Raises if the field value belongs to a forbidden base field, so a forbidden
+-- value is never serialized. Read paths exclude forbidden fields via the
+-- permitted_* functions; this guards the paths that serialize a row directly
+-- (the field value insert), which do not filter by permission.
+CREATE FUNCTION assert_proposal_field_value_not_forbidden(
+	proposal_field_value proposal_field_values
+) RETURNS void AS $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM application_form_fields
+		INNER JOIN base_fields
+			ON base_fields.short_code = application_form_fields.base_field_short_code
+		WHERE application_form_fields.id
+			= proposal_field_value.application_form_field_id
+			AND base_fields.sensitivity_classification = 'forbidden'
+	) THEN
+		RAISE EXCEPTION
+			'Refusing to serialize forbidden proposal_field_value (%)',
+			proposal_field_value.id
+			USING ERRCODE = '22023'; -- invalid_parameter_value
+	END IF;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/1_build_proposal_field_value_result.sql
+++ b/src/database/initialization/1_build_proposal_field_value_result.sql
@@ -1,0 +1,41 @@
+SELECT drop_function('build_proposal_field_value_result');
+
+-- Gathers a single proposal field value's children (application form field,
+-- file) and assembles the result with the proposal_field_value_to_json shape.
+-- For the single-row endpoints; the proposals read path gathers field values in
+-- bulk instead. Guards against forbidden fields, since callers may serialize a
+-- row that has not been permission-filtered (the field value insert).
+CREATE FUNCTION build_proposal_field_value_result(
+	proposal_field_value proposal_field_values
+) RETURNS jsonb AS $$
+DECLARE
+	is_file_field BOOLEAN;
+	application_form_field_json JSONB;
+	version_created_by UUID;
+BEGIN
+	PERFORM assert_proposal_field_value_not_forbidden(proposal_field_value);
+
+	SELECT
+		base_fields.data_type = 'file',
+		application_form_field_to_json(application_form_fields.*)
+	INTO is_file_field, application_form_field_json
+	FROM application_form_fields
+	INNER JOIN base_fields
+		ON base_fields.short_code = application_form_fields.base_field_short_code
+	WHERE application_form_fields.id
+		= proposal_field_value.application_form_field_id;
+
+	SELECT proposal_versions.created_by
+	INTO version_created_by
+	FROM proposal_versions
+	WHERE proposal_versions.id = proposal_field_value.proposal_version_id;
+
+	RETURN proposal_field_value_to_json(
+		proposal_field_value,
+		application_form_field_json,
+		proposal_field_value_file_to_json(
+			proposal_field_value, is_file_field, version_created_by
+		)
+	);
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/1_build_proposal_version_result.sql
+++ b/src/database/initialization/1_build_proposal_version_result.sql
@@ -1,0 +1,51 @@
+SELECT drop_function('build_proposal_version_result');
+
+-- Gathers a single proposal version's children (its viewable field values and
+-- its source) and assembles the result with the proposal_version_to_json shape.
+-- For the single-row endpoints; the proposals read path gathers versions in
+-- bulk instead.
+CREATE FUNCTION build_proposal_version_result(
+	proposal_version proposal_versions,
+	auth_context_keycloak_user_id uuid DEFAULT NULL,
+	auth_context_is_administrator boolean DEFAULT FALSE
+) RETURNS jsonb AS $$
+DECLARE
+	field_values_json JSONB;
+	source_json JSONB;
+BEGIN
+	SELECT jsonb_agg(
+		build_proposal_field_value_result(proposal_field_values)
+		ORDER BY proposal_field_values.position, proposal_field_values.id DESC
+	)
+	INTO field_values_json
+	FROM proposal_field_values
+	INNER JOIN permitted_proposal_field_value_ids_among(
+		auth_context_keycloak_user_id,
+		auth_context_is_administrator,
+		'view',
+		'proposalFieldValue',
+		ARRAY(
+			SELECT id
+			FROM proposal_field_values
+			WHERE proposal_field_values.proposal_version_id = proposal_version.id
+		)
+	) AS permitted_field_values
+		ON permitted_field_values.id = proposal_field_values.id
+	WHERE proposal_field_values.proposal_version_id = proposal_version.id;
+
+	SELECT source_to_json(
+		sources.*,
+		auth_context_keycloak_user_id,
+		auth_context_is_administrator
+	)
+	INTO source_json
+	FROM sources
+	WHERE sources.id = proposal_version.source_id;
+
+	RETURN proposal_version_to_json(
+		proposal_version,
+		field_values_json,
+		source_json
+	);
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/1_changemaker_proposal_to_json.sql
+++ b/src/database/initialization/1_changemaker_proposal_to_json.sql
@@ -10,14 +10,17 @@ DECLARE
   proposal_json JSONB;
   changemaker_json JSONB;
 BEGIN
-  SELECT proposal_to_json(
-    proposals.*,
+  SELECT serialized_proposal.object
+  INTO proposal_json
+  FROM build_proposals_results(
+    ARRAY(
+      SELECT proposals
+      FROM proposals
+      WHERE proposals.id = changemaker_proposal.proposal_id
+    ),
     auth_context_keycloak_user_id,
     auth_context_is_administrator
-  )
-  INTO proposal_json
-  FROM proposals
-  WHERE proposals.id = changemaker_proposal.proposal_id;
+  ) AS serialized_proposal;
 
   SELECT changemaker_to_json(
     changemakers.*,

--- a/src/database/initialization/1_changemaker_to_json.sql
+++ b/src/database/initialization/1_changemaker_to_json.sql
@@ -50,7 +50,7 @@ BEGIN
 		FROM (
 			-- ProposalFieldValues
 			SELECT
-				proposal_field_value_to_json(pfv.*) AS field_value_json,
+				build_proposal_field_value_result(pfv.*) AS field_value_json,
 				bf.short_code AS base_field_short_code,
 				s.changemaker_id AS source_changemaker_id,
 				s.funder_short_code AS source_funder_short_code,

--- a/src/database/initialization/1_permitted_proposal_field_value_ids_among.sql
+++ b/src/database/initialization/1_permitted_proposal_field_value_ids_among.sql
@@ -6,10 +6,10 @@ SELECT drop_function('permitted_proposal_field_value_ids_among');
 -- the field value or inherited from its proposal, opportunity, funder, or
 -- changemaker, subject to the grant's base field category `conditions`.
 --
--- The inheritance is expanded here rather than reusing permitted_proposal_ids
--- because the per-field-value category conditions cannot be expressed at the
--- proposal level. Taking the ids as a parameter keeps the work proportional to
--- the candidates instead of every field value the user can see.
+-- Bounding to `filter_ids` keeps the work proportional to the candidates rather
+-- than every field value the user can see. Administrators skip the
+-- grant-inheritance branch entirely: they already have every non-forbidden
+-- field, so that branch can only return a subset of what they already get.
 CREATE FUNCTION permitted_proposal_field_value_ids_among(
 	user_keycloak_user_id uuid,
 	user_is_admin boolean,
@@ -19,28 +19,24 @@ CREATE FUNCTION permitted_proposal_field_value_ids_among(
 ) RETURNS TABLE (id int) AS $$
 	-- Public fields are viewable by any authenticated user.
 	SELECT pfv.id
-	FROM unnest(
-		permitted_proposal_field_value_ids_among.filter_ids
-	) AS candidate (id)
-	INNER JOIN proposal_field_values pfv ON pfv.id = candidate.id
+	FROM proposal_field_values pfv
 	INNER JOIN application_form_fields aff
 		ON pfv.application_form_field_id = aff.id
 	INNER JOIN base_fields bf ON aff.base_field_short_code = bf.short_code
-	WHERE bf.sensitivity_classification = 'public'
+	WHERE pfv.id = ANY(permitted_proposal_field_value_ids_among.filter_ids)
+		AND bf.sensitivity_classification = 'public'
 		AND permitted_proposal_field_value_ids_among.verb = 'view'
 
 	UNION
 
 	-- Administrators have all permissions, except on forbidden fields.
 	SELECT pfv.id
-	FROM unnest(
-		permitted_proposal_field_value_ids_among.filter_ids
-	) AS candidate (id)
-	INNER JOIN proposal_field_values pfv ON pfv.id = candidate.id
+	FROM proposal_field_values pfv
 	INNER JOIN application_form_fields aff
 		ON pfv.application_form_field_id = aff.id
 	INNER JOIN base_fields bf ON aff.base_field_short_code = bf.short_code
-	WHERE bf.sensitivity_classification <> 'forbidden'
+	WHERE pfv.id = ANY(permitted_proposal_field_value_ids_among.filter_ids)
+		AND bf.sensitivity_classification <> 'forbidden'
 		AND permitted_proposal_field_value_ids_among.user_is_admin
 
 	UNION
@@ -48,10 +44,7 @@ CREATE FUNCTION permitted_proposal_field_value_ids_among(
 	-- Granted on the field value or inherited from its proposal, opportunity,
 	-- funder, or changemaker -- subject to the grant's base field conditions.
 	SELECT pfv.id
-	FROM unnest(
-		permitted_proposal_field_value_ids_among.filter_ids
-	) AS candidate (id)
-	INNER JOIN proposal_field_values pfv ON pfv.id = candidate.id
+	FROM proposal_field_values pfv
 	INNER JOIN application_form_fields aff
 		ON pfv.application_form_field_id = aff.id
 	INNER JOIN base_fields bf ON aff.base_field_short_code = bf.short_code
@@ -82,7 +75,9 @@ CREATE FUNCTION permitted_proposal_field_value_ids_among(
 				AND pg.changemaker_id = cp.changemaker_id
 			)
 		)
-	WHERE bf.sensitivity_classification <> 'forbidden'
+	WHERE pfv.id = ANY(permitted_proposal_field_value_ids_among.filter_ids)
+		AND NOT permitted_proposal_field_value_ids_among.user_is_admin
+		AND bf.sensitivity_classification <> 'forbidden'
 		AND verb_set_permits_verb(
 			pg.verbs, permitted_proposal_field_value_ids_among.verb
 		)

--- a/src/database/initialization/1_proposal_field_value_file_to_json.sql
+++ b/src/database/initialization/1_proposal_field_value_file_to_json.sql
@@ -1,0 +1,17 @@
+SELECT drop_function('proposal_field_value_file_to_json');
+
+-- The file a proposal field value points at, or null. A field value references
+-- a file when its base field is a file field and its value is the file's id;
+-- the file is only revealed to the version's own creator.
+CREATE FUNCTION proposal_field_value_file_to_json(
+	proposal_field_value proposal_field_values,
+	is_file_field boolean,
+	version_created_by uuid
+) RETURNS jsonb AS $$
+	SELECT file_to_json(files.*)
+	FROM files
+	WHERE proposal_field_value_file_to_json.is_file_field
+		AND proposal_field_value.value ~ '^[0-9]+$'
+		AND files.id = proposal_field_value.value::integer
+		AND files.created_by = proposal_field_value_file_to_json.version_created_by;
+$$ LANGUAGE sql STABLE;

--- a/src/database/initialization/1_proposal_field_value_to_json.sql
+++ b/src/database/initialization/1_proposal_field_value_to_json.sql
@@ -1,64 +1,20 @@
 SELECT drop_function('proposal_field_value_to_json');
 
 CREATE FUNCTION proposal_field_value_to_json(
-	proposal_field_value proposal_field_values
-)
-RETURNS jsonb AS $$
-DECLARE
-	is_forbidden BOOLEAN;
-	application_form_field_json JSONB;
-	base_field_data_type TEXT;
-	file_json JSONB;
-	value_json JSONB;
-	file_id INTEGER;
-BEGIN
-	SELECT EXISTS (
-		SELECT 1
-		FROM application_form_fields
-		JOIN base_fields ON application_form_fields.base_field_short_code = base_fields.short_code
-		WHERE application_form_fields.id = proposal_field_value.application_form_field_id
-			AND base_fields.sensitivity_classification = 'forbidden'
-	) INTO is_forbidden;
-
-	IF is_forbidden THEN
-		RAISE EXCEPTION 'Attempt to convert forbidden proposal_field_value to JSON (%)', proposal_field_value.id
-			USING ERRCODE = '22023'; -- invalid_parameter_value
-	END IF;
-
-	SELECT application_form_field_to_json(application_form_fields.*)
-	INTO application_form_field_json
-	FROM application_form_fields
-	WHERE application_form_fields.id = proposal_field_value.application_form_field_id;
-
-	-- Get the base field data type
-	SELECT base_fields.data_type
-	INTO base_field_data_type
-	FROM application_form_fields
-	JOIN base_fields ON application_form_fields.base_field_short_code = base_fields.short_code
-	WHERE application_form_fields.id = proposal_field_value.application_form_field_id;
-
-	-- Load file data for file base fields
-	IF base_field_data_type = 'file' AND proposal_field_value.value ~ '^[0-9]+$' THEN
-		SELECT file_to_json(files.*)
-		INTO file_json
-		FROM files
-		JOIN proposal_versions ON proposal_versions.id = proposal_field_value.proposal_version_id
-		WHERE files.id = (proposal_field_value.value)::INTEGER
-			AND files.created_by = proposal_versions.created_by;
-	END IF;
-
-	-- Build the JSON object with file property (jsonb_strip_nulls removes the file key if it's null)
-	RETURN jsonb_build_object(
+	proposal_field_value proposal_field_values,
+	application_form_field jsonb,
+	file jsonb
+) RETURNS jsonb AS $$
+	SELECT jsonb_build_object(
 		'id', proposal_field_value.id,
 		'proposalVersionId', proposal_field_value.proposal_version_id,
 		'applicationFormFieldId', proposal_field_value.application_form_field_id,
-		'applicationFormField', application_form_field_json,
+		'applicationFormField', application_form_field,
 		'position', proposal_field_value.position,
 		'value', proposal_field_value.value,
-		'file', file_json,
+		'file', file,
 		'goodAsOf', proposal_field_value.good_as_of,
 		'isValid', proposal_field_value.is_valid,
 		'createdAt', proposal_field_value.created_at
 	);
-END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE sql IMMUTABLE;

--- a/src/database/initialization/1_proposal_to_json.sql
+++ b/src/database/initialization/1_proposal_to_json.sql
@@ -2,60 +2,18 @@ SELECT drop_function('proposal_to_json');
 
 CREATE FUNCTION proposal_to_json(
 	proposal proposals,
-	auth_context_keycloak_user_id uuid DEFAULT NULL,
-	auth_context_is_administrator boolean DEFAULT FALSE
-)
-RETURNS jsonb AS $$
-DECLARE
-  proposal_versions_json JSONB;
-  opportunity_json JSONB;
-  changemakers_json JSONB;
-BEGIN
-  SELECT jsonb_agg(
-    build_proposal_version_result(
-      proposal_versions.*,
-      auth_context_keycloak_user_id,
-      auth_context_is_administrator
-    )
-    ORDER BY proposal_versions.version DESC, proposal_versions.id DESC
-  )
-  INTO proposal_versions_json
-  FROM proposal_versions
-  WHERE proposal_versions.proposal_id = proposal.id;
-
-  SELECT opportunity_to_json(
-    opportunities.*,
-    auth_context_keycloak_user_id,
-    auth_context_is_administrator
-  )
-  INTO opportunity_json
-  FROM opportunities
-  WHERE opportunities.id = proposal.opportunity_id;
-
-  SELECT jsonb_agg(
-    changemaker_to_json(
-      changemakers.*,
-      auth_context_keycloak_user_id,
-      auth_context_is_administrator,
-      TRUE
-    )
-    ORDER BY changemakers.id ASC
-  )
-  INTO changemakers_json
-  FROM changemakers
-  INNER JOIN changemakers_proposals
-    ON changemakers.id = changemakers_proposals.changemaker_id
-  WHERE changemakers_proposals.proposal_id = proposal.id;
-
-  RETURN jsonb_build_object(
-    'id', proposal.id,
-    'opportunityId', proposal.opportunity_id,
-    'opportunity', opportunity_json,
-    'externalId', proposal.external_id,
-    'versions', COALESCE(proposal_versions_json, '[]'::JSONB),
-    'changemakers', COALESCE(changemakers_json, '[]'::JSONB),
-    'createdAt', proposal.created_at,
-    'createdBy', proposal.created_by
-  );
-END;
-$$ LANGUAGE plpgsql;
+	opportunity jsonb,
+	versions jsonb,
+	changemakers jsonb
+) RETURNS jsonb AS $$
+	SELECT jsonb_build_object(
+		'id', proposal.id,
+		'opportunityId', proposal.opportunity_id,
+		'opportunity', opportunity,
+		'externalId', proposal.external_id,
+		'versions', COALESCE(versions, '[]'::jsonb),
+		'changemakers', COALESCE(changemakers, '[]'::jsonb),
+		'createdAt', proposal.created_at,
+		'createdBy', proposal.created_by
+	);
+$$ LANGUAGE sql IMMUTABLE;

--- a/src/database/initialization/1_proposal_to_json.sql
+++ b/src/database/initialization/1_proposal_to_json.sql
@@ -12,7 +12,7 @@ DECLARE
   changemakers_json JSONB;
 BEGIN
   SELECT jsonb_agg(
-    proposal_version_to_json(
+    build_proposal_version_result(
       proposal_versions.*,
       auth_context_keycloak_user_id,
       auth_context_is_administrator

--- a/src/database/initialization/1_proposal_version_to_json.sql
+++ b/src/database/initialization/1_proposal_version_to_json.sql
@@ -2,54 +2,18 @@ SELECT drop_function('proposal_version_to_json');
 
 CREATE FUNCTION proposal_version_to_json(
 	proposal_version proposal_versions,
-	auth_context_keycloak_user_id uuid DEFAULT NULL,
-	auth_context_is_administrator boolean DEFAULT FALSE
-)
-RETURNS jsonb AS $$
-DECLARE
-	proposal_field_values_json JSONB;
-	source_json JSONB;
-BEGIN
-	WITH version_field_values AS MATERIALIZED (
-		SELECT proposal_field_values.*
-		FROM proposal_field_values
-		WHERE proposal_field_values.proposal_version_id = proposal_version.id
-	)
-
-	SELECT jsonb_agg(
-		build_proposal_field_value_result(version_field_values.*)
-		ORDER BY version_field_values.position, version_field_values.id DESC
-	)
-	INTO proposal_field_values_json
-	FROM version_field_values
-	INNER JOIN permitted_proposal_field_value_ids_among(
-		auth_context_keycloak_user_id,
-		auth_context_is_administrator,
-		'view',
-		'proposalFieldValue',
-		ARRAY(SELECT version_field_values.id FROM version_field_values)
-	) AS permitted_field_values
-		ON permitted_field_values.id = version_field_values.id;
-
-	SELECT source_to_json(
-		sources.*,
-		auth_context_keycloak_user_id,
-		auth_context_is_administrator
-	)
-	INTO source_json
-	FROM sources
-	WHERE sources.id = proposal_version.source_id;
-
-	RETURN jsonb_build_object(
+	field_values jsonb,
+	source jsonb
+) RETURNS jsonb AS $$
+	SELECT jsonb_build_object(
 		'id', proposal_version.id,
 		'proposalId', proposal_version.proposal_id,
 		'sourceId', proposal_version.source_id,
-		'source', source_json,
+		'source', source,
 		'applicationFormId', proposal_version.application_form_id,
 		'version', proposal_version.version,
-		'fieldValues', COALESCE(proposal_field_values_json, '[]'::JSONB),
+		'fieldValues', COALESCE(field_values, '[]'::jsonb),
 		'createdAt', proposal_version.created_at,
 		'createdBy', proposal_version.created_by
 	);
-END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE sql IMMUTABLE;

--- a/src/database/initialization/1_proposal_version_to_json.sql
+++ b/src/database/initialization/1_proposal_version_to_json.sql
@@ -17,7 +17,7 @@ BEGIN
 	)
 
 	SELECT jsonb_agg(
-		proposal_field_value_to_json(version_field_values.*)
+		build_proposal_field_value_result(version_field_values.*)
 		ORDER BY version_field_values.position, version_field_values.id DESC
 	)
 	INTO proposal_field_values_json

--- a/src/database/initialization/5_build_proposals_results.sql
+++ b/src/database/initialization/5_build_proposals_results.sql
@@ -1,0 +1,121 @@
+SELECT drop_function('build_proposals_results');
+
+-- Serializes a page of proposals in a single pass (see README: result
+-- builders). Takes rows, not ids, so it never re-queries the proposals table
+-- and can serialize a proposal INSERTed earlier in the same statement -- which
+-- a STABLE function's snapshot would not otherwise see -- so callers pass rows.
+CREATE FUNCTION build_proposals_results(
+	proposals proposals [],
+	auth_context_keycloak_user_id uuid DEFAULT NULL,
+	auth_context_is_administrator boolean DEFAULT FALSE
+) RETURNS TABLE (id int, object jsonb) AS $$
+	WITH input_proposals AS (
+		SELECT p.* FROM unnest(build_proposals_results.proposals) AS p
+	),
+	target_versions AS (
+		SELECT pv.* FROM proposal_versions pv
+		WHERE pv.proposal_id IN (SELECT ip.id FROM input_proposals ip)
+	),
+	-- viewable field values, bounded to this page's field values so the
+	-- permission lookup is proportional to the page, not the whole corpus
+	permitted_field_values AS (
+		SELECT p.id
+		FROM permitted_proposal_field_value_ids_among(
+			build_proposals_results.auth_context_keycloak_user_id,
+			build_proposals_results.auth_context_is_administrator,
+			'view', 'proposalFieldValue',
+			ARRAY(
+				SELECT pfv.id
+				FROM proposal_field_values pfv
+				INNER JOIN target_versions tv ON tv.id = pfv.proposal_version_id
+			)
+		) AS p
+	),
+	application_form_field_json AS (
+		SELECT aff.id, application_form_field_to_json(aff.*) AS object
+		FROM application_form_fields aff
+		WHERE aff.id IN (
+			SELECT pfv.application_form_field_id
+			FROM proposal_field_values pfv
+			INNER JOIN target_versions tv ON tv.id = pfv.proposal_version_id
+		)
+	),
+	field_value_json AS (
+		SELECT
+			pfv.proposal_version_id,
+			jsonb_agg(
+				proposal_field_value_to_json(
+					pfv,
+					affj.object,
+					proposal_field_value_file_to_json(
+						pfv, bf.data_type = 'file', tv.created_by
+					)
+				)
+				ORDER BY pfv.position, pfv.id DESC
+			) AS field_values
+		FROM proposal_field_values pfv
+		INNER JOIN target_versions tv ON tv.id = pfv.proposal_version_id
+		INNER JOIN permitted_field_values pf ON pf.id = pfv.id
+		INNER JOIN application_form_field_json affj
+			ON affj.id = pfv.application_form_field_id
+		INNER JOIN application_form_fields aff
+			ON aff.id = pfv.application_form_field_id
+		INNER JOIN base_fields bf ON bf.short_code = aff.base_field_short_code
+		GROUP BY pfv.proposal_version_id
+	),
+	source_json AS (
+		SELECT s.id, source_to_json(
+			s.*,
+			build_proposals_results.auth_context_keycloak_user_id,
+			build_proposals_results.auth_context_is_administrator
+		) AS object
+		FROM sources s
+		WHERE s.id IN (SELECT tv.source_id FROM target_versions tv)
+	),
+	version_json AS (
+		SELECT
+			tv.proposal_id,
+			jsonb_agg(
+				proposal_version_to_json(tv, fvj.field_values, sj.object)
+				ORDER BY tv.version DESC, tv.id DESC
+			) AS versions
+		FROM target_versions tv
+		LEFT JOIN field_value_json fvj ON fvj.proposal_version_id = tv.id
+		LEFT JOIN source_json sj ON sj.id = tv.source_id
+		GROUP BY tv.proposal_id
+	),
+	opportunity_json AS (
+		SELECT o.id, opportunity_to_json(
+			o.*,
+			build_proposals_results.auth_context_keycloak_user_id,
+			build_proposals_results.auth_context_is_administrator
+		) AS object
+		FROM opportunities o
+		WHERE o.id IN (SELECT ip.opportunity_id FROM input_proposals ip)
+	),
+	changemaker_json AS (
+		SELECT
+			cp.proposal_id,
+			jsonb_agg(
+				changemaker_to_json(
+					c.*,
+					build_proposals_results.auth_context_keycloak_user_id,
+					build_proposals_results.auth_context_is_administrator,
+					TRUE
+				)
+				ORDER BY c.id ASC
+			) AS changemakers
+		FROM changemakers_proposals cp
+		INNER JOIN changemakers c ON c.id = cp.changemaker_id
+		WHERE cp.proposal_id IN (SELECT ip.id FROM input_proposals ip)
+		GROUP BY cp.proposal_id
+	)
+
+	SELECT
+		ip.id,
+		proposal_to_json(ip, oj.object, vj.versions, cj.changemakers) AS object
+	FROM input_proposals ip
+	LEFT JOIN version_json vj ON vj.proposal_id = ip.id
+	LEFT JOIN opportunity_json oj ON oj.id = ip.opportunity_id
+	LEFT JOIN changemaker_json cj ON cj.proposal_id = ip.id;
+$$ LANGUAGE sql STABLE;

--- a/src/database/initialization/README.md
+++ b/src/database/initialization/README.md
@@ -9,3 +9,32 @@ Specifically, they can be edited over time.
 Files are created one at a time in filename order, so a numeric prefix controls when a file is created relative to the others — lower numbers first. Use a prefix where it is necessary: when a function written in `LANGUAGE sql` references another function defined here, give it a higher prefix than the functions it depends on so they already exist when it is created. Function body validation stays enabled, so a function created before something it references — a wrong prefix, or a circular reference — fails loudly at startup rather than on its first call.
 
 Functions written in `LANGUAGE plpgsql` resolve their references when called rather than when created, so their order never matters.
+
+## Serialization: shapes vs. result builders
+
+Entity serialization is split into two kinds of function so the JSON structure is defined once and the heavy lifting stays out of the read hot path.
+
+### Shape functions — `<entity>_to_json`
+
+Assemble an entity's JSON from its row plus its already-gathered children, passed in as `jsonb` arguments. They do **no table access** — a shape is the single source of truth for an entity's structure and nothing else:
+
+```sql
+proposal_to_json(proposal, opportunity, versions, changemakers)
+proposal_version_to_json(proposal_version, field_values, source)
+proposal_field_value_to_json(proposal_field_value, application_form_field, file)
+```
+
+Because they never query, shapes can be reused by any caller — one row at a time or thousands — without dictating how the children are loaded.
+
+### Result builders — `build_<entity>_result(s)`
+
+Load an entity's children and assemble the result with the shape functions. The gathering — and the decision of what to include — lives here, never in a shape.
+
+- `build_proposals_results(proposals[], …)` serializes a whole page in one pass for the proposals read path. It gathers inline rather than calling the single-entity builders: crossing a function boundary per level would push the rows through array round-trips the planner cannot see past, multiplying buffer reads. Reusing the (table-free) shapes keeps it DRY regardless.
+- `build_proposal_version_result(…)` and `build_proposal_field_value_result(…)` serialize a single entity for the per-row endpoints, where composing builders is fine because the work is bounded to one entity.
+
+`assert_proposal_field_value_not_forbidden` raises if a field value belongs to a forbidden base field. Read paths exclude forbidden fields via the `permitted_*` functions; the guard covers paths that serialize a row directly (the field value insert), which do not filter by permission.
+
+## Permission lookups
+
+`permitted_*_ids` return the entities a user may access. The `_among` variants take a candidate id array and return the permitted subset, keeping the work proportional to the candidates rather than the whole corpus — use them when a caller already holds a bounded set (a page, one version's field values).

--- a/src/database/initialization/__tests__/build_proposal_field_value_result.int.test.ts
+++ b/src/database/initialization/__tests__/build_proposal_field_value_result.int.test.ts
@@ -22,8 +22,8 @@ import {
 } from '../../../types';
 import type { ProposalFieldValue, JsonResultSet } from '../../../types';
 
-describe('/proposal_field_value_to_json', () => {
-	it('returns a db error if attempting to load a forbidden proposal_field_value_to_json', async () => {
+describe('/build_proposal_field_value_result', () => {
+	it('returns a db error if attempting to serialize a forbidden proposal field value', async () => {
 		const db = getDatabase();
 		const testUser = await loadTestUser(db);
 		const testUserAuthContext = getAuthContext(testUser);
@@ -72,10 +72,10 @@ describe('/proposal_field_value_to_json', () => {
 
 		await expect(
 			db.query(
-				'SELECT proposal_field_value_to_json(proposal_field_values.*) FROM proposal_field_values WHERE proposal_field_values.id = 1',
+				'SELECT assert_proposal_field_value_not_forbidden(proposal_field_values.*) FROM proposal_field_values WHERE proposal_field_values.id = 1',
 			),
 		).rejects.toThrow(
-			'Attempt to convert forbidden proposal_field_value to JSON (1)',
+			'Refusing to serialize forbidden proposal_field_value (1)',
 		);
 	});
 
@@ -141,7 +141,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 
 		const result = await db.query<JsonResultSet<ProposalFieldValue>>(
-			`SELECT proposal_field_value_to_json(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
+			`SELECT build_proposal_field_value_result(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
 		);
 
 		const {
@@ -221,7 +221,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 
 		const result = await db.query<JsonResultSet<ProposalFieldValue>>(
-			`SELECT proposal_field_value_to_json(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
+			`SELECT build_proposal_field_value_result(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
 		);
 
 		const {
@@ -290,7 +290,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 
 		const result = await db.query<JsonResultSet<ProposalFieldValue>>(
-			`SELECT proposal_field_value_to_json(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
+			`SELECT build_proposal_field_value_result(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
 		);
 
 		const {
@@ -359,7 +359,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 
 		const result = await db.query<JsonResultSet<ProposalFieldValue>>(
-			`SELECT proposal_field_value_to_json(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
+			`SELECT build_proposal_field_value_result(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
 		);
 
 		const {
@@ -426,7 +426,7 @@ describe('/proposal_field_value_to_json', () => {
 		});
 
 		const result = await db.query<JsonResultSet<ProposalFieldValue>>(
-			`SELECT proposal_field_value_to_json(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
+			`SELECT build_proposal_field_value_result(proposal_field_values.*) as object FROM proposal_field_values WHERE proposal_field_values.id = ${proposalFieldValue.id}`,
 		);
 
 		const {

--- a/src/database/queries/proposalFieldValues/insertOne.sql
+++ b/src/database/queries/proposalFieldValues/insertOne.sql
@@ -13,4 +13,4 @@ INSERT INTO proposal_field_values (
 	:isValid,
 	:goodAsOf
 )
-RETURNING proposal_field_value_to_json(proposal_field_values) AS object;
+RETURNING build_proposal_field_value_result(proposal_field_values) AS object;

--- a/src/database/queries/proposalFieldValues/selectById.sql
+++ b/src/database/queries/proposalFieldValues/selectById.sql
@@ -4,10 +4,11 @@ WHERE
 	proposal_field_values.id = :proposalFieldValueId
 	AND proposal_field_values.id IN (
 		SELECT permitted_field_values.id
-		FROM permitted_proposal_field_value_ids(
+		FROM permitted_proposal_field_value_ids_among(
 			:authContextKeycloakUserId,
 			:authContextIsAdministrator,
 			'view',
-			'proposalFieldValue'
+			'proposalFieldValue',
+			ARRAY[:proposalFieldValueId::integer]
 		) AS permitted_field_values
 	);

--- a/src/database/queries/proposalFieldValues/selectById.sql
+++ b/src/database/queries/proposalFieldValues/selectById.sql
@@ -1,11 +1,13 @@
-SELECT proposal_field_value_to_json(proposal_field_values.*) AS object
+SELECT build_proposal_field_value_result(proposal_field_values) AS object
 FROM proposal_field_values
-	INNER JOIN
-		permitted_proposal_field_value_ids(
+WHERE
+	proposal_field_values.id = :proposalFieldValueId
+	AND proposal_field_values.id IN (
+		SELECT permitted_field_values.id
+		FROM permitted_proposal_field_value_ids(
 			:authContextKeycloakUserId,
 			:authContextIsAdministrator,
 			'view',
 			'proposalFieldValue'
-		) AS permitted_proposal_field_values
-		ON proposal_field_values.id = permitted_proposal_field_values.id
-WHERE proposal_field_values.id = :proposalFieldValueId;
+		) AS permitted_field_values
+	);

--- a/src/database/queries/proposalVersions/insertOne.sql
+++ b/src/database/queries/proposalVersions/insertOne.sql
@@ -18,7 +18,7 @@ INSERT INTO proposal_versions (
 		1
 	)
 )
-RETURNING proposal_version_to_json(
+RETURNING build_proposal_version_result(
 	proposal_versions,
 	:authContextKeycloakUserId,
 	:authContextIsAdministrator

--- a/src/database/queries/proposalVersions/selectById.sql
+++ b/src/database/queries/proposalVersions/selectById.sql
@@ -1,16 +1,18 @@
 SELECT
-	proposal_version_to_json(
-		proposal_versions.*,
+	build_proposal_version_result(
+		proposal_versions,
 		:authContextKeycloakUserId,
 		:authContextIsAdministrator
 	) AS object
 FROM proposal_versions
-	INNER JOIN
-		permitted_proposal_ids(
+WHERE
+	proposal_versions.id = :proposalVersionId
+	AND proposal_versions.proposal_id IN (
+		SELECT permitted_proposals.id
+		FROM permitted_proposal_ids(
 			:authContextKeycloakUserId,
 			:authContextIsAdministrator,
 			'view',
 			'proposal'
 		) AS permitted_proposals
-		ON proposal_versions.proposal_id = permitted_proposals.id
-WHERE proposal_versions.id = :proposalVersionId;
+	);

--- a/src/database/queries/proposals/insertOne.sql
+++ b/src/database/queries/proposals/insertOne.sql
@@ -1,10 +1,18 @@
-INSERT INTO proposals (
-	external_id,
-	opportunity_id,
-	created_by
-) VALUES (
-	:externalId,
-	:opportunityId,
-	:authContextKeycloakUserId
-)
-RETURNING proposal_to_json(proposals) AS object;
+WITH
+	inserted_proposal AS (
+		INSERT INTO proposals (
+			external_id,
+			opportunity_id,
+			created_by
+		) VALUES (
+			:externalId,
+			:opportunityId,
+			:authContextKeycloakUserId
+		)
+		RETURNING *
+	)
+
+SELECT serialized_proposal.object
+FROM build_proposals_results(
+	array(SELECT inserted_proposal::proposals FROM inserted_proposal)
+) AS serialized_proposal;

--- a/src/database/queries/proposals/selectById.sql
+++ b/src/database/queries/proposals/selectById.sql
@@ -1,16 +1,23 @@
-SELECT
-	proposal_to_json(
-		proposals.*,
-		:authContextKeycloakUserId,
-		:authContextIsAdministrator
-	) AS object
-FROM proposals
-	INNER JOIN
-		permitted_proposal_ids(
-			:authContextKeycloakUserId,
-			:authContextIsAdministrator,
-			'view',
-			'proposal'
-		) AS permitted_proposals
-		ON proposals.id = permitted_proposals.id
-WHERE proposals.id = :proposalId;
+WITH
+	requested_proposal AS (
+		SELECT proposals AS proposal
+		FROM proposals
+		WHERE
+			proposals.id = :proposalId
+			AND proposals.id IN (
+				SELECT permitted_proposals.id
+				FROM permitted_proposal_ids(
+					:authContextKeycloakUserId,
+					:authContextIsAdministrator,
+					'view',
+					'proposal'
+				) AS permitted_proposals
+			)
+	)
+
+SELECT serialized_proposal.object
+FROM build_proposals_results(
+	array(SELECT requested_proposal.proposal FROM requested_proposal),
+	:authContextKeycloakUserId,
+	:authContextIsAdministrator
+) AS serialized_proposal;

--- a/src/database/queries/proposals/selectWithPagination.sql
+++ b/src/database/queries/proposals/selectWithPagination.sql
@@ -67,16 +67,30 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			proposal_to_json(
-				candidate_entries.*::proposals,
-				:authContextKeycloakUserId,
-				:authContextIsAdministrator
-			) AS object
+	page AS (
+		SELECT candidate_entries.id
 		FROM candidate_entries
-		ORDER BY id DESC
+		ORDER BY candidate_entries.id DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	page_proposals AS (
+		SELECT proposals AS proposal
+		FROM proposals
+		WHERE proposals.id IN (SELECT page.id FROM page)
+	),
+
+	paginated_entries AS (
+		SELECT serialized_proposal.object
+		FROM page
+			INNER JOIN
+				build_proposals_results(
+					array(SELECT page_proposals.proposal FROM page_proposals),
+					:authContextKeycloakUserId,
+					:authContextIsAdministrator
+				) AS serialized_proposal
+				ON page.id = serialized_proposal.id
+		ORDER BY page.id DESC
 	)
 
 SELECT


### PR DESCRIPTION
Our json serializer ran on individual entities which was resulting in a ton of internal + duplicate calls.  This change moves towards a more efficient model where entity sets are serialized together.  We're starting with proposals, but will move into lower proposal entities as well.

Related to #2473
Related to #2475 