### PR TITLE
Include proposalId in proposalFieldValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.41.0 2026-07-24
+
 ### Fixed
 
 - Paginated list endpoints no longer slow down as you request later pages.
 
 ### Added
 
+- Proposal field value objects now include a `proposalId` attribute, so a value in a changemaker's `fields` (or anywhere else a proposal field value appears) can be traced back to its proposal without an extra call to `GET /proposalVersions/{proposalVersionId}`.
 - Added a `GET /funders/{memberFunderShortCode}/collaboratives` endpoint that lists funder collaborative memberships for a given member funder.
 - Bulk upload CSVs may now include `control:`-prefixed columns (e.g. `control:pdc_changemaker_id`). Control columns carry meta-information that changes how a row is processed; they are exempt from application-form validation and are not stored as base fields.
 

--- a/src/__tests__/changemakers.int.test.ts
+++ b/src/__tests__/changemakers.int.test.ts
@@ -2182,6 +2182,7 @@ describe('/changemakers', () => {
 								value: 'multi@test.com',
 							}),
 							expectObjectContaining({
+								proposalId: proposal.id,
 								proposalVersionId: proposalVersion.id,
 								value: '+15555559999',
 							}),
@@ -2664,6 +2665,7 @@ describe('/changemakers', () => {
 						id: changemaker.id,
 						fields: [
 							expectObjectContaining({
+								proposalId: proposal.id,
 								proposalVersionId: proposalVersion.id,
 								value: testFile.id.toString(),
 								file: expectObjectContaining({

--- a/src/__tests__/proposals.int.test.ts
+++ b/src/__tests__/proposals.int.test.ts
@@ -368,6 +368,7 @@ describe('/proposals', () => {
 								fieldValues: [
 									{
 										id: 1,
+										proposalId: 1,
 										applicationFormFieldId: 1,
 										proposalVersionId: 1,
 										position: 1,
@@ -654,6 +655,7 @@ describe('/proposals', () => {
 								fieldValues: [
 									{
 										id: 1,
+										proposalId: 1,
 										applicationFormFieldId: 1,
 										proposalVersionId: 1,
 										position: 1,
@@ -967,6 +969,7 @@ describe('/proposals', () => {
 						fieldValues: [
 							{
 								id: 3,
+								proposalId: proposal.id,
 								proposalVersionId: 2,
 								applicationFormFieldId: 1,
 								position: 1,
@@ -990,6 +993,7 @@ describe('/proposals', () => {
 							},
 							{
 								id: 4,
+								proposalId: proposal.id,
 								proposalVersionId: 2,
 								applicationFormFieldId: 2,
 								position: 2,
@@ -1025,6 +1029,7 @@ describe('/proposals', () => {
 						fieldValues: [
 							{
 								id: 1,
+								proposalId: proposal.id,
 								proposalVersionId: 1,
 								applicationFormFieldId: 1,
 								position: 1,
@@ -1048,6 +1053,7 @@ describe('/proposals', () => {
 							},
 							{
 								id: 2,
+								proposalId: proposal.id,
 								proposalVersionId: 1,
 								applicationFormFieldId: 2,
 								position: 2,
@@ -1170,6 +1176,7 @@ describe('/proposals', () => {
 						fieldValues: [
 							{
 								id: 3,
+								proposalId: proposal.id,
 								proposalVersionId: 2,
 								applicationFormFieldId: 1,
 								position: 1,
@@ -1193,6 +1200,7 @@ describe('/proposals', () => {
 							},
 							{
 								id: 4,
+								proposalId: proposal.id,
 								proposalVersionId: 2,
 								applicationFormFieldId: 2,
 								position: 2,
@@ -1228,6 +1236,7 @@ describe('/proposals', () => {
 						fieldValues: [
 							{
 								id: 1,
+								proposalId: proposal.id,
 								proposalVersionId: 1,
 								applicationFormFieldId: 1,
 								position: 1,
@@ -1251,6 +1260,7 @@ describe('/proposals', () => {
 							},
 							{
 								id: 2,
+								proposalId: proposal.id,
 								proposalVersionId: 1,
 								applicationFormFieldId: 2,
 								position: 2,
@@ -1434,6 +1444,7 @@ describe('/proposals', () => {
 						fieldValues: [
 							{
 								id: 1,
+								proposalId: proposal.id,
 								proposalVersionId: 1,
 								applicationFormFieldId: 1,
 								position: 1,

--- a/src/database/initialization/1_build_proposal_field_value_result.sql
+++ b/src/database/initialization/1_build_proposal_field_value_result.sql
@@ -12,6 +12,7 @@ DECLARE
 	is_file_field BOOLEAN;
 	application_form_field_json JSONB;
 	version_created_by UUID;
+	version_proposal_id INTEGER;
 BEGIN
 	PERFORM assert_proposal_field_value_not_forbidden(proposal_field_value);
 
@@ -25,8 +26,8 @@ BEGIN
 	WHERE application_form_fields.id
 		= proposal_field_value.application_form_field_id;
 
-	SELECT proposal_versions.created_by
-	INTO version_created_by
+	SELECT proposal_versions.created_by, proposal_versions.proposal_id
+	INTO version_created_by, version_proposal_id
 	FROM proposal_versions
 	WHERE proposal_versions.id = proposal_field_value.proposal_version_id;
 
@@ -35,7 +36,8 @@ BEGIN
 		application_form_field_json,
 		proposal_field_value_file_to_json(
 			proposal_field_value, is_file_field, version_created_by
-		)
+		),
+		version_proposal_id
 	);
 END;
 $$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/1_proposal_field_value_to_json.sql
+++ b/src/database/initialization/1_proposal_field_value_to_json.sql
@@ -3,10 +3,12 @@ SELECT drop_function('proposal_field_value_to_json');
 CREATE FUNCTION proposal_field_value_to_json(
 	proposal_field_value proposal_field_values,
 	application_form_field jsonb,
-	file jsonb
+	file jsonb,
+	proposal_id integer
 ) RETURNS jsonb AS $$
 	SELECT jsonb_build_object(
 		'id', proposal_field_value.id,
+		'proposalId', proposal_field_value_to_json.proposal_id,
 		'proposalVersionId', proposal_field_value.proposal_version_id,
 		'applicationFormFieldId', proposal_field_value.application_form_field_id,
 		'applicationFormField', application_form_field,

--- a/src/database/initialization/5_build_proposals_results.sql
+++ b/src/database/initialization/5_build_proposals_results.sql
@@ -49,7 +49,8 @@ CREATE FUNCTION build_proposals_results(
 					affj.object,
 					proposal_field_value_file_to_json(
 						pfv, bf.data_type = 'file', tv.created_by
-					)
+					),
+					tv.proposal_id
 				)
 				ORDER BY pfv.position, pfv.id DESC
 			) AS field_values

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "Philanthropy Data Commons API",
 		"description": "An API for a common data platform to make the process of submitting data requests to funders less burdensome for changemakers seeking grants.",
-		"version": "0.40.0",
+		"version": "0.41.0",
 		"license": {
 			"name": "GNU Affero General Public License v3.0 only",
 			"url": "https://spdx.org/licenses/AGPL-3.0-only.html"

--- a/src/openapi/components/schemas/ProposalFieldValue.json
+++ b/src/openapi/components/schemas/ProposalFieldValue.json
@@ -4,6 +4,11 @@
 		{
 			"type": "object",
 			"properties": {
+				"proposalId": {
+					"allOf": [{ "$ref": "./id.json" }],
+					"readOnly": true,
+					"example": 2911
+				},
 				"proposalVersionId": {
 					"allOf": [{ "$ref": "./id.json" }],
 					"readOnly": true,
@@ -23,6 +28,7 @@
 				}
 			},
 			"required": [
+				"proposalId",
 				"proposalVersionId",
 				"applicationFormFieldId",
 				"applicationFormField",

--- a/src/tasks/__tests__/processBulkUploadTask.int.test.ts
+++ b/src/tasks/__tests__/processBulkUploadTask.int.test.ts
@@ -514,6 +514,7 @@ describe('processBulkUploadTask', () => {
 									isValid: true,
 									goodAsOf: null,
 									position: 0,
+									proposalId: 2,
 									proposalVersionId: 2,
 									value: 'foo@example.com',
 									file: null,
@@ -547,6 +548,7 @@ describe('processBulkUploadTask', () => {
 									isValid: true,
 									goodAsOf: null,
 									position: 1,
+									proposalId: 2,
 									proposalVersionId: 2,
 									value: 'Bar Inc.',
 									file: null,
@@ -580,6 +582,7 @@ describe('processBulkUploadTask', () => {
 									isValid: true,
 									goodAsOf: null,
 									position: 2,
+									proposalId: 2,
 									proposalVersionId: 2,
 									value: twoTxtFile.id.toString(),
 									file: { ...twoTxtFile, downloadUrl: expectString() },
@@ -637,6 +640,7 @@ describe('processBulkUploadTask', () => {
 									isValid: true,
 									goodAsOf: null,
 									position: 0,
+									proposalId: 1,
 									proposalVersionId: 1,
 									value: 'foo@example.com',
 									file: null,
@@ -670,6 +674,7 @@ describe('processBulkUploadTask', () => {
 									isValid: true,
 									goodAsOf: null,
 									position: 1,
+									proposalId: 1,
 									proposalVersionId: 1,
 									value: 'Foo LLC.',
 									file: null,
@@ -703,6 +708,7 @@ describe('processBulkUploadTask', () => {
 									isValid: true,
 									goodAsOf: null,
 									position: 2,
+									proposalId: 1,
 									proposalVersionId: 1,
 									value: oneTxtFile.id.toString(),
 									file: { ...oneTxtFile, downloadUrl: expectString() },
@@ -1295,6 +1301,9 @@ describe('processBulkUploadTask', () => {
 			NO_LIMIT,
 			NO_OFFSET,
 		);
+		const uploadedProposal = proposalBundle.entries.find(
+			(proposal) => proposal.externalId === '1',
+		);
 		const fieldValues = proposalBundle.entries
 			.flatMap((proposal) => proposal.versions)
 			.flatMap((version) => version.fieldValues)
@@ -1330,6 +1339,7 @@ describe('processBulkUploadTask', () => {
 				isValid: true,
 				goodAsOf: null,
 				position: 0,
+				proposalId: uploadedProposal?.id,
 				proposalVersionId: expectNumber(),
 				value: 'foo@example.com',
 				file: null,
@@ -1363,6 +1373,7 @@ describe('processBulkUploadTask', () => {
 				isValid: true,
 				goodAsOf: null,
 				position: 1,
+				proposalId: uploadedProposal?.id,
 				proposalVersionId: expectNumber(),
 				value: 'A Deliberately Different Name',
 				file: null,
@@ -1455,6 +1466,12 @@ describe('processBulkUploadTask', () => {
 			NO_OFFSET,
 		);
 		expect(proposalBundle.total).toBe(2);
+		const rowOneProposal = proposalBundle.entries.find(
+			(proposal) => proposal.externalId === '1',
+		);
+		const rowTwoProposal = proposalBundle.entries.find(
+			(proposal) => proposal.externalId === '2',
+		);
 		const fieldValues = proposalBundle.entries
 			.flatMap((proposal) => proposal.versions)
 			.flatMap((version) => version.fieldValues)
@@ -1489,6 +1506,7 @@ describe('processBulkUploadTask', () => {
 				isValid: true,
 				goodAsOf: null,
 				position: 0,
+				proposalId: rowOneProposal?.id,
 				proposalVersionId: expectNumber(),
 				value: 'Alice Org',
 				file: null,
@@ -1522,6 +1540,7 @@ describe('processBulkUploadTask', () => {
 				isValid: true,
 				goodAsOf: null,
 				position: 0,
+				proposalId: rowTwoProposal?.id,
 				proposalVersionId: expectNumber(),
 				value: 'Bob Org',
 				file: null,

--- a/src/types/ProposalFieldValue.ts
+++ b/src/types/ProposalFieldValue.ts
@@ -6,6 +6,7 @@ import type { FieldValueBase } from './FieldValueBase';
 import type { Writable } from './Writable';
 
 interface ProposalFieldValue extends FieldValueBase {
+	readonly proposalId: Id;
 	proposalVersionId: Id;
 	applicationFormFieldId: Id;
 	position: number;


### PR DESCRIPTION
This commit adds proposalId as a field in the proposalFieldValue object when it is queried from the database, a convenience for retrieving the related proposal.

Closes #1993 