### PR TITLE
Add `InitiativeFieldValue` entity

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -71,3 +71,5 @@ terminologySetId = 1
 isCollaborative = false
 granteeType = 'user'
 verb = 'view'
+initiativeId = 1
+initiativeFieldValueId = 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added an `initiative` entity representing a project led by a changemaker, managed via the administrator-only `/initiatives` endpoints.
+- Added an `initiativeFieldValue` entity capturing base field data for an initiative, managed via the administrator-only `/initiatives/{initiativeId}/fieldValues` endpoints.
 
 ## 0.41.0 2026-07-24
 

--- a/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
+++ b/docs/ENTITY_RELATIONSHIP_DIAGRAM.md
@@ -53,6 +53,17 @@ erDiagram
     datetime createdAt
     uuid createdBy FK
   }
+  InitiativeFieldValue {
+    int id PK
+    int initiativeId FK
+    string baseFieldShortCode FK
+    int sourceId FK
+    string value
+    boolean isValid
+    datetime goodAsOf
+    datetime createdAt
+    uuid createdBy FK
+  }
   ChangemakersProposal {
     int id PK
     int changemakerId FK
@@ -226,6 +237,9 @@ erDiagram
   Changemaker ||--o{ ChangemakersProposal : "is associated with"
   Proposal ||--o{ ChangemakersProposal : "is associated with"
   Changemaker ||--o{ Initiative : "leads"
+  Initiative ||--o{ InitiativeFieldValue : "has"
+  InitiativeFieldValue }o--|| BaseField : "is for"
+  InitiativeFieldValue }o--|| Source : "comes from"
   Changemaker ||--o{ ChangemakerFieldValue : "has"
   ChangemakerFieldValue }o--|| BaseField : "is for"
   ChangemakerFieldValue }o--|| ChangemakerFieldValueBatch : "belongs to"
@@ -279,6 +293,7 @@ Additionally...
 10. `Changemaker Field Values` are grouped into `Changemaker Field Value Batches`, each of which comes from a `Source`.
 11. `Changemakers` can have `Fiscal Sponsorship` relationships with other `Changemakers`.
 12. A `Changemaker` can lead many `Initiatives`, each of which represents a project or program that changemaker runs.
+13. An `Initiative` can have `Initiative Field Values` that store base field data about that initiative, each of which comes from a `Source`. Any base field category other than `organization` may be used, since organization data belongs to the changemaker rather than to one of its initiatives.
 
 The thinking is that when a new proposal is being written, a Grant Management System could ask the PDC "is there any pre-populated data we should use for this changemaker?"
 

--- a/src/__tests__/initiativeFieldValues.int.test.ts
+++ b/src/__tests__/initiativeFieldValues.int.test.ts
@@ -1,0 +1,726 @@
+import request from 'supertest';
+import { app } from '../app';
+import {
+	createOrUpdateBaseField,
+	getDatabase,
+	loadTableMetrics,
+} from '../database';
+import { loadUnifiedAuditLogBundle } from '../database/operations/unifiedAuditLogs';
+import {
+	createTestBaseField,
+	createTestInitiative,
+	createTestInitiativeFieldValue,
+	createTestSource,
+} from '../test/factories';
+import {
+	getAuthContext,
+	getTestAuthContext,
+	loadTestUser,
+	NO_LIMIT,
+	NO_OFFSET,
+} from '../test/utils';
+import {
+	expectArray,
+	expectObjectContaining,
+	expectTimestamp,
+} from '../test/asymettricMatchers';
+import {
+	BaseFieldCategory,
+	BaseFieldDataType,
+	BaseFieldSensitivityClassification,
+} from '../types';
+import {
+	mockJwt as authHeader,
+	mockJwtWithAdminRole as authHeaderWithAdminRole,
+} from '../test/mockJwt';
+
+describe('/initiatives/:initiativeId/fieldValues', () => {
+	describe('GET /', () => {
+		it('requires authentication', async () => {
+			await request(app).get('/initiatives/1/fieldValues').expect(401);
+		});
+
+		it('requires administrator role', async () => {
+			await request(app)
+				.get('/initiatives/1/fieldValues')
+				.set(authHeader)
+				.expect(401);
+		});
+
+		it('returns 400 when the initiative id is not numeric', async () => {
+			const response = await request(app)
+				.get('/initiatives/not_a_valid_id/fieldValues')
+				.set(authHeaderWithAdminRole)
+				.expect(400);
+			expect(response.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expectArray(),
+			});
+		});
+
+		it('returns 404 when the initiative does not exist', async () => {
+			await request(app)
+				.get('/initiatives/9001/fieldValues')
+				.set(authHeaderWithAdminRole)
+				.expect(404);
+		});
+
+		it('returns an empty bundle when the initiative has no field values', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+
+			await request(app)
+				.get(`/initiatives/${initiative.id}/fieldValues`)
+				.set(authHeaderWithAdminRole)
+				.expect(200, {
+					entries: [],
+					total: 0,
+				});
+		});
+
+		it('returns the field values of the specified initiative', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const otherInitiative = await createTestInitiative(
+				db,
+				testUserAuthContext,
+			);
+			const fieldValueA = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: initiative.id, value: 'A' },
+			);
+			const fieldValueB = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: initiative.id, value: 'B' },
+			);
+			await createTestInitiativeFieldValue(db, testUserAuthContext, {
+				initiativeId: otherInitiative.id,
+				value: 'Other',
+			});
+
+			const response = await request(app)
+				.get(`/initiatives/${initiative.id}/fieldValues`)
+				.set(authHeaderWithAdminRole)
+				.expect(200);
+			expect(response.body).toEqual({
+				entries: [fieldValueA, fieldValueB],
+				total: 2,
+			});
+		});
+
+		it('omits field values whose base field has become forbidden', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const visibleBaseField = await createTestBaseField(db, null, {
+				category: BaseFieldCategory.PROJECT,
+				sensitivityClassification:
+					BaseFieldSensitivityClassification.RESTRICTED,
+			});
+			const forbiddenBaseField = await createTestBaseField(db, null, {
+				category: BaseFieldCategory.PROJECT,
+				sensitivityClassification:
+					BaseFieldSensitivityClassification.RESTRICTED,
+			});
+			const visibleFieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{
+					initiativeId: initiative.id,
+					baseFieldShortCode: visibleBaseField.shortCode,
+					value: 'Visible',
+				},
+			);
+			await createTestInitiativeFieldValue(db, testUserAuthContext, {
+				initiativeId: initiative.id,
+				baseFieldShortCode: forbiddenBaseField.shortCode,
+				value: 'Forbidden',
+			});
+			await createOrUpdateBaseField(db, null, {
+				...forbiddenBaseField,
+				sensitivityClassification: BaseFieldSensitivityClassification.FORBIDDEN,
+			});
+
+			const response = await request(app)
+				.get(`/initiatives/${initiative.id}/fieldValues`)
+				.set(authHeaderWithAdminRole)
+				.expect(200);
+			expect(response.body).toEqual({
+				entries: [visibleFieldValue],
+				total: 1,
+			});
+		});
+	});
+
+	describe('GET /:fieldValueId', () => {
+		it('requires authentication', async () => {
+			await request(app).get('/initiatives/1/fieldValues/1').expect(401);
+		});
+
+		it('requires administrator role', async () => {
+			await request(app)
+				.get('/initiatives/1/fieldValues/1')
+				.set(authHeader)
+				.expect(401);
+		});
+
+		it('returns 400 when the field value id is not numeric', async () => {
+			const response = await request(app)
+				.get('/initiatives/1/fieldValues/not_a_valid_id')
+				.set(authHeaderWithAdminRole)
+				.expect(400);
+			expect(response.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expectArray(),
+			});
+		});
+
+		it('returns 404 when the field value does not exist', async () => {
+			await request(app)
+				.get('/initiatives/9001/fieldValues/9001')
+				.set(authHeaderWithAdminRole)
+				.expect(404);
+		});
+
+		it('returns 404 when the field value belongs to a different initiative', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const otherInitiative = await createTestInitiative(
+				db,
+				testUserAuthContext,
+			);
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: otherInitiative.id },
+			);
+
+			await request(app)
+				.get(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.set(authHeaderWithAdminRole)
+				.expect(404);
+		});
+
+		it('returns the field value', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: initiative.id },
+			);
+
+			const response = await request(app)
+				.get(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.set(authHeaderWithAdminRole)
+				.expect(200);
+			expect(response.body).toEqual(fieldValue);
+		});
+
+		it('returns 404 when the base field has become forbidden', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, null, {
+				category: BaseFieldCategory.PROJECT,
+				sensitivityClassification:
+					BaseFieldSensitivityClassification.RESTRICTED,
+			});
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{
+					initiativeId: initiative.id,
+					baseFieldShortCode: baseField.shortCode,
+				},
+			);
+			await createOrUpdateBaseField(db, null, {
+				...baseField,
+				sensitivityClassification: BaseFieldSensitivityClassification.FORBIDDEN,
+			});
+
+			await request(app)
+				.get(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.set(authHeaderWithAdminRole)
+				.expect(404);
+		});
+	});
+
+	describe('POST /', () => {
+		it('requires authentication', async () => {
+			await request(app).post('/initiatives/1/fieldValues').expect(401);
+		});
+
+		it('requires administrator role', async () => {
+			await request(app)
+				.post('/initiatives/1/fieldValues')
+				.type('application/json')
+				.set(authHeader)
+				.send({
+					baseFieldShortCode: 'initiative_description',
+					sourceId: 1,
+					value: 'A clean water program.',
+					goodAsOf: null,
+				})
+				.expect(401);
+		});
+
+		it('returns 400 when the value is missing', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, testUserAuthContext, {
+				category: BaseFieldCategory.PROJECT,
+			});
+			const source = await createTestSource(db, testUserAuthContext);
+
+			const response = await request(app)
+				.post(`/initiatives/${initiative.id}/fieldValues`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					baseFieldShortCode: baseField.shortCode,
+					sourceId: source.id,
+					goodAsOf: null,
+				})
+				.expect(400);
+			expect(response.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expectArray(),
+			});
+		});
+
+		it('returns 404 when the initiative does not exist', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const baseField = await createTestBaseField(db, testUserAuthContext, {
+				category: BaseFieldCategory.PROJECT,
+			});
+			const source = await createTestSource(db, testUserAuthContext);
+
+			await request(app)
+				.post('/initiatives/9001/fieldValues')
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					baseFieldShortCode: baseField.shortCode,
+					sourceId: source.id,
+					value: 'A clean water program.',
+					goodAsOf: null,
+				})
+				.expect(404);
+		});
+
+		it('returns 404 when the base field does not exist', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const source = await createTestSource(db, testUserAuthContext);
+
+			await request(app)
+				.post(`/initiatives/${initiative.id}/fieldValues`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					baseFieldShortCode: 'not_a_real_base_field',
+					sourceId: source.id,
+					value: 'A clean water program.',
+					goodAsOf: null,
+				})
+				.expect(404);
+		});
+
+		it('returns 404 when the source does not exist', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, testUserAuthContext, {
+				category: BaseFieldCategory.PROJECT,
+			});
+
+			await request(app)
+				.post(`/initiatives/${initiative.id}/fieldValues`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					baseFieldShortCode: baseField.shortCode,
+					sourceId: 9001,
+					value: 'A clean water program.',
+					goodAsOf: null,
+				})
+				.expect(404);
+		});
+
+		it('returns 422 when the base field is an organization field', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, testUserAuthContext, {
+				category: BaseFieldCategory.ORGANIZATION,
+			});
+			const source = await createTestSource(db, testUserAuthContext);
+
+			const response = await request(app)
+				.post(`/initiatives/${initiative.id}/fieldValues`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					baseFieldShortCode: baseField.shortCode,
+					sourceId: source.id,
+					value: 'A clean water program.',
+					goodAsOf: null,
+				})
+				.expect(422);
+			expect(response.body).toMatchObject({
+				name: 'UnprocessableEntityError',
+			});
+		});
+
+		it('accepts base field categories other than project and organization', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, testUserAuthContext, {
+				category: BaseFieldCategory.OUTCOMES,
+			});
+			const source = await createTestSource(db, testUserAuthContext);
+
+			const response = await request(app)
+				.post(`/initiatives/${initiative.id}/fieldValues`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					baseFieldShortCode: baseField.shortCode,
+					sourceId: source.id,
+					value: 'Two thousand households served.',
+					goodAsOf: null,
+				})
+				.expect(201);
+			expect(response.body).toMatchObject({
+				baseFieldShortCode: baseField.shortCode,
+				value: 'Two thousand households served.',
+			});
+		});
+
+		it('returns 422 when the base field is forbidden', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, testUserAuthContext, {
+				category: BaseFieldCategory.PROJECT,
+				sensitivityClassification: BaseFieldSensitivityClassification.FORBIDDEN,
+			});
+			const source = await createTestSource(db, testUserAuthContext);
+
+			const response = await request(app)
+				.post(`/initiatives/${initiative.id}/fieldValues`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					baseFieldShortCode: baseField.shortCode,
+					sourceId: source.id,
+					value: 'A clean water program.',
+					goodAsOf: null,
+				})
+				.expect(422);
+			expect(response.body).toMatchObject({
+				name: 'UnprocessableEntityError',
+			});
+		});
+
+		it('creates exactly one initiative field value', async () => {
+			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, testUserAuthContext, {
+				category: BaseFieldCategory.PROJECT,
+			});
+			const source = await createTestSource(db, testUserAuthContext);
+
+			const before = await loadTableMetrics(db, 'initiative_field_values');
+			const response = await request(app)
+				.post(`/initiatives/${initiative.id}/fieldValues`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					baseFieldShortCode: baseField.shortCode,
+					sourceId: source.id,
+					value: 'A clean water program.',
+					goodAsOf: null,
+				})
+				.expect(201);
+			const after = await loadTableMetrics(db, 'initiative_field_values');
+
+			expect(after.count).toEqual(before.count + 1);
+			expect(response.body).toMatchObject({
+				initiativeId: initiative.id,
+				baseFieldShortCode: baseField.shortCode,
+				baseField: expectObjectContaining({
+					shortCode: baseField.shortCode,
+				}),
+				sourceId: source.id,
+				source: expectObjectContaining({ id: source.id }),
+				value: 'A clean water program.',
+				file: null,
+				goodAsOf: null,
+				isValid: true,
+				createdAt: expectTimestamp(),
+				createdBy: testUser.keycloakUserId,
+			});
+		});
+
+		it('marks a value that does not match the base field data type as invalid', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, testUserAuthContext, {
+				category: BaseFieldCategory.PROJECT,
+				dataType: BaseFieldDataType.NUMBER,
+			});
+			const source = await createTestSource(db, testUserAuthContext);
+
+			const response = await request(app)
+				.post(`/initiatives/${initiative.id}/fieldValues`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					baseFieldShortCode: baseField.shortCode,
+					sourceId: source.id,
+					value: 'not a number',
+					goodAsOf: null,
+				})
+				.expect(201);
+			expect(response.body).toMatchObject({
+				value: 'not a number',
+				isValid: false,
+			});
+		});
+	});
+
+	describe('PATCH /:fieldValueId', () => {
+		it('requires authentication', async () => {
+			await request(app).patch('/initiatives/1/fieldValues/1').expect(401);
+		});
+
+		it('requires administrator role', async () => {
+			await request(app)
+				.patch('/initiatives/1/fieldValues/1')
+				.type('application/json')
+				.set(authHeader)
+				.send({ value: 'An updated value.' })
+				.expect(401);
+		});
+
+		it('returns 400 when the body is empty', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: initiative.id },
+			);
+
+			const response = await request(app)
+				.patch(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({})
+				.expect(400);
+			expect(response.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expectArray(),
+			});
+		});
+
+		it('returns 400 when the body contains an unwritable attribute', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: initiative.id },
+			);
+
+			const response = await request(app)
+				.patch(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({ baseFieldShortCode: 'a_different_base_field' })
+				.expect(400);
+			expect(response.body).toMatchObject({
+				name: 'InputValidationError',
+				details: expectArray(),
+			});
+		});
+
+		it('returns 404 when the field value does not exist', async () => {
+			await request(app)
+				.patch('/initiatives/9001/fieldValues/9001')
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({ value: 'An updated value.' })
+				.expect(404);
+		});
+
+		it('returns 404 when the field value belongs to a different initiative', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const otherInitiative = await createTestInitiative(
+				db,
+				testUserAuthContext,
+			);
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: otherInitiative.id },
+			);
+
+			await request(app)
+				.patch(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({ value: 'An updated value.' })
+				.expect(404);
+		});
+
+		it('returns 404 when the new source does not exist', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: initiative.id },
+			);
+
+			await request(app)
+				.patch(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({ sourceId: 9001 })
+				.expect(404);
+		});
+
+		it('updates the value', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: initiative.id, value: 'The original value.' },
+			);
+
+			const response = await request(app)
+				.patch(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({ value: 'An updated value.' })
+				.expect(200);
+			expect(response.body).toEqual({
+				...fieldValue,
+				value: 'An updated value.',
+			});
+		});
+
+		it('updates goodAsOf and the source', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: initiative.id, goodAsOf: null },
+			);
+			const newSource = await createTestSource(db, testUserAuthContext);
+
+			const response = await request(app)
+				.patch(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({
+					sourceId: newSource.id,
+					goodAsOf: '2026-08-13T00:00:00.000Z',
+				})
+				.expect(200);
+			expect(response.body).toMatchObject({
+				sourceId: newSource.id,
+				source: expectObjectContaining({ id: newSource.id }),
+				goodAsOf: expectTimestamp(),
+			});
+		});
+
+		it('revalidates the value against the base field data type', async () => {
+			const db = getDatabase();
+			const testUserAuthContext = getAuthContext(await loadTestUser(db));
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const baseField = await createTestBaseField(db, testUserAuthContext, {
+				category: BaseFieldCategory.PROJECT,
+				dataType: BaseFieldDataType.NUMBER,
+			});
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{
+					initiativeId: initiative.id,
+					baseFieldShortCode: baseField.shortCode,
+					value: '42',
+				},
+			);
+
+			const response = await request(app)
+				.patch(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({ value: 'not a number' })
+				.expect(200);
+			expect(response.body).toMatchObject({
+				value: 'not a number',
+				isValid: false,
+			});
+		});
+
+		it('records the acting user in the audit log', async () => {
+			const db = getDatabase();
+			const testUser = await loadTestUser(db);
+			const testUserAuthContext = getAuthContext(testUser);
+			const initiative = await createTestInitiative(db, testUserAuthContext);
+			const fieldValue = await createTestInitiativeFieldValue(
+				db,
+				testUserAuthContext,
+				{ initiativeId: initiative.id },
+			);
+
+			await request(app)
+				.patch(`/initiatives/${initiative.id}/fieldValues/${fieldValue.id}`)
+				.type('application/json')
+				.set(authHeaderWithAdminRole)
+				.send({ value: 'An updated value.' })
+				.expect(200);
+
+			const auditLogs = await loadUnifiedAuditLogBundle(
+				db,
+				await getTestAuthContext(db),
+				NO_LIMIT,
+				NO_OFFSET,
+			);
+			expect(auditLogs.entries).toContainEqual(
+				expectObjectContaining({
+					operation: 'Called query initiativeFieldValues.updateById',
+					userKeycloakUserId: testUser.keycloakUserId,
+					userIsAdministrator: true,
+				}),
+			);
+		});
+	});
+});

--- a/src/database/initialization/1_assert_initiative_field_value_not_forbidden.sql
+++ b/src/database/initialization/1_assert_initiative_field_value_not_forbidden.sql
@@ -1,0 +1,24 @@
+SELECT drop_function('assert_initiative_field_value_not_forbidden');
+
+-- Raises if the field value belongs to a forbidden base field, so a forbidden
+-- value is never serialized. Read paths exclude forbidden fields themselves;
+-- this guards the paths that serialize a row directly (the field value insert
+-- and update), which do not filter by sensitivity.
+CREATE FUNCTION assert_initiative_field_value_not_forbidden(
+	initiative_field_value initiative_field_values
+) RETURNS void AS $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM base_fields
+		WHERE base_fields.short_code
+			= initiative_field_value.base_field_short_code
+			AND base_fields.sensitivity_classification = 'forbidden'
+	) THEN
+		RAISE EXCEPTION
+			'Refusing to serialize forbidden initiative_field_value (%)',
+			initiative_field_value.id
+			USING ERRCODE = '22023'; -- invalid_parameter_value
+	END IF;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/1_build_initiative_field_value_result.sql
+++ b/src/database/initialization/1_build_initiative_field_value_result.sql
@@ -1,0 +1,32 @@
+SELECT drop_function('build_initiative_field_value_result');
+
+CREATE FUNCTION build_initiative_field_value_result(
+	initiative_field_value initiative_field_values
+) RETURNS jsonb AS $$
+DECLARE
+	is_file_field BOOLEAN;
+	base_field_json JSONB;
+	source_json JSONB;
+BEGIN
+	PERFORM assert_initiative_field_value_not_forbidden(initiative_field_value);
+
+	SELECT
+		base_fields.data_type = 'file',
+		base_field_to_json(base_fields.*)
+	INTO is_file_field, base_field_json
+	FROM base_fields
+	WHERE base_fields.short_code = initiative_field_value.base_field_short_code;
+
+	SELECT source_to_json(sources.*)
+	INTO source_json
+	FROM sources
+	WHERE sources.id = initiative_field_value.source_id;
+
+	RETURN initiative_field_value_to_json(
+		initiative_field_value,
+		base_field_json,
+		source_json,
+		initiative_field_value_file_to_json(initiative_field_value, is_file_field)
+	);
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/database/initialization/1_initiative_field_value_to_json.sql
+++ b/src/database/initialization/1_initiative_field_value_to_json.sql
@@ -1,0 +1,23 @@
+SELECT drop_function('initiative_field_value_to_json');
+
+CREATE FUNCTION initiative_field_value_to_json(
+	initiative_field_value initiative_field_values,
+	base_field jsonb,
+	source jsonb,
+	file jsonb
+) RETURNS jsonb AS $$
+	SELECT jsonb_build_object(
+		'id', initiative_field_value.id,
+		'initiativeId', initiative_field_value.initiative_id,
+		'baseFieldShortCode', initiative_field_value.base_field_short_code,
+		'baseField', base_field,
+		'sourceId', initiative_field_value.source_id,
+		'source', source,
+		'value', initiative_field_value.value,
+		'file', file,
+		'goodAsOf', initiative_field_value.good_as_of,
+		'isValid', initiative_field_value.is_valid,
+		'createdAt', initiative_field_value.created_at,
+		'createdBy', initiative_field_value.created_by
+	);
+$$ LANGUAGE sql IMMUTABLE;

--- a/src/database/initialization/2_initiative_field_value_file_to_json.sql
+++ b/src/database/initialization/2_initiative_field_value_file_to_json.sql
@@ -1,0 +1,12 @@
+SELECT drop_function('initiative_field_value_file_to_json');
+
+CREATE FUNCTION initiative_field_value_file_to_json(
+	initiative_field_value initiative_field_values,
+	is_file_field boolean
+) RETURNS jsonb AS $$
+	SELECT file_to_json(files.*)
+	FROM files
+	WHERE initiative_field_value_file_to_json.is_file_field
+		AND initiative_field_value.value ~ '^[0-9]+$'
+		AND files.id = initiative_field_value.value::integer;
+$$ LANGUAGE sql STABLE;

--- a/src/database/migrations/0119-create-initiative_field_values.sql
+++ b/src/database/migrations/0119-create-initiative_field_values.sql
@@ -1,0 +1,79 @@
+CREATE TABLE initiative_field_values (
+	id int PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+	initiative_id int NOT NULL REFERENCES initiatives (id) ON DELETE CASCADE,
+	base_field_short_code text NOT NULL
+	REFERENCES base_fields (short_code) ON DELETE RESTRICT,
+	source_id int NOT NULL REFERENCES sources (id) ON DELETE RESTRICT,
+	value text NOT NULL,
+	is_valid boolean NOT NULL DEFAULT TRUE,
+	good_as_of timestamp with time zone,
+	created_at timestamp with time zone NOT NULL DEFAULT now(),
+	created_by uuid NOT NULL REFERENCES users (keycloak_user_id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE initiative_field_values IS
+'Base field values captured directly against an initiative.';
+
+CREATE INDEX idx_initiative_field_values_initiative
+ON initiative_field_values (initiative_id);
+
+CREATE INDEX idx_initiative_field_values_base_field
+ON initiative_field_values (base_field_short_code);
+
+CREATE INDEX idx_initiative_field_values_source
+ON initiative_field_values (source_id);
+
+CREATE OR REPLACE FUNCTION prevent_forbidden_initiative_field_value()
+RETURNS trigger AS $$
+DECLARE
+    forbidden BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1
+        FROM base_fields
+        WHERE base_fields.short_code = NEW.base_field_short_code
+          AND base_fields.sensitivity_classification = 'forbidden'
+    ) INTO forbidden;
+
+    IF forbidden THEN
+        RAISE EXCEPTION 'Cannot insert initiative field value for forbidden base field %', NEW.base_field_short_code
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER check_forbidden_initiative_field_value
+BEFORE INSERT OR UPDATE ON initiative_field_values
+FOR EACH ROW
+EXECUTE FUNCTION prevent_forbidden_initiative_field_value();
+
+CREATE OR REPLACE FUNCTION
+prevent_organization_category_initiative_field_value()
+RETURNS trigger AS $$
+DECLARE
+    wrong_category BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1
+        FROM base_fields
+        WHERE base_fields.short_code = NEW.base_field_short_code
+          AND base_fields.category = 'organization'
+    ) INTO wrong_category;
+
+    IF wrong_category THEN
+        RAISE EXCEPTION 'Cannot insert initiative field value for organization base field %', NEW.base_field_short_code
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER check_organization_category_initiative_field_value
+BEFORE INSERT OR UPDATE ON initiative_field_values
+FOR EACH ROW
+EXECUTE FUNCTION prevent_organization_category_initiative_field_value();
+
+SELECT audit_table('initiative_field_values');

--- a/src/database/operations/index.ts
+++ b/src/database/operations/index.ts
@@ -18,6 +18,7 @@ export * from './funderCollaborativeInvitations';
 export * from './funderCollaborativeMembers';
 export * from './funders';
 export * from './generic';
+export * from './initiativeFieldValues';
 export * from './initiatives';
 export * from './opportunities';
 export * from './organizations';

--- a/src/database/operations/initiativeFieldValues/createInitiativeFieldValue.ts
+++ b/src/database/operations/initiativeFieldValues/createInitiativeFieldValue.ts
@@ -1,0 +1,26 @@
+import { generateCreateItemOperation } from '../generators';
+import { decorateWithFileDownloadUrl } from '../../../decorators/initiativeFieldValue';
+import type {
+	InitiativeFieldValue,
+	InternallyWritableInitiativeFieldValue,
+} from '../../../types';
+
+const createInitiativeFieldValue = generateCreateItemOperation<
+	InitiativeFieldValue,
+	InternallyWritableInitiativeFieldValue,
+	[]
+>(
+	'initiativeFieldValues.insertOne',
+	[
+		'initiativeId',
+		'baseFieldShortCode',
+		'sourceId',
+		'value',
+		'isValid',
+		'goodAsOf',
+	],
+	[],
+	decorateWithFileDownloadUrl,
+);
+
+export { createInitiativeFieldValue };

--- a/src/database/operations/initiativeFieldValues/index.ts
+++ b/src/database/operations/initiativeFieldValues/index.ts
@@ -1,0 +1,4 @@
+export * from './createInitiativeFieldValue';
+export * from './loadInitiativeFieldValue';
+export * from './loadInitiativeFieldValueBundle';
+export * from './updateInitiativeFieldValue';

--- a/src/database/operations/initiativeFieldValues/loadInitiativeFieldValue.ts
+++ b/src/database/operations/initiativeFieldValues/loadInitiativeFieldValue.ts
@@ -1,0 +1,15 @@
+import { generateLoadItemOperation } from '../generators';
+import { decorateWithFileDownloadUrl } from '../../../decorators/initiativeFieldValue';
+import type { Id, InitiativeFieldValue } from '../../../types';
+
+const loadInitiativeFieldValue = generateLoadItemOperation<
+	InitiativeFieldValue,
+	[initiativeId: Id, initiativeFieldValueId: Id]
+>(
+	'initiativeFieldValues.selectById',
+	'InitiativeFieldValue',
+	['initiativeId', 'initiativeFieldValueId'],
+	decorateWithFileDownloadUrl,
+);
+
+export { loadInitiativeFieldValue };

--- a/src/database/operations/initiativeFieldValues/loadInitiativeFieldValueBundle.ts
+++ b/src/database/operations/initiativeFieldValues/loadInitiativeFieldValueBundle.ts
@@ -1,0 +1,14 @@
+import { generateLoadBundleOperation } from '../generators';
+import { decorateWithFileDownloadUrl } from '../../../decorators/initiativeFieldValue';
+import type { Id, InitiativeFieldValue } from '../../../types';
+
+const loadInitiativeFieldValueBundle = generateLoadBundleOperation<
+	InitiativeFieldValue,
+	[initiativeId: Id]
+>(
+	'initiativeFieldValues.selectWithPagination',
+	['initiativeId'],
+	decorateWithFileDownloadUrl,
+);
+
+export { loadInitiativeFieldValueBundle };

--- a/src/database/operations/initiativeFieldValues/updateInitiativeFieldValue.ts
+++ b/src/database/operations/initiativeFieldValues/updateInitiativeFieldValue.ts
@@ -1,0 +1,20 @@
+import { generateUpdateItemOperation } from '../generators';
+import { decorateWithFileDownloadUrl } from '../../../decorators/initiativeFieldValue';
+import type {
+	Id,
+	InitiativeFieldValue,
+	InternallyWritableInitiativeFieldValuePatch,
+} from '../../../types';
+
+const updateInitiativeFieldValue = generateUpdateItemOperation<
+	InitiativeFieldValue,
+	InternallyWritableInitiativeFieldValuePatch,
+	[initiativeId: Id, initiativeFieldValueId: Id]
+>(
+	'initiativeFieldValues.updateById',
+	['value', 'sourceId', 'goodAsOf', 'isValid'],
+	['initiativeId', 'initiativeFieldValueId'],
+	decorateWithFileDownloadUrl,
+);
+
+export { updateInitiativeFieldValue };

--- a/src/database/queries/initiativeFieldValues/insertOne.sql
+++ b/src/database/queries/initiativeFieldValues/insertOne.sql
@@ -1,0 +1,19 @@
+INSERT INTO initiative_field_values (
+	initiative_id,
+	base_field_short_code,
+	source_id,
+	value,
+	is_valid,
+	good_as_of,
+	created_by
+) VALUES (
+	:initiativeId,
+	:baseFieldShortCode,
+	:sourceId,
+	:value,
+	:isValid,
+	:goodAsOf,
+	:authContextKeycloakUserId
+)
+RETURNING
+	build_initiative_field_value_result(initiative_field_values) AS object;

--- a/src/database/queries/initiativeFieldValues/selectById.sql
+++ b/src/database/queries/initiativeFieldValues/selectById.sql
@@ -1,0 +1,13 @@
+SELECT
+	build_initiative_field_value_result(
+		initiative_field_values.*::initiative_field_values
+	) AS object
+FROM initiative_field_values
+	INNER JOIN base_fields
+		ON
+			initiative_field_values.base_field_short_code
+			= base_fields.short_code
+WHERE
+	initiative_field_values.id = :initiativeFieldValueId
+	AND initiative_field_values.initiative_id = :initiativeId
+	AND base_fields.sensitivity_classification <> 'forbidden';

--- a/src/database/queries/initiativeFieldValues/selectWithPagination.sql
+++ b/src/database/queries/initiativeFieldValues/selectWithPagination.sql
@@ -1,0 +1,38 @@
+WITH
+	candidate_entries AS MATERIALIZED (
+		SELECT initiative_field_values.*
+		FROM initiative_field_values
+			INNER JOIN base_fields
+				ON
+					initiative_field_values.base_field_short_code
+					= base_fields.short_code
+		WHERE
+			initiative_field_values.initiative_id = :initiativeId
+			AND base_fields.sensitivity_classification <> 'forbidden'
+	),
+
+	entry_count AS (
+		SELECT count(*) AS total FROM candidate_entries
+	),
+
+	page AS (
+		SELECT candidate_entries.*
+		FROM candidate_entries
+		ORDER BY id
+		LIMIT :limit OFFSET :offset
+	),
+
+	paginated_entries AS (
+		SELECT
+			build_initiative_field_value_result(
+				page.*::initiative_field_values
+			) AS object
+		FROM page
+		ORDER BY id
+	)
+
+SELECT
+	paginated_entries.object,
+	entry_count.total
+FROM entry_count
+	LEFT JOIN paginated_entries ON TRUE;

--- a/src/database/queries/initiativeFieldValues/updateById.sql
+++ b/src/database/queries/initiativeFieldValues/updateById.sql
@@ -1,0 +1,13 @@
+UPDATE initiative_field_values
+SET
+	value = update_if(:valueWasProvided, :value::text, value),
+	source_id = update_if(:sourceIdWasProvided, :sourceId::integer, source_id),
+	good_as_of = update_if(
+		:goodAsOfWasProvided, :goodAsOf::timestamptz, good_as_of
+	),
+	is_valid = :isValid
+WHERE
+	id = :initiativeFieldValueId
+	AND initiative_id = :initiativeId
+RETURNING
+	build_initiative_field_value_result(initiative_field_values) AS object;

--- a/src/decorators/initiativeFieldValue.ts
+++ b/src/decorators/initiativeFieldValue.ts
@@ -1,0 +1,19 @@
+import { decorateWithDownloadUrl } from './file';
+import type { InitiativeFieldValue } from '../types';
+
+const decorateWithFileDownloadUrl = async (
+	initiativeFieldValue: InitiativeFieldValue,
+): Promise<InitiativeFieldValue> => {
+	if (initiativeFieldValue.file === null) {
+		return initiativeFieldValue;
+	}
+	const decoratedFile = await decorateWithDownloadUrl(
+		initiativeFieldValue.file,
+	);
+	return {
+		...initiativeFieldValue,
+		file: decoratedFile,
+	};
+};
+
+export { decorateWithFileDownloadUrl };

--- a/src/handlers/initiativeFieldValuesHandlers.ts
+++ b/src/handlers/initiativeFieldValuesHandlers.ts
@@ -1,0 +1,212 @@
+import { HTTP_STATUS } from '../constants';
+import {
+	createInitiativeFieldValue,
+	getDatabase,
+	getLimitValues,
+	loadBaseField,
+	loadInitiative,
+	loadInitiativeFieldValue,
+	loadInitiativeFieldValueBundle,
+	loadSource,
+	updateInitiativeFieldValue,
+} from '../database';
+import {
+	BaseFieldCategory,
+	BaseFieldSensitivityClassification,
+	isAuthContext,
+	isId,
+	isInitiativeFieldValuePatch,
+	isWritableInitiativeFieldValue,
+} from '../types';
+import {
+	FailedMiddlewareError,
+	InputValidationError,
+	UnprocessableEntityError,
+} from '../errors';
+import { extractPaginationParameters } from '../queryParameters';
+import { coerceParams } from '../coercion';
+import { fieldValueIsValid } from '../fieldValidation';
+import type { BaseField, Id } from '../types';
+import type { Request, Response } from 'express';
+
+const extractInitiativeId = (req: Request): Id => {
+	const { initiativeId } = coerceParams(req.params);
+	if (!isId(initiativeId)) {
+		throw new InputValidationError(
+			'Invalid initiativeId parameter.',
+			isId.errors ?? [],
+		);
+	}
+	return initiativeId;
+};
+
+const extractFieldValueId = (req: Request): Id => {
+	const { fieldValueId } = coerceParams(req.params);
+	if (!isId(fieldValueId)) {
+		throw new InputValidationError(
+			'Invalid fieldValueId parameter.',
+			isId.errors ?? [],
+		);
+	}
+	return fieldValueId;
+};
+
+const assertBaseFieldIsUsableByInitiatives = (baseField: BaseField): void => {
+	if (baseField.category === BaseFieldCategory.ORGANIZATION) {
+		throw new UnprocessableEntityError(
+			`Values for ${baseField.shortCode} must be provided in the context of a changemaker because this field is of category '${baseField.category}'.  Organization field values may not be posted here.`,
+		);
+	}
+	if (
+		baseField.sensitivityClassification ===
+		BaseFieldSensitivityClassification.FORBIDDEN
+	) {
+		throw new UnprocessableEntityError(
+			`Base field ${baseField.shortCode} is forbidden and cannot be used for initiative field values.`,
+		);
+	}
+};
+
+const getInitiativeFieldValues = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const db = getDatabase();
+	const initiativeId = extractInitiativeId(req);
+	const paginationParameters = extractPaginationParameters(req);
+	const { offset, limit } = getLimitValues(paginationParameters);
+
+	await loadInitiative(db, req, initiativeId);
+
+	const bundle = await loadInitiativeFieldValueBundle(
+		db,
+		req,
+		initiativeId,
+		limit,
+		offset,
+	);
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(bundle);
+};
+
+const getInitiativeFieldValue = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const db = getDatabase();
+	const initiativeId = extractInitiativeId(req);
+	const fieldValueId = extractFieldValueId(req);
+
+	const initiativeFieldValue = await loadInitiativeFieldValue(
+		db,
+		req,
+		initiativeId,
+		fieldValueId,
+	);
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(initiativeFieldValue);
+};
+
+const postInitiativeFieldValue = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const db = getDatabase();
+	const initiativeId = extractInitiativeId(req);
+	const body = req.body as unknown;
+	if (!isWritableInitiativeFieldValue(body)) {
+		throw new InputValidationError(
+			'Invalid request body.',
+			isWritableInitiativeFieldValue.errors ?? [],
+		);
+	}
+	const { baseFieldShortCode, sourceId, value, goodAsOf } = body;
+
+	await loadInitiative(db, req, initiativeId);
+	const baseField = await loadBaseField(db, req, baseFieldShortCode);
+	assertBaseFieldIsUsableByInitiatives(baseField);
+	await loadSource(db, req, sourceId);
+
+	const initiativeFieldValue = await createInitiativeFieldValue(db, req, {
+		initiativeId,
+		baseFieldShortCode,
+		sourceId,
+		value,
+		isValid: fieldValueIsValid(value, baseField.dataType),
+		goodAsOf,
+	});
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.CREATED)
+		.contentType('application/json')
+		.send(initiativeFieldValue);
+};
+
+const patchInitiativeFieldValue = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	if (!isAuthContext(req)) {
+		throw new FailedMiddlewareError('Unexpected lack of auth context.');
+	}
+	const db = getDatabase();
+	const initiativeId = extractInitiativeId(req);
+	const fieldValueId = extractFieldValueId(req);
+	const body = req.body as unknown;
+	if (!isInitiativeFieldValuePatch(body)) {
+		throw new InputValidationError(
+			'Invalid request body.',
+			isInitiativeFieldValuePatch.errors ?? [],
+		);
+	}
+
+	const existingInitiativeFieldValue = await loadInitiativeFieldValue(
+		db,
+		req,
+		initiativeId,
+		fieldValueId,
+	);
+	if (body.sourceId !== undefined) {
+		await loadSource(db, req, body.sourceId);
+	}
+
+	const value = body.value ?? existingInitiativeFieldValue.value;
+	const updatedInitiativeFieldValue = await updateInitiativeFieldValue(
+		db,
+		req,
+		{
+			...body,
+			isValid: fieldValueIsValid(
+				value,
+				existingInitiativeFieldValue.baseField.dataType,
+			),
+		},
+		initiativeId,
+		fieldValueId,
+	);
+	res
+		.status(HTTP_STATUS.SUCCESSFUL.OK)
+		.contentType('application/json')
+		.send(updatedInitiativeFieldValue);
+};
+
+const initiativeFieldValuesHandlers = {
+	getInitiativeFieldValues,
+	getInitiativeFieldValue,
+	postInitiativeFieldValue,
+	patchInitiativeFieldValue,
+};
+
+export { initiativeFieldValuesHandlers };

--- a/src/openapi/api.json
+++ b/src/openapi/api.json
@@ -203,6 +203,15 @@
 			"InitiativeBundle": {
 				"$ref": "./components/schemas/InitiativeBundle.json"
 			},
+			"InitiativeFieldValue": {
+				"$ref": "./components/schemas/InitiativeFieldValue.json"
+			},
+			"InitiativeFieldValueBundle": {
+				"$ref": "./components/schemas/InitiativeFieldValueBundle.json"
+			},
+			"InitiativeFieldValuePatch": {
+				"$ref": "./components/schemas/InitiativeFieldValuePatch.json"
+			},
 			"InitiativePatch": {
 				"$ref": "./components/schemas/InitiativePatch.json"
 			},
@@ -418,6 +427,12 @@
 		},
 		"/initiatives/{initiativeId}": {
 			"$ref": "./paths/initiative.json"
+		},
+		"/initiatives/{initiativeId}/fieldValues": {
+			"$ref": "./paths/initiativeFieldValues.json"
+		},
+		"/initiatives/{initiativeId}/fieldValues/{fieldValueId}": {
+			"$ref": "./paths/initiativeFieldValue.json"
 		},
 		"/opportunities": {
 			"$ref": "./paths/opportunities.json"

--- a/src/openapi/components/schemas/InitiativeFieldValue.json
+++ b/src/openapi/components/schemas/InitiativeFieldValue.json
@@ -1,0 +1,47 @@
+{
+	"allOf": [
+		{ "$ref": "./FieldValueBase.json" },
+		{
+			"type": "object",
+			"properties": {
+				"initiativeId": {
+					"allOf": [{ "$ref": "./id.json" }],
+					"description": "The initiative this value describes.  It is taken from the request path.",
+					"readOnly": true,
+					"example": 42
+				},
+				"baseFieldShortCode": {
+					"allOf": [{ "$ref": "./shortCode.json" }],
+					"example": "initiative_description"
+				},
+				"baseField": {
+					"$ref": "./BaseField.json",
+					"readOnly": true
+				},
+				"sourceId": {
+					"allOf": [{ "$ref": "./id.json" }],
+					"description": "The source that provided this value.",
+					"example": 7
+				},
+				"source": {
+					"$ref": "./Source.json",
+					"readOnly": true
+				},
+				"createdBy": {
+					"description": "The keycloak user id of the PDC user that created this field value",
+					"type": "string",
+					"format": "uuid",
+					"readOnly": true
+				}
+			},
+			"required": [
+				"initiativeId",
+				"baseFieldShortCode",
+				"baseField",
+				"sourceId",
+				"source",
+				"createdBy"
+			]
+		}
+	]
+}

--- a/src/openapi/components/schemas/InitiativeFieldValueBundle.json
+++ b/src/openapi/components/schemas/InitiativeFieldValueBundle.json
@@ -1,0 +1,19 @@
+{
+	"allOf": [
+		{
+			"$ref": "./Bundle.json"
+		},
+		{
+			"type": "object",
+			"properties": {
+				"entries": {
+					"type": "array",
+					"items": {
+						"$ref": "./InitiativeFieldValue.json"
+					}
+				}
+			},
+			"required": ["entries"]
+		}
+	]
+}

--- a/src/openapi/components/schemas/InitiativeFieldValuePatch.json
+++ b/src/openapi/components/schemas/InitiativeFieldValuePatch.json
@@ -1,0 +1,20 @@
+{
+	"type": "object",
+	"properties": {
+		"value": {
+			"type": "string",
+			"example": "A program that brings clean water to the upper valley."
+		},
+		"sourceId": {
+			"allOf": [{ "$ref": "./id.json" }],
+			"example": 7
+		},
+		"goodAsOf": {
+			"type": ["string", "null"],
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false,
+	"minProperties": 1,
+	"required": []
+}

--- a/src/openapi/paths/initiativeFieldValue.json
+++ b/src/openapi/paths/initiativeFieldValue.json
@@ -1,0 +1,126 @@
+{
+	"get": {
+		"operationId": "getInitiativeFieldValueById",
+		"summary": "Gets a specific initiative field value.",
+		"description": "Requires the administrator role.",
+		"tags": ["Initiatives"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "initiativeId",
+				"description": "The PDC-generated ID of an initiative.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"$ref": "../components/schemas/id.json"
+				}
+			},
+			{
+				"name": "fieldValueId",
+				"description": "The PDC-generated ID of an initiative field value.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"$ref": "../components/schemas/id.json"
+				}
+			}
+		],
+		"responses": {
+			"200": {
+				"description": "The requested initiative field value.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/InitiativeFieldValue.json"
+						}
+					}
+				}
+			},
+			"400": {
+				"$ref": "../components/responses/InputValidation.json"
+			},
+			"401": {
+				"$ref": "../components/responses/Unauthorized.json",
+				"description": "The request is unauthenticated, or the caller does not have the administrator role."
+			},
+			"404": {
+				"$ref": "../components/responses/NotFound.json",
+				"description": "The initiative field value could not be found."
+			},
+			"500": {
+				"$ref": "../components/responses/InternalServerError.json"
+			}
+		}
+	},
+	"patch": {
+		"operationId": "updateInitiativeFieldValueById",
+		"summary": "Updates a specific initiative field value.",
+		"description": "Requires the administrator role.",
+		"tags": ["Initiatives"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "initiativeId",
+				"description": "The PDC-generated ID of an initiative.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"$ref": "../components/schemas/id.json"
+				}
+			},
+			{
+				"name": "fieldValueId",
+				"description": "The PDC-generated ID of an initiative field value.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"$ref": "../components/schemas/id.json"
+				}
+			}
+		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/InitiativeFieldValuePatch.json"
+					}
+				}
+			}
+		},
+		"responses": {
+			"200": {
+				"description": "The updated initiative field value.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/InitiativeFieldValue.json"
+						}
+					}
+				}
+			},
+			"400": {
+				"$ref": "../components/responses/InputValidation.json"
+			},
+			"401": {
+				"$ref": "../components/responses/Unauthorized.json",
+				"description": "The request is unauthenticated, or the caller does not have the administrator role."
+			},
+			"404": {
+				"$ref": "../components/responses/NotFound.json",
+				"description": "The initiative field value or source could not be found."
+			},
+			"500": {
+				"$ref": "../components/responses/InternalServerError.json"
+			}
+		}
+	}
+}

--- a/src/openapi/paths/initiativeFieldValues.json
+++ b/src/openapi/paths/initiativeFieldValues.json
@@ -1,0 +1,114 @@
+{
+	"get": {
+		"operationId": "getInitiativeFieldValues",
+		"summary": "Gets the field values of an initiative.",
+		"description": "Returns a paginated list of the field values recorded against an initiative. Requires the administrator role.",
+		"tags": ["Initiatives"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "initiativeId",
+				"description": "The PDC-generated ID of an initiative.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"$ref": "../components/schemas/id.json"
+				}
+			},
+			{ "$ref": "../components/parameters/pageParam.json" },
+			{ "$ref": "../components/parameters/countParam.json" }
+		],
+		"responses": {
+			"200": {
+				"description": "All field values for the initiative.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/InitiativeFieldValueBundle.json"
+						}
+					}
+				}
+			},
+			"400": {
+				"$ref": "../components/responses/InputValidation.json"
+			},
+			"401": {
+				"$ref": "../components/responses/Unauthorized.json",
+				"description": "The request is unauthenticated, or the caller does not have the administrator role."
+			},
+			"404": {
+				"$ref": "../components/responses/NotFound.json",
+				"description": "The initiative could not be found."
+			},
+			"500": {
+				"$ref": "../components/responses/InternalServerError.json"
+			}
+		}
+	},
+	"post": {
+		"operationId": "addInitiativeFieldValue",
+		"summary": "Creates a new field value for an initiative.",
+		"description": "Creates a new value for a base field on the given initiative. Any base field category other than `organization` may be used, since organization data belongs to the changemaker rather than to one of its initiatives. Multiple values can exist for the same initiative and field combination. Requires the administrator role.",
+		"tags": ["Initiatives"],
+		"security": [
+			{
+				"auth": []
+			}
+		],
+		"parameters": [
+			{
+				"name": "initiativeId",
+				"description": "The PDC-generated ID of an initiative.",
+				"in": "path",
+				"required": true,
+				"schema": {
+					"$ref": "../components/schemas/id.json"
+				}
+			}
+		],
+		"requestBody": {
+			"required": true,
+			"content": {
+				"application/json": {
+					"schema": {
+						"$ref": "../components/schemas/InitiativeFieldValue.json"
+					}
+				}
+			}
+		},
+		"responses": {
+			"201": {
+				"description": "The new initiative field value that was created.",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "../components/schemas/InitiativeFieldValue.json"
+						}
+					}
+				}
+			},
+			"400": {
+				"$ref": "../components/responses/InputValidation.json"
+			},
+			"401": {
+				"$ref": "../components/responses/Unauthorized.json",
+				"description": "The request is unauthenticated, or the caller does not have the administrator role."
+			},
+			"404": {
+				"$ref": "../components/responses/NotFound.json",
+				"description": "The initiative, base field, or source could not be found."
+			},
+			"422": {
+				"$ref": "../components/responses/UnprocessableEntity.json",
+				"description": "The base field is an organization-category field, or the base field is forbidden."
+			},
+			"500": {
+				"$ref": "../components/responses/InternalServerError.json"
+			}
+		}
+	}
+}

--- a/src/routers/initiativesRouter.ts
+++ b/src/routers/initiativesRouter.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { initiativesHandlers } from '../handlers/initiativesHandlers';
+import { initiativeFieldValuesHandlers } from '../handlers/initiativeFieldValuesHandlers';
 import { requireAdministratorRole } from '../middleware';
 
 const initiativesRouter = express.Router();
@@ -23,6 +24,26 @@ initiativesRouter.patch(
 	'/:initiativeId',
 	requireAdministratorRole,
 	initiativesHandlers.patchInitiative,
+);
+initiativesRouter.post(
+	'/:initiativeId/fieldValues',
+	requireAdministratorRole,
+	initiativeFieldValuesHandlers.postInitiativeFieldValue,
+);
+initiativesRouter.get(
+	'/:initiativeId/fieldValues',
+	requireAdministratorRole,
+	initiativeFieldValuesHandlers.getInitiativeFieldValues,
+);
+initiativesRouter.get(
+	'/:initiativeId/fieldValues/:fieldValueId',
+	requireAdministratorRole,
+	initiativeFieldValuesHandlers.getInitiativeFieldValue,
+);
+initiativesRouter.patch(
+	'/:initiativeId/fieldValues/:fieldValueId',
+	requireAdministratorRole,
+	initiativeFieldValuesHandlers.patchInitiativeFieldValue,
 );
 
 export { initiativesRouter };

--- a/src/test/factories/createTestInitiativeFieldValue.ts
+++ b/src/test/factories/createTestInitiativeFieldValue.ts
@@ -1,0 +1,45 @@
+import { v4 as uuidv4 } from 'uuid';
+import { createInitiativeFieldValue } from '../../database';
+import { BaseFieldCategory } from '../../types';
+import { createTestBaseField } from './createTestBaseField';
+import { createTestInitiative } from './createTestInitiative';
+import { createTestSource } from './createTestSource';
+import type { TinyPg } from 'tinypg';
+import type {
+	AuthContext,
+	InitiativeFieldValue,
+	InternallyWritableInitiativeFieldValue,
+} from '../../types';
+
+const createTestInitiativeFieldValue = async (
+	db: TinyPg,
+	authContext: AuthContext | null,
+	overrideValues?: Partial<InternallyWritableInitiativeFieldValue>,
+): Promise<InitiativeFieldValue> => {
+	const initiativeId =
+		overrideValues?.initiativeId ??
+		(await createTestInitiative(db, authContext)).id;
+	const baseFieldShortCode =
+		overrideValues?.baseFieldShortCode ??
+		(
+			await createTestBaseField(db, authContext, {
+				category: BaseFieldCategory.PROJECT,
+			})
+		).shortCode;
+	const sourceId =
+		overrideValues?.sourceId ?? (await createTestSource(db, authContext)).id;
+	const defaultValues: InternallyWritableInitiativeFieldValue = {
+		initiativeId,
+		baseFieldShortCode,
+		sourceId,
+		value: `Test Initiative Field Value ${uuidv4()}`,
+		isValid: true,
+		goodAsOf: null,
+	};
+	return await createInitiativeFieldValue(db, authContext, {
+		...defaultValues,
+		...overrideValues,
+	});
+};
+
+export { createTestInitiativeFieldValue };

--- a/src/test/factories/index.ts
+++ b/src/test/factories/index.ts
@@ -4,6 +4,7 @@ export * from './createTestDataProvider';
 export * from './createTestFile';
 export * from './createTestFunder';
 export * from './createTestInitiative';
+export * from './createTestInitiativeFieldValue';
 export * from './createTestOpportunity';
 export * from './createTestPermissionGrant';
 export * from './createTestProposal';

--- a/src/types/InitiativeFieldValue.ts
+++ b/src/types/InitiativeFieldValue.ts
@@ -1,0 +1,101 @@
+import { ajv } from '../ajv';
+import { idSchema } from './Id';
+import { shortCodeSchema } from './ShortCode';
+import type { Id } from './Id';
+import type { JSONSchemaType } from 'ajv';
+import type { BaseField } from './BaseField';
+import type { FieldValueBase } from './FieldValueBase';
+import type { KeycloakId } from './KeycloakId';
+import type { ShortCode } from './ShortCode';
+import type { Source } from './Source';
+import type { Writable } from './Writable';
+
+interface InitiativeFieldValue extends FieldValueBase {
+	readonly initiativeId: Id;
+	baseFieldShortCode: ShortCode;
+	sourceId: Id;
+	readonly baseField: BaseField;
+	readonly source: Source;
+	readonly createdBy: KeycloakId;
+}
+
+type WritableInitiativeFieldValue = Writable<InitiativeFieldValue>;
+
+const writableInitiativeFieldValueSchema: JSONSchemaType<WritableInitiativeFieldValue> =
+	{
+		type: 'object',
+		properties: {
+			baseFieldShortCode: shortCodeSchema,
+			sourceId: idSchema,
+			value: {
+				type: 'string',
+			},
+			goodAsOf: {
+				type: 'string',
+				/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion --
+				 * This is a gross workaround for the fact that AJV does not support nullable types in TypeScript.
+				 * See: https://github.com/ajv-validator/ajv/issues/2163
+				 */
+				nullable: true as false,
+			},
+		},
+		required: ['baseFieldShortCode', 'sourceId', 'value', 'goodAsOf'],
+	};
+
+const isWritableInitiativeFieldValue = ajv.compile(
+	writableInitiativeFieldValueSchema,
+);
+
+type InternallyWritableInitiativeFieldValue = WritableInitiativeFieldValue &
+	Pick<InitiativeFieldValue, 'initiativeId' | 'isValid'>;
+
+type InitiativeFieldValuePatch = Partial<
+	Pick<InitiativeFieldValue, 'value' | 'sourceId' | 'goodAsOf'>
+>;
+
+const initiativeFieldValuePatchSchema: JSONSchemaType<InitiativeFieldValuePatch> =
+	{
+		type: 'object',
+		properties: {
+			value: {
+				type: 'string',
+				/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion --
+				 * AJV's JSONSchemaType does not properly support nullable for patches.
+				 * See https://github.com/ajv-validator/ajv/issues/2163
+				 */
+				nullable: false as true,
+			},
+			sourceId: {
+				...idSchema,
+				/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion --
+				 * AJV's JSONSchemaType does not properly support nullable for patches.
+				 * See https://github.com/ajv-validator/ajv/issues/2163
+				 */
+				nullable: false as true,
+			},
+			goodAsOf: {
+				type: 'string',
+				nullable: true,
+			},
+		},
+		additionalProperties: false,
+		minProperties: 1,
+	};
+
+const isInitiativeFieldValuePatch = ajv.compile(
+	initiativeFieldValuePatchSchema,
+);
+
+type InternallyWritableInitiativeFieldValuePatch = InitiativeFieldValuePatch &
+	Pick<InitiativeFieldValue, 'isValid'>;
+
+export {
+	type InitiativeFieldValue,
+	type InitiativeFieldValuePatch,
+	type InternallyWritableInitiativeFieldValue,
+	type InternallyWritableInitiativeFieldValuePatch,
+	type WritableInitiativeFieldValue,
+	writableInitiativeFieldValueSchema,
+	isWritableInitiativeFieldValue,
+	isInitiativeFieldValuePatch,
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,7 @@ export * from './FunderCollaborativeInvitation';
 export * from './FunderCollaborativeMember';
 export * from './Id';
 export * from './Initiative';
+export * from './InitiativeFieldValue';
 export * from './JsonObject';
 export * from './JsonResultSet';
 export * from './KeycloakId';


### PR DESCRIPTION
This PR adds a new `InitiativeFieldValue` entity type which allows base field values with an initiative in the system.

In this implementation I did decide to disallow organization base field data to be linked to an initiative -- this is better represented by a `ChangemakerFieldValue`.

Resolves #2530