### PR TITLE
Fix source scope for funder, changemaker, dataProvider contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an `initiativeFieldValue` entity capturing base field data for an initiative, managed via the administrator-only `/initiatives/{initiativeId}/fieldValues` endpoints.
 - Added an `initiative` permission scope, inherited from the owning changemaker, that governs who can view and edit initiatives.
 
+### Fixed
+
+- `POST /permissionGrants` now accepts `source` as a scope for `funder`, `changemaker`, and `dataProvider` context entity types, matching the documented and database-supported behavior. Previously the handler rejected these grants with `InputValidationError` even though the SQL inheritance already supported `source` grants inherited from a source's funder, changemaker, or data provider.
+
 ## 0.41.0 2026-07-24
 
 ### Fixed

--- a/src/__tests__/permissionGrants.int.test.ts
+++ b/src/__tests__/permissionGrants.int.test.ts
@@ -938,6 +938,81 @@ describe('/permissionGrants', () => {
 			expect(after.count).toEqual(before.count + 1);
 		});
 
+		it('creates a grant with source scope on a funder context', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const funder = await createTestFunder(db, authContext);
+			const result = await agent
+				.post('/permissionGrants')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUserKeycloakUserId,
+					contextEntityType: 'funder',
+					funderShortCode: funder.shortCode,
+					scope: ['source'],
+					verbs: ['create'],
+				})
+				.expect(201);
+			expect(result.body).toMatchObject({
+				contextEntityType: 'funder',
+				funderShortCode: funder.shortCode,
+				scope: ['source'],
+				verbs: ['create'],
+			});
+		});
+
+		it('creates a grant with source scope on a changemaker context', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const changemaker = await createTestChangemaker(db, authContext);
+			const result = await agent
+				.post('/permissionGrants')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUserKeycloakUserId,
+					contextEntityType: 'changemaker',
+					changemakerId: changemaker.id,
+					scope: ['source'],
+					verbs: ['view'],
+				})
+				.expect(201);
+			expect(result.body).toMatchObject({
+				contextEntityType: 'changemaker',
+				changemakerId: changemaker.id,
+				scope: ['source'],
+				verbs: ['view'],
+			});
+		});
+
+		it('creates a grant with source scope on a dataProvider context', async () => {
+			const db = getDatabase();
+			const authContext = await getTestAuthContext(db);
+			const dataProvider = await createTestDataProvider(db, authContext);
+			const result = await agent
+				.post('/permissionGrants')
+				.type('application/json')
+				.set(adminUserAuthHeader)
+				.send({
+					granteeType: 'user',
+					granteeUserKeycloakUserId: testUserKeycloakUserId,
+					contextEntityType: 'dataProvider',
+					dataProviderShortCode: dataProvider.shortCode,
+					scope: ['source'],
+					verbs: ['create'],
+				})
+				.expect(201);
+			expect(result.body).toMatchObject({
+				contextEntityType: 'dataProvider',
+				dataProviderShortCode: dataProvider.shortCode,
+				scope: ['source'],
+				verbs: ['create'],
+			});
+		});
+
 		it('creates a permission grant for a user not in the users table', async () => {
 			const db = getDatabase();
 			const arbitraryUserKeycloakUserId =

--- a/src/types/PermissionGrantEntityType.ts
+++ b/src/types/PermissionGrantEntityType.ts
@@ -122,6 +122,7 @@ const contextEntityTypeNativeScopes = {
 		PermissionGrantEntityType.INITIATIVE,
 		PermissionGrantEntityType.PROPOSAL,
 		PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
+		PermissionGrantEntityType.SOURCE,
 	],
 	[PermissionGrantEntityType.FUNDER]: [
 		PermissionGrantEntityType.FUNDER,
@@ -130,9 +131,11 @@ const contextEntityTypeNativeScopes = {
 		PermissionGrantEntityType.PROPOSAL,
 		PermissionGrantEntityType.PROPOSAL_FIELD_VALUE,
 		PermissionGrantEntityType.TERMINOLOGY_SET,
+		PermissionGrantEntityType.SOURCE,
 	],
 	[PermissionGrantEntityType.DATA_PROVIDER]: [
 		PermissionGrantEntityType.DATA_PROVIDER,
+		PermissionGrantEntityType.SOURCE,
 	],
 	[PermissionGrantEntityType.OPPORTUNITY]: [
 		PermissionGrantEntityType.OPPORTUNITY,


### PR DESCRIPTION
## Summary

`POST /permissionGrants` rejected `scope: ["source"]` when `contextEntityType` was `funder`, `changemaker`, or `dataProvider`, despite `docs/PERMISSIONS.md`, `CHANGELOG.md`, and the SQL inheritance (`2_permitted_source_ids.sql`) all supporting it. Fixes #2552.

## Root cause

`assertPermissionGrantHasValidScope` (`src/handlers/permissionGrantsHandlers.ts`) reads allowed scopes from `getScopesForContextEntityType` -> `contextEntityTypeNativeScopes` in `src/types/PermissionGrantEntityType.ts`. That map omitted `SOURCE` from the `FUNDER`, `CHANGEMAKER`, and `DATA_PROVIDER` entries, so the handler rejected the documented grants before they reached the DB. The gap was introduced by #2362, which added the `0108-add-source-scope-to-existing-permissions.sql` migration (appending `source` to existing parent-context grants) and the source-permission inheritance, but did not update the TypeScript allow-list.

## Why untested at the HTTP layer

Existing HTTP tests used `contextEntityType: "source"` (a direct source grant). The funder/changemaker + `source` scope combination was only exercised via the DB operation `createPermissionGrant`, which bypasses handler validation.

## Changes

- `src/types/PermissionGrantEntityType.ts`: add `SOURCE` to the native scopes for `FUNDER`, `CHANGEMAKER`, and `DATA_PROVIDER`.
- `src/__tests__/permissionGrants.int.test.ts`: add three integration tests covering `source` scope on funder, changemaker, and dataProvider contexts. These fail before the fix (`400 InputValidationError`) and pass after.
- `CHANGELOG.md`: note the fix under `## Unreleased`.

## Verification

- New integration tests fail before the fix (`expected 201 Created, got 400 Bad Request`) and pass after.
- Full `permissionGrants.int.test.ts` suite (115 tests) passes.
- `npm run format` clean; `npm run lint` clean (only a pre-existing `compose-ci.yml` docker-compose key-order warning, in a file not touched here).

GLM-5.2