### PR TITLE
Pin `eslint-config-love`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint-config-love'
+        update-types: ['version-update:semver-major']
       - dependency-name: '@eslint/*'
         update-types: ['version-update:semver-major']
       - dependency-name: 'typescript'

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
 				"copyfiles": "^2.4.1",
 				"dclint": "^3.1.0",
 				"eslint": "^9.39.5",
-				"eslint-config-love": "^154.1.0",
+				"eslint-config-love": "154.1.0",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-import-resolver-typescript": "^4.4.5",
 				"eslint-plugin-pino": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"copyfiles": "^2.4.1",
 		"dclint": "^3.1.0",
 		"eslint": "^9.39.5",
-		"eslint-config-love": "^154.1.0",
+		"eslint-config-love": "154.1.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-import-resolver-typescript": "^4.4.5",
 		"eslint-plugin-pino": "^1.0.3",


### PR DESCRIPTION
This PR pins eslint-config-love to a version that continues support for the import plugin.