### PR TITLE
Add workflow to auto-add issues to project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,13 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened, transferred, reopened]
+
+permissions: {}
+
+jobs:
+  add-to-project:
+    uses: PhilanthropyDataCommons/.github/.github/workflows/add-to-project.yml@v1
+    secrets:
+      PDC_BOT_PRIVATE_KEY: ${{ secrets.PDC_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Adds the org caller workflow so new issues land on the project board automatically.

Uses the current org template — pinned to the `v1` tag and passing only `PDC_BOT_PRIVATE_KEY` rather than `secrets: inherit`. Supersedes the earlier stale branch, which pointed at `@main`.

Requires the pdc-bot app setup in PhilanthropyDataCommons/.github to be complete before runs will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V72EH61bzDFnGMcnEfvnZY