### PR TITLE
Add ability to query a funder's collaboratives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a `GET /funders/{memberFunderShortCode}/collaboratives` endpoint that lists funder collaborative memberships for a given member funder.
 - Bulk upload CSVs may now include `control:`-prefixed columns (e.g. `control:pdc_changemaker_id`). Control columns carry meta-information that changes how a row is processed; they are exempt from application-form validation and are not stored as base fields.
 
 ### Changed

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -272,6 +272,7 @@ context key).
 | edit   | terminologySet     | Create or update terminology sets owned by the funder                                |
 | manage | funder             | View, send, and respond to funder collaborative invitations                          |
 |        |                    | View collaborative members for the funder                                            |
+|        |                    | View the collaboratives the funder is a member of                                    |
 
 ### Changemaker Permissions
 

--- a/src/__tests__/funders.int.test.ts
+++ b/src/__tests__/funders.int.test.ts
@@ -958,6 +958,135 @@ describe('/funders', () => {
 			});
 		});
 	});
+	describe('/funders/:funderShortCode/collaboratives', () => {
+		describe('GET /', () => {
+			it('requires authentication', async () => {
+				await agent.get('/funders/foo/collaboratives').expect(401);
+			});
+
+			it('throws a 400 error if the funder short code is invalid', async () => {
+				await agent
+					.get('/funders/!!!!!!!/collaboratives')
+					.set(adminUserAuthHeader)
+					.expect(400);
+			});
+
+			it('requires MANAGE permission on the funder', async () => {
+				const db = getDatabase();
+				const testUser = await loadTestUser(db);
+				const testUserAuthContext = getAuthContext(testUser);
+				await createTestFunders(db, testUserAuthContext, {
+					theFundFund: true,
+					theFoundationFoundation: false,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+				const result = await agent
+					.get('/funders/theFoundationFoundation/collaboratives')
+					.set(authHeader)
+					.expect(403);
+				expect(result.body).toMatchObject({
+					message:
+						'Authenticated user does not have permission to perform this action.',
+					details: expectArray(),
+				});
+			});
+
+			it('returns all collaboratives that a funder is a member of', async () => {
+				const db = getDatabase();
+				const testUser = await loadTestUser(db);
+				const testUserAuthContext = getAuthContext(testUser);
+				await createTestFunders(db, testUserAuthContext, {
+					theFundFund: true,
+					theFoundationFoundation: true,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+
+				await createOrUpdateFunderCollaborativeMember(db, testUserAuthContext, {
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFundersWhoFund',
+				});
+				await createOrUpdateFunderCollaborativeMember(db, testUserAuthContext, {
+					funderCollaborativeShortCode: 'theFoundationFoundation',
+					memberFunderShortCode: 'theFundersWhoFund',
+				});
+				await createOrUpdateFunderCollaborativeMember(db, testUserAuthContext, {
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFundingFathers',
+				});
+				const response = await agent
+					.get('/funders/theFundersWhoFund/collaboratives')
+					.set(adminUserAuthHeader)
+					.expect(200);
+				expect(response.body).toEqual({
+					entries: [
+						{
+							funderCollaborativeShortCode: 'theFoundationFoundation',
+							memberFunderShortCode: 'theFundersWhoFund',
+							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
+						},
+						{
+							funderCollaborativeShortCode: 'theFundFund',
+							memberFunderShortCode: 'theFundersWhoFund',
+							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
+						},
+					],
+					total: 2,
+				});
+			});
+
+			it('returns collaboratives when the user has MANAGE permission on the funder', async () => {
+				const db = getDatabase();
+				const testUser = await loadTestUser(db);
+				const testUserAuthContext = getAuthContext(testUser);
+				const systemUser = await loadSystemUser(db, null);
+				const systemUserAuthContext = getAuthContext(systemUser);
+				await createTestFunders(db, testUserAuthContext, {
+					theFundFund: true,
+					theFoundationFoundation: false,
+					theFundersWhoFund: false,
+					theFundingFathers: false,
+					theFunnyFunders: false,
+					theFungibleFund: false,
+				});
+				await createPermissionGrant(db, systemUserAuthContext, {
+					granteeType: PermissionGrantGranteeType.USER,
+					granteeUserKeycloakUserId: testUser.keycloakUserId,
+					contextEntityType: PermissionGrantEntityType.FUNDER,
+					funderShortCode: 'theFoundationFoundation',
+					scope: [PermissionGrantEntityType.FUNDER],
+					verbs: [PermissionGrantVerb.MANAGE],
+				});
+				await createOrUpdateFunderCollaborativeMember(db, testUserAuthContext, {
+					funderCollaborativeShortCode: 'theFundFund',
+					memberFunderShortCode: 'theFoundationFoundation',
+				});
+
+				const response = await agent
+					.get('/funders/theFoundationFoundation/collaboratives')
+					.set(authHeader)
+					.expect(200);
+				expect(response.body).toEqual({
+					entries: [
+						{
+							funderCollaborativeShortCode: 'theFundFund',
+							memberFunderShortCode: 'theFoundationFoundation',
+							createdAt: expectTimestamp(),
+							createdBy: testUser.keycloakUserId,
+						},
+					],
+					total: 1,
+				});
+			});
+		});
+	});
 	describe('POST /:shortCode/invitations/sent/:invitedFunderShortCode', () => {
 		it('requires authentication', async () => {
 			const db = getDatabase();

--- a/src/handlers/__tests__/funderCollaborativeMembersHandlers.unit.test.ts
+++ b/src/handlers/__tests__/funderCollaborativeMembersHandlers.unit.test.ts
@@ -1,0 +1,15 @@
+import { funderCollaborativeMembersHandlers } from '../funderCollaborativeMembersHandlers';
+import { FailedMiddlewareError } from '../../errors';
+import { getMockRequest, getMockResponse } from '../../test/mockExpress';
+
+describe('funderCollaborativeMembersHandlers', () => {
+	describe('getFunderCollaboratives', () => {
+		it('throws a FailedMiddlewareError when the request lacks an auth context', async () => {
+			const req = getMockRequest();
+			const res = getMockResponse();
+			await expect(
+				funderCollaborativeMembersHandlers.getFunderCollaboratives(req, res),
+			).rejects.toThrow(FailedMiddlewareError);
+		});
+	});
+});

--- a/src/handlers/funderCollaborativeMembersHandlers.ts
+++ b/src/handlers/funderCollaborativeMembersHandlers.ts
@@ -79,6 +79,38 @@ const getFunderCollaborativeMembers = async (
 		.send(funderBundle);
 };
 
+const getFunderCollaboratives = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const db = getDatabase();
+	const { funderShortCode } = coerceParams(req.params);
+	if (!isShortCode(funderShortCode)) {
+		throw new InputValidationError(
+			'Invalid member funder short code.',
+			isShortCode.errors ?? [],
+		);
+	}
+	const paginationParameters = extractPaginationParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+	const funderBundle = await loadFunderCollaborativeMemberBundle(
+		db,
+		req,
+		undefined,
+		funderShortCode,
+		limit,
+		offset,
+	);
+
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(funderBundle);
+};
+
 const postFunderCollaborativeMember = async (
 	req: Request,
 	res: Response,
@@ -149,6 +181,7 @@ const deleteFunderCollaborativeMember = async (
 export const funderCollaborativeMembersHandlers = {
 	getFunderCollaborativeMember,
 	getFunderCollaborativeMembers,
+	getFunderCollaboratives,
 	postFunderCollaborativeMember,
 	deleteFunderCollaborativeMember,
 };

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -383,6 +383,9 @@
 		"/funders/{funderCollaborativeShortCode}/members/{memberFunderShortCode}": {
 			"$ref": "./paths/funderCollaborativeMember.json"
 		},
+		"/funders/{memberFunderShortCode}/collaboratives": {
+			"$ref": "./paths/funderCollaboratives.json"
+		},
 		"/funders/{funderCollaborativeShortCode}/invitations/sent": {
 			"$ref": "./paths/funderCollaborativeInvitationsSent.json"
 		},

--- a/src/openapi/paths/funderCollaboratives.json
+++ b/src/openapi/paths/funderCollaboratives.json
@@ -1,0 +1,53 @@
+{
+	"get": {
+		"operationId": "getFunderCollaboratives",
+		"summary": "Gets a list of funder collaborative membership records for the collaboratives that the funder is a member of.",
+		"tags": ["Funder Collaborative Members"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "memberFunderShortCode",
+				"description": "The short code of a member funder.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"$ref": "../components/schemas/shortCode.json"
+				}
+			},
+			{
+				"$ref": "../components/parameters/pageParam.json"
+			},
+			{
+				"$ref": "../components/parameters/countParam.json"
+			}
+		],
+		"responses": {
+			"200": {
+				"description": "A list of funder collaborative memberships for the funder.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/FunderCollaborativeMemberBundle.json"
+						}
+					}
+				}
+			},
+			"401": {
+				"$ref": "../components/responses/Unauthorized.json"
+			},
+			"403": {
+				"$ref": "../components/responses/Forbidden.json"
+			},
+			"404": {
+				"$ref": "../components/responses/NotFound.json"
+			},
+			"500": {
+				"$ref": "../components/responses/InternalServerError.json"
+			}
+		}
+	}
+}

--- a/src/routers/fundersRouter.ts
+++ b/src/routers/fundersRouter.ts
@@ -49,6 +49,12 @@ fundersRouter.delete(
 	funderCollaborativeMembersHandlers.deleteFunderCollaborativeMember,
 );
 
+fundersRouter.get(
+	'/:funderShortCode/collaboratives',
+	requireFunderPermission(PermissionGrantVerb.MANAGE),
+	funderCollaborativeMembersHandlers.getFunderCollaboratives,
+);
+
 fundersRouter.post(
 	'/:funderShortCode/invitations/sent/:invitedFunderShortCode',
 	requireFunderPermission(PermissionGrantVerb.MANAGE),


### PR DESCRIPTION
This small commit adds a new nested endpoint,
`/funders/{memberFunderShortCode}/collaboratives` which allows a user to query the collaboratives of a funder based on the memberFunderShortCode. This follows the existing patterns we have for nested endpoints, like for funder members or invitations.

Closes #2312 