### PR TITLE
Serialize changemaker proposals in a single pass

### DIFF
--- a/src/database/initialization/1_changemaker_proposal_to_json.sql
+++ b/src/database/initialization/1_changemaker_proposal_to_json.sql
@@ -2,45 +2,15 @@ SELECT drop_function('changemaker_proposal_to_json');
 
 CREATE FUNCTION changemaker_proposal_to_json(
 	changemaker_proposal changemakers_proposals,
-	auth_context_keycloak_user_id uuid DEFAULT NULL,
-	auth_context_is_administrator boolean DEFAULT FALSE
-)
-RETURNS jsonb AS $$
-DECLARE
-  proposal_json JSONB;
-  changemaker_json JSONB;
-BEGIN
-  SELECT serialized_proposal.object
-  INTO proposal_json
-  FROM build_proposals_results(
-    ARRAY(
-      SELECT proposals
-      FROM proposals
-      WHERE proposals.id = changemaker_proposal.proposal_id
-    ),
-    auth_context_keycloak_user_id,
-    auth_context_is_administrator
-  ) AS serialized_proposal;
-
-  SELECT serialized_changemaker.object
-  INTO changemaker_json
-  FROM build_changemakers_results(
-    ARRAY(
-      SELECT changemakers
-      FROM changemakers
-      WHERE changemakers.id = changemaker_proposal.changemaker_id
-    ),
-    auth_context_keycloak_user_id,
-    auth_context_is_administrator
-  ) AS serialized_changemaker;
-
-  RETURN jsonb_build_object(
-    'id', changemaker_proposal.id,
-    'changemakerId', changemaker_proposal.changemaker_id,
-    'changemaker', changemaker_json,
-    'proposalId', changemaker_proposal.proposal_id,
-    'proposal', proposal_json,
-    'createdAt', changemaker_proposal.created_at
-  );
-END;
-$$ LANGUAGE plpgsql;
+	changemaker jsonb,
+	proposal jsonb
+) RETURNS jsonb AS $$
+	SELECT jsonb_build_object(
+		'id', changemaker_proposal.id,
+		'changemakerId', changemaker_proposal.changemaker_id,
+		'changemaker', changemaker,
+		'proposalId', changemaker_proposal.proposal_id,
+		'proposal', proposal,
+		'createdAt', changemaker_proposal.created_at
+	);
+$$ LANGUAGE sql IMMUTABLE;

--- a/src/database/initialization/6_build_changemakers_proposals_results.sql
+++ b/src/database/initialization/6_build_changemakers_proposals_results.sql
@@ -1,0 +1,49 @@
+SELECT drop_function('build_changemakers_proposals_results');
+
+-- Serializes a page of changemaker-proposals in a single pass (see README:
+-- result builders). Volatile, not STABLE: the embedded proposal reads its
+-- changemakers from changemakers_proposals, so the insert path needs a fresh
+-- snapshot to see the row it just inserted.
+CREATE FUNCTION build_changemakers_proposals_results(
+	changemakers_proposals changemakers_proposals [],
+	auth_context_keycloak_user_id uuid DEFAULT NULL,
+	auth_context_is_administrator boolean DEFAULT FALSE
+) RETURNS TABLE (id int, object jsonb) AS $$
+	WITH input_entries AS (
+		SELECT cp.*
+		FROM unnest(
+			build_changemakers_proposals_results.changemakers_proposals
+		) AS cp
+	),
+	changemaker_json AS (
+		SELECT serialized_changemaker.id, serialized_changemaker.object
+		FROM build_changemakers_results(
+			ARRAY(
+				SELECT c
+				FROM changemakers c
+				WHERE c.id IN (SELECT ie.changemaker_id FROM input_entries ie)
+			),
+			build_changemakers_proposals_results.auth_context_keycloak_user_id,
+			build_changemakers_proposals_results.auth_context_is_administrator
+		) AS serialized_changemaker
+	),
+	proposal_json AS (
+		SELECT serialized_proposal.id, serialized_proposal.object
+		FROM build_proposals_results(
+			ARRAY(
+				SELECT p
+				FROM proposals p
+				WHERE p.id IN (SELECT ie.proposal_id FROM input_entries ie)
+			),
+			build_changemakers_proposals_results.auth_context_keycloak_user_id,
+			build_changemakers_proposals_results.auth_context_is_administrator
+		) AS serialized_proposal
+	)
+
+	SELECT
+		ie.id,
+		changemaker_proposal_to_json(ie, cj.object, pj.object) AS object
+	FROM input_entries ie
+	LEFT JOIN changemaker_json cj ON cj.id = ie.changemaker_id
+	LEFT JOIN proposal_json pj ON pj.id = ie.proposal_id;
+$$ LANGUAGE sql VOLATILE;

--- a/src/database/queries/changemakersProposals/insertOne.sql
+++ b/src/database/queries/changemakersProposals/insertOne.sql
@@ -1,12 +1,18 @@
-INSERT INTO changemakers_proposals (
-	changemaker_id,
-	proposal_id
-) VALUES (
-	:changemakerId,
-	:proposalId
-)
-RETURNING changemaker_proposal_to_json(
-	changemakers_proposals,
+WITH
+	inserted_entry AS (
+		INSERT INTO changemakers_proposals (
+			changemaker_id,
+			proposal_id
+		) VALUES (
+			:changemakerId,
+			:proposalId
+		)
+		RETURNING *
+	)
+
+SELECT serialized_entry.object
+FROM build_changemakers_proposals_results(
+	array(SELECT inserted_entry::changemakers_proposals FROM inserted_entry),
 	:authContextKeycloakUserId,
 	:authContextIsAdministrator
-) AS object;
+) AS serialized_entry;

--- a/src/database/queries/changemakersProposals/selectWithPagination.sql
+++ b/src/database/queries/changemakersProposals/selectWithPagination.sql
@@ -30,21 +30,29 @@ WITH
 	),
 
 	page AS (
-		SELECT candidate_entries.*
+		SELECT candidate_entries.id
 		FROM candidate_entries
-		ORDER BY id DESC
+		ORDER BY candidate_entries.id DESC
 		LIMIT :limit OFFSET :offset
 	),
 
+	page_entries AS (
+		SELECT changemakers_proposals AS entry
+		FROM changemakers_proposals
+		WHERE changemakers_proposals.id IN (SELECT page.id FROM page)
+	),
+
 	paginated_entries AS (
-		SELECT
-			changemaker_proposal_to_json(
-				page.*::changemakers_proposals,
-				:authContextKeycloakUserId,
-				:authContextIsAdministrator
-			) AS object
+		SELECT serialized_entry.object
 		FROM page
-		ORDER BY id DESC
+			INNER JOIN
+				build_changemakers_proposals_results(
+					array(SELECT page_entries.entry FROM page_entries),
+					:authContextKeycloakUserId,
+					:authContextIsAdministrator
+				) AS serialized_entry
+				ON page.id = serialized_entry.id
+		ORDER BY page.id DESC
 	)
 
 SELECT


### PR DESCRIPTION
This PR applies our new collection patterns (to remove `N+1` queries) to the `GET /changemakersProposals` endpoint.

Resolves #2492