### PR TITLE
Include Fluxx integration in onboarding checklists

### DIFF
--- a/docs/onboarding/FUNDER_FLUXX_INTEGRATION.md
+++ b/docs/onboarding/FUNDER_FLUXX_INTEGRATION.md
@@ -1,0 +1,30 @@
+# Fluxx Onboarding Checklist
+
+Funders that link Fluxx with PDC require these steps to integrate.
+
+These steps are not expected for changemaker organizations, only funders.
+
+## In the PDC Keycloak
+
+These steps require Keycloak PDC realm administrative access.
+
+Visit https://auth.philanthropydatacommons.org/admin/pdc/console/#/pdc/clients
+
+- [ ] Add a client for the Fluxx/funder integration:
+  - [ ] Follow the `pdc-fluxx-[org short name]` naming convention
+  - [ ] Set the Root URL, usually like `https://[org short name].fluxx.io`
+  - [ ] Add a "Valid redirect URI" like `https://[org short name].fluxx.io/*`
+  - [ ] If other subdomains are used, add them to "Valid redirect URIs"
+  - [ ] Set "Valid post logout redirect URIs" to `+`
+  - [ ] Set "Web origins" to `+`
+  - [ ] Set "Client authentication" to `Off`
+  - [ ] Enable the "Standard flow"
+  - [ ] Uncheck all other Authentication flows
+  - [ ] Set "Require PKCE" to `On`
+  - [ ] Click "Save"
+  - [ ] In "Client Scopes" tab set `organizations` client scope to `Default`
+
+Test the integration from Fluxx and correct the Valid redirect URIs as needed.
+Users of any organization (for example, changemakers) who can log into Fluxx
+should be able to click the PDC login button inside the Fluxx integration, log
+in, and successfully get redirected back into Fluxx.

--- a/docs/onboarding/ORGANIZATION_ONBOARDING_CHECKLIST.md
+++ b/docs/onboarding/ORGANIZATION_ONBOARDING_CHECKLIST.md
@@ -9,7 +9,6 @@ These steps require Keycloak PDC realm administrative access.
 
 Use https://auth.philanthropydatacommons.org/admin to do these steps.
 
-- [ ] Add a human from the organization to Keycloak users
 - [ ] Add the organization to Keycloak organizations
   - [ ] Follow existing naming conventions
   - [ ] Note/copy the new organization UUID for use below

--- a/docs/onboarding/ORGANIZATION_ONBOARDING_CHECKLIST.md
+++ b/docs/onboarding/ORGANIZATION_ONBOARDING_CHECKLIST.md
@@ -7,7 +7,7 @@ to the PDC. The intended audience is PDC administrators.
 
 These steps require Keycloak PDC realm administrative access.
 
-Use https://auth.philanthropydatacommons.org/admin to do these steps.
+Use https://auth.philanthropydatacommons.org/admin/pdc/console to do these steps.
 
 - [ ] Add the organization to Keycloak organizations
   - [ ] Follow existing naming conventions

--- a/docs/onboarding/ORGANIZATION_ONBOARDING_CHECKLIST.md
+++ b/docs/onboarding/ORGANIZATION_ONBOARDING_CHECKLIST.md
@@ -13,6 +13,8 @@ Use https://auth.philanthropydatacommons.org/admin/pdc/console to do these steps
   - [ ] Follow existing naming conventions
   - [ ] Note/copy the new organization UUID for use below
 - [ ] If the organization has an IdP, [integrate it](./ORGANIZATION_IDP_INTEGRATION.md)
+- [ ] If the organization is a funder that uses Fluxx, [integrate
+      it](./FUNDER_FLUXX_INTEGRATION.md)
 - [ ] If the organization will submit data using software, add a Keycloak client
   - [ ] Follow the `pdc-[org short name]-data-ingest` naming convention
   - [ ] Set "Client authentication" to "On"

--- a/docs/onboarding/USER_ONBOARDING_CHECKLIST.md
+++ b/docs/onboarding/USER_ONBOARDING_CHECKLIST.md
@@ -5,9 +5,7 @@ PDC. The intended audience is PDC administrators. These steps apply to users
 that do not belong to an organization with an authentication system (IdP)
 integrated with the PDC Keycloak.
 
-## In the PDC Keycloak (PDC Realm)
-
-These steps require membership in the `pdc-admin` group.
+## Add a user
 
 Visit https://auth.philanthropydatacommons.org/admin/pdc/console/#/pdc/users
 
@@ -33,13 +31,9 @@ Visit https://auth.philanthropydatacommons.org/admin/pdc/console/#/pdc/users
 
 Do [organization onboarding](./ORGANIZATION_ONBOARDING_CHECKLIST.md) as needed.
 
-## In the PDC Keycloak (Keycloak Realm)
-
 Join the newly created user to an organization.
 
-These steps require PDC realm administrative access (from the Keycloak realm).
-
-Use https://auth.philanthropydatacommons.org/admin/master/console/#/pdc/ here.
+Visit https://auth.philanthropydatacommons.org/admin/pdc/console/#/pdc/organizations
 
 - [ ] Click "Organizations"
 - [ ] Click on the new user's organization

--- a/docs/onboarding/USER_ONBOARDING_CHECKLIST.md
+++ b/docs/onboarding/USER_ONBOARDING_CHECKLIST.md
@@ -1,7 +1,9 @@
 # User Onboarding Checklist
 
 These steps should ensure a good user experience for users that are new to the
-PDC. The intended audience is PDC administrators.
+PDC. The intended audience is PDC administrators. These steps apply to users
+that do not belong to an organization with an authentication system (IdP)
+integrated with the PDC Keycloak.
 
 ## In the PDC Keycloak (PDC Realm)
 


### PR DESCRIPTION
When integrating with Fluxx, funders need a client added to Keycloak. This change documents how to do that.

While looking over the onboarding steps, I noticed a handful of other updates were needed. Those are in separate commits.