### PR TITLE
Ignore major `typescript` version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@eslint/*'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
This PR updates dependabot to ignore major versions of `typescript` to prevent dependency conflicts.