### PR TITLE
Update Keycloak to 26.7 in `compose-ci.yml`

### DIFF
--- a/compose-ci.yml
+++ b/compose-ci.yml
@@ -121,7 +121,7 @@ services:
             -d '{"pdcApiUrl": "'${PDC_SYNC_URL:-https://api.philanthropydatacommons.org}'"}'
         user: '999'
   pdc-auth:
-    image: docker.io/keycloak/keycloak:26.6
+    image: docker.io/keycloak/keycloak:26.7
     depends_on:
       pdc-databases:
         condition: service_healthy


### PR DESCRIPTION
The actual Keycloak instance is on 26.7.0, this matches it now.

Issue #2512