### PR TITLE
Paginate list entries before serializing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Paginated list endpoints no longer slow down as you request later pages.
+
 ## 0.40.0 2026-06-26
 
 ### Added

--- a/src/database/queries/applicationFormFields/selectWithPagination.sql
+++ b/src/database/queries/applicationFormFields/selectWithPagination.sql
@@ -25,14 +25,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			application_form_field_to_json(
-				candidate_entries.*::application_form_fields
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY position, id
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			application_form_field_to_json(
+				page.*::application_form_fields
+			) AS object
+		FROM page
+		ORDER BY position, id
 	)
 
 SELECT

--- a/src/database/queries/applicationForms/selectWithPagination.sql
+++ b/src/database/queries/applicationForms/selectWithPagination.sql
@@ -16,14 +16,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			application_form_to_json(
-				candidate_entries.*::application_forms
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			application_form_to_json(
+				page.*::application_forms
+			) AS object
+		FROM page
+		ORDER BY id
 	)
 
 SELECT

--- a/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
+++ b/src/database/queries/baseFieldLocalizations/selectWithPagination.sql
@@ -15,14 +15,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			base_field_localization_to_json(
-				candidate_entries.*::base_field_localizations
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY created_at
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			base_field_localization_to_json(
+				page.*::base_field_localizations
+			) AS object
+		FROM page
+		ORDER BY created_at
 	)
 
 SELECT

--- a/src/database/queries/baseFields/selectWithPagination.sql
+++ b/src/database/queries/baseFields/selectWithPagination.sql
@@ -21,11 +21,17 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT base_field_to_json(candidate_entries.*::base_fields) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY created_at DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT base_field_to_json(page.*::base_fields) AS object
+		FROM page
+		ORDER BY created_at DESC
 	)
 
 SELECT

--- a/src/database/queries/baseFieldsCopyTasks/selectWithPagination.sql
+++ b/src/database/queries/baseFieldsCopyTasks/selectWithPagination.sql
@@ -25,14 +25,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			base_fields_copy_task_to_json(
-				candidate_entries.*::base_fields_copy_tasks
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			base_fields_copy_task_to_json(
+				page.*::base_fields_copy_tasks
+			) AS object
+		FROM page
+		ORDER BY id DESC
 	)
 
 SELECT

--- a/src/database/queries/bulkUploadTasks/selectWithPagination.sql
+++ b/src/database/queries/bulkUploadTasks/selectWithPagination.sql
@@ -25,16 +25,22 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			bulk_upload_task_to_json(
-				candidate_entries.*::bulk_upload_tasks,
-				:authContextKeycloakUserId,
-				:authContextIsAdministrator
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			bulk_upload_task_to_json(
+				page.*::bulk_upload_tasks,
+				:authContextKeycloakUserId,
+				:authContextIsAdministrator
+			) AS object
+		FROM page
+		ORDER BY id DESC
 	)
 
 SELECT

--- a/src/database/queries/changemakerFieldValueBatches/selectWithPagination.sql
+++ b/src/database/queries/changemakerFieldValueBatches/selectWithPagination.sql
@@ -11,16 +11,22 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			changemaker_field_value_batch_to_json(
-				candidate_entries.*::changemaker_field_value_batches,
-				:authContextKeycloakUserId,
-				:authContextIsAdministrator
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			changemaker_field_value_batch_to_json(
+				page.*::changemaker_field_value_batches,
+				:authContextKeycloakUserId,
+				:authContextIsAdministrator
+			) AS object
+		FROM page
+		ORDER BY id DESC
 	)
 
 SELECT

--- a/src/database/queries/changemakerFieldValues/selectWithPagination.sql
+++ b/src/database/queries/changemakerFieldValues/selectWithPagination.sql
@@ -29,14 +29,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			build_changemaker_field_value_result(
-				candidate_entries.*::changemaker_field_values
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			build_changemaker_field_value_result(
+				page.*::changemaker_field_values
+			) AS object
+		FROM page
+		ORDER BY id DESC
 	)
 
 SELECT

--- a/src/database/queries/changemakersProposals/selectWithPagination.sql
+++ b/src/database/queries/changemakersProposals/selectWithPagination.sql
@@ -29,16 +29,22 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			changemaker_proposal_to_json(
-				candidate_entries.*::changemakers_proposals,
-				:authContextKeycloakUserId,
-				:authContextIsAdministrator
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			changemaker_proposal_to_json(
+				page.*::changemakers_proposals,
+				:authContextKeycloakUserId,
+				:authContextIsAdministrator
+			) AS object
+		FROM page
+		ORDER BY id DESC
 	)
 
 SELECT

--- a/src/database/queries/dataProviders/selectWithPagination.sql
+++ b/src/database/queries/dataProviders/selectWithPagination.sql
@@ -8,11 +8,17 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT data_provider_to_json(candidate_entries.*::data_providers) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY created_at DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT data_provider_to_json(page.*::data_providers) AS object
+		FROM page
+		ORDER BY created_at DESC
 	)
 
 SELECT

--- a/src/database/queries/files/selectWithPagination.sql
+++ b/src/database/queries/files/selectWithPagination.sql
@@ -19,11 +19,17 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT file_to_json(candidate_entries.*::files) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT file_to_json(page.*::files) AS object
+		FROM page
+		ORDER BY id DESC
 	)
 
 SELECT

--- a/src/database/queries/funderCollaborativeInvitations/selectWithPagination.sql
+++ b/src/database/queries/funderCollaborativeInvitations/selectWithPagination.sql
@@ -37,14 +37,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			funder_collaborative_invitation_to_json(
-				candidate_entries.*::funder_collaborative_invitations
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY created_at DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			funder_collaborative_invitation_to_json(
+				page.*::funder_collaborative_invitations
+			) AS object
+		FROM page
+		ORDER BY created_at DESC
 	)
 
 SELECT

--- a/src/database/queries/funderCollaborativeMembers/selectWithPagination.sql
+++ b/src/database/queries/funderCollaborativeMembers/selectWithPagination.sql
@@ -28,14 +28,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			funder_collaborative_member_to_json(
-				candidate_entries.*::funder_collaborative_members
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY created_at DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			funder_collaborative_member_to_json(
+				page.*::funder_collaborative_members
+			) AS object
+		FROM page
+		ORDER BY created_at DESC
 	)
 
 SELECT

--- a/src/database/queries/funders/selectWithPagination.sql
+++ b/src/database/queries/funders/selectWithPagination.sql
@@ -41,11 +41,17 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT funder_to_json(candidate_entries.*::funders) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY created_at DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT funder_to_json(page.*::funders) AS object
+		FROM page
+		ORDER BY created_at DESC
 	)
 
 SELECT

--- a/src/database/queries/opportunities/selectWithPagination.sql
+++ b/src/database/queries/opportunities/selectWithPagination.sql
@@ -23,16 +23,22 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			opportunity_to_json(
-				candidate_entries.*::opportunities,
-				:authContextKeycloakUserId,
-				:authContextIsAdministrator
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			opportunity_to_json(
+				page.*::opportunities,
+				:authContextKeycloakUserId,
+				:authContextIsAdministrator
+			) AS object
+		FROM page
+		ORDER BY id
 	)
 
 SELECT

--- a/src/database/queries/permissionGrants/selectWithPagination.sql
+++ b/src/database/queries/permissionGrants/selectWithPagination.sql
@@ -14,14 +14,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			permission_grant_to_json(
-				candidate_entries.*::permission_grants
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			permission_grant_to_json(
+				page.*::permission_grants
+			) AS object
+		FROM page
+		ORDER BY id DESC
 	)
 
 SELECT

--- a/src/database/queries/sources/selectWithPagination.sql
+++ b/src/database/queries/sources/selectWithPagination.sql
@@ -16,16 +16,22 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			source_to_json(
-				candidate_entries.*::sources,
-				:authContextKeycloakUserId,
-				:authContextIsAdministrator
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			source_to_json(
+				page.*::sources,
+				:authContextKeycloakUserId,
+				:authContextIsAdministrator
+			) AS object
+		FROM page
+		ORDER BY id DESC
 	)
 
 SELECT

--- a/src/database/queries/terminologySets/selectWithPagination.sql
+++ b/src/database/queries/terminologySets/selectWithPagination.sql
@@ -20,14 +20,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			terminology_set_to_json(
-				candidate_entries.*::terminology_sets
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY id
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			terminology_set_to_json(
+				page.*::terminology_sets
+			) AS object
+		FROM page
+		ORDER BY id
 	)
 
 SELECT

--- a/src/database/queries/unifiedAuditLogs/selectWithPagination.sql
+++ b/src/database/queries/unifiedAuditLogs/selectWithPagination.sql
@@ -8,14 +8,20 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			unified_audit_log_to_json(
-				candidate_entries.*::unified_audit_logs
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY action_tstamp_stm DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			unified_audit_log_to_json(
+				page.*::unified_audit_logs
+			) AS object
+		FROM page
+		ORDER BY action_tstamp_stm DESC
 	)
 
 SELECT

--- a/src/database/queries/users/selectWithPagination.sql
+++ b/src/database/queries/users/selectWithPagination.sql
@@ -25,16 +25,22 @@ WITH
 		SELECT count(*) AS total FROM candidate_entries
 	),
 
-	paginated_entries AS (
-		SELECT
-			user_to_json(
-				candidate_entries.*::users,
-				:authContextKeycloakUserId,
-				:authContextIsAdministrator
-			) AS object
+	page AS (
+		SELECT candidate_entries.*
 		FROM candidate_entries
 		ORDER BY created_at DESC
 		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			user_to_json(
+				page.*::users,
+				:authContextKeycloakUserId,
+				:authContextIsAdministrator
+			) AS object
+		FROM page
+		ORDER BY created_at DESC
 	)
 
 SELECT


### PR DESCRIPTION
This PR updates our pagination queries to paginate *before* serialization, since postgres will apply the serialization on the entire potential result set before pagination (resulting in later pages performing a lot of work for no reason / linear growth)

Resolves #2490